### PR TITLE
feat: implement basic pinning support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "nix-uri"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322d3e6cecd463a8f3bcbb875771eef2dcf1d402125899bfc85d327066fc95cc"
+checksum = "d4acc3f0410bee3acab7e8d7099b7e5686244da81e1e642eaf46814398d863f0"
 dependencies = [
  "nom",
  "serde",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Commands:
           List flake inputs
   update
           Update inputs to their latest specified release
+  pin
+          Pin inputs to their current or a specified rev
   help
           Print this message or the help of the given subcommand(s)
 
@@ -126,6 +128,27 @@ List the outputs, that are specified inside the inputs attribute.
 ![flake-edit list example](https://vhs.charm.sh/vhs-2ZSgdhkzBe3eoxuYtM1JL6.gif)
 List the outputs, that are specified inside the inputs attribute, in json format.
 ![flake-edit list example](https://vhs.charm.sh/vhs-35E6eiL63lFTSC70rQyE1Y.gif)
+
+### `$ flake-edit pin`
+`$ flake-edit help pin`
+
+```
+Pin inputs to their current or a specified rev
+
+Usage: flake-edit pin <ID> [REV]
+
+Arguments:
+  <ID>
+          The id of an input attribute
+  [REV]
+          Optionally specify a rev for the inputs attribute
+
+Options:
+  -h, --help
+          Print help
+```
+![flake-edit pin](https://vhs.charm.sh/vhs-629lX7LqP4MS1aHffb4Ufh.gif)
+Pin a specific input to it's current revision (rev).
 
 
 ## License

--- a/assets/completions/fish/completions.fish
+++ b/assets/completions/fish/completions.fish
@@ -2,6 +2,10 @@ function __fish_complete_inputs
     flake-edit list --format simple 2>/dev/null
 end
 
+function __fish_complete_inputs_toplevel
+    flake-edit list --format toplevel 2>/dev/null
+end
+
 function __fish_complete_add
     flake-edit completion add 2>/dev/null
 end
@@ -10,10 +14,10 @@ complete -c flake-edit -n "__fish_seen_subcommand_from rm" -f -a "(__fish_comple
 complete -c flake-edit -n "__fish_seen_subcommand_from remove" -f -a "(__fish_complete_inputs)" -d Input
 complete -c flake-edit -n "__fish_seen_subcommand_from change" -f -a "(__fish_complete_inputs)" -d Input
 complete -c flake-edit -n "__fish_seen_subcommand_from c" -f -a "(__fish_complete_inputs)" -d Input
-complete -c flake-edit -n "__fish_seen_subcommand_from pin" -f -a "(__fish_complete_inputs)" -d Input
-complete -c flake-edit -n "__fish_seen_subcommand_from p" -f -a "(__fish_complete_inputs)" -d Input
+complete -c flake-edit -n "__fish_seen_subcommand_from pin" -f -a "(__fish_complete_inputs_toplevel)" -d Input
+complete -c flake-edit -n "__fish_seen_subcommand_from p" -f -a "(__fish_complete_inputs_toplevel)" -d Input
 
 set -x ignore_space true
-complete -c flake-edit -n "__fish_seen_subcommand_from a" -f -r --keep-order -a  "(__fish_complete_add)" -d Add
-complete -c flake-edit -n "__fish_seen_subcommand_from add" -f -r --keep-order -a  "(__fish_complete_add)" -d Add
+complete -c flake-edit -n "__fish_seen_subcommand_from a" -f -r --keep-order -a "(__fish_complete_add)" -d Add
+complete -c flake-edit -n "__fish_seen_subcommand_from add" -f -r --keep-order -a "(__fish_complete_add)" -d Add
 set -x ignore_space false

--- a/assets/tape/pin_input.tape
+++ b/assets/tape/pin_input.tape
@@ -1,0 +1,71 @@
+# VHS documentation
+#
+# Output:
+#   Output <path>.gif               Create a GIF output at the given <path>
+#   Output <path>.mp4               Create an MP4 output at the given <path>
+#   Output <path>.webm              Create a WebM output at the given <path>
+#
+# Require:
+#   Require <string>                Ensure a program is on the $PATH to proceed
+#
+# Settings:
+#   Set FontSize <number>           Set the font size of the terminal
+#   Set FontFamily <string>         Set the font family of the terminal
+#   Set Height <number>             Set the height of the terminal
+#   Set Width <number>              Set the width of the terminal
+#   Set LetterSpacing <float>       Set the font letter spacing (tracking)
+#   Set LineHeight <float>          Set the font line height
+#   Set LoopOffset <float>%         Set the starting frame offset for the GIF loop
+#   Set Theme <json|string>         Set the theme of the terminal
+#   Set Padding <number>            Set the padding of the terminal
+#   Set Framerate <number>          Set the framerate of the recording
+#   Set PlaybackSpeed <float>       Set the playback speed of the recording
+#   Set MarginFill <file|#000000>   Set the file or color the margin will be filled with.
+#   Set Margin <number>             Set the size of the margin. Has no effect if MarginFill isn't set.
+#   Set BorderRadius <number>       Set terminal border radius, in pixels.
+#   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
+#   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
+#   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms.
+#
+# Sleep:
+#   Sleep <time>                    Sleep for a set amount of <time> in seconds
+#
+# Type:
+#   Type[@<time>] "<characters>"    Type <characters> into the terminal with a
+#                                   <time> delay between each character
+#
+# Keys:
+#   Backspace[@<time>] [number]     Press the Backspace key
+#   Down[@<time>] [number]          Press the Down key
+#   Enter[@<time>] [number]         Press the Enter key
+#   Space[@<time>] [number]         Press the Space key
+#   Tab[@<time>] [number]           Press the Tab key
+#   Left[@<time>] [number]          Press the Left Arrow key
+#   Right[@<time>] [number]         Press the Right Arrow key
+#   Up[@<time>] [number]            Press the Up Arrow key
+#   Down[@<time>] [number]          Press the Down Arrow key
+#   PageUp[@<time>] [number]        Press the Page Up key
+#   PageDown[@<time>] [number]      Press the Page Down key
+#   Ctrl+<key>                      Press the Control key + <key> (e.g. Ctrl+C)
+#
+# Display:
+#   Hide                            Hide the subsequent commands from the output
+#   Show                            Show the subsequent commands in the output
+
+Output output/pin_input.gif
+
+Require echo
+
+Set Shell "fish"
+Set FontSize 32
+Set Width 1200
+Set Height 600
+
+Hide
+#Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter
+Type "set -x fish_function_path ''" Enter
+Type "clear" Enter
+Show
+
+Type "flake-edit --diff pin rust-overlay" Sleep 1000ms Enter
+Sleep 5s

--- a/src/bin/flake-edit/cli.rs
+++ b/src/bin/flake-edit/cli.rs
@@ -49,6 +49,9 @@ impl CliArgs {
     pub(crate) fn update(&self) -> bool {
         matches!(self.subcommand, Command::Update { .. })
     }
+    pub(crate) fn pin(&self) -> bool {
+        matches!(self.subcommand, Command::Pin { .. })
+    }
 
     pub fn flake(&self) -> Option<&String> {
         self.flake.as_ref()
@@ -93,6 +96,14 @@ pub(crate) enum Command {
     /// Update inputs to their latest specified release.
     #[clap(alias = "u")]
     Update {},
+    /// Pin inputs to their current or a specified rev.
+    #[clap(alias = "p")]
+    Pin {
+        /// The id of an input attribute.
+        id: String,
+        /// Optionally specify a rev for the inputs attribute.
+        rev: Option<String>,
+    },
     #[clap(hide = true)]
     #[command(name = "completion")]
     /// Meant for shell completions.

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,10 @@ pub enum FlakeEditError {
     Io(#[from] std::io::Error),
     #[error("The flake should be a root.")]
     NotARoot,
+    #[error("There is an error in the Lockfile: {0}")]
+    LockError(String),
+    #[error("Deserialization Error: {0}")]
+    Serde(#[from] serde_json::Error),
     // Reqwest Error
     // #[error("Incorrect Channel")]
     // IncorrectChannel(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod diff;
 pub mod edit;
 pub mod error;
 pub mod input;
+pub mod lock;
 pub mod state;
 pub mod update;
 pub mod walk;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,320 @@
+use crate::error::FlakeEditError;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlakeLock {
+    nodes: HashMap<String, Node>,
+    root: String,
+    version: u8,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Node {
+    inputs: Option<HashMap<String, Input>>,
+    locked: Option<Locked>,
+    original: Option<Original>,
+}
+
+impl Node {
+    fn get_rev(&self) -> String {
+        self.locked.clone().unwrap().get_rev().to_string()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Input {
+    Direct(String),
+    Indirect(Vec<String>),
+}
+
+impl Input {
+    fn get_id(&self) -> String {
+        match self {
+            Input::Direct(id) => id.to_string(),
+            Input::Indirect(_) => todo!(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Locked {
+    owner: Option<String>,
+    repo: Option<String>,
+    rev: Option<String>,
+    #[serde(rename = "type")]
+    node_type: String,
+    #[serde(rename = "ref")]
+    ref_field: Option<String>,
+}
+
+impl Locked {
+    fn get_rev(&self) -> String {
+        self.rev.clone().unwrap()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Original {
+    owner: Option<String>,
+    repo: Option<String>,
+    #[serde(rename = "type")]
+    node_type: String,
+    #[serde(rename = "ref")]
+    ref_field: Option<String>,
+    url: Option<String>,
+}
+
+impl FlakeLock {
+    const LOCK: &'static str = "flake.lock";
+
+    // TODO: implement root path traversal
+    pub fn from_default_path() -> Result<Self, FlakeEditError> {
+        let path = PathBuf::from(Self::LOCK);
+        Self::from_file(path)
+    }
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, FlakeEditError> {
+        let mut file = File::open(path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        Self::read_from_str(&contents)
+    }
+    pub fn read_from_str(str: &str) -> Result<Self, FlakeEditError> {
+        Ok(serde_json::from_str(str)?)
+    }
+    pub fn root(&self) -> &str {
+        &self.root
+    }
+    /// Query the lock file for a specific rev.
+    /// TODO: implement proper root resolving
+    pub fn get_rev_by_id(&self, id: &str) -> Result<String, FlakeEditError> {
+        let root = self.root();
+        let resolved_root = self.nodes.get(root).ok_or(FlakeEditError::NotARoot)?;
+        let binding = resolved_root
+            .inputs
+            .clone()
+            .ok_or_else(|| FlakeEditError::LockError("Could not resolve root.".into()))?;
+        let resolved_id = binding
+            .get(id)
+            .ok_or_else(|| FlakeEditError::LockError("Could not resolve id.".into()))?;
+        let id = resolved_id.get_id();
+        let node = self
+            .nodes
+            .get(&id)
+            .ok_or_else(|| FlakeEditError::LockError("Could not find node with id.".into()))?;
+        Ok(node.get_rev())
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn minimal_lock() -> &'static str {
+        r#"
+    {
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718714799,
+        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+    "#
+    }
+    fn minimal_independent_lock_no_overrides() -> &'static str {
+        r#"
+    {
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721138476,
+        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1721382922,
+        "narHash": "sha256-GYpibTC0YYKRpFR9aftym9jjRdUk67ejw1IWiaQkaiU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "50104496fb55c9140501ea80d183f3223d13ff65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+    "#
+    }
+
+    fn minimal_independent_lock_nixpkgs_overridden() -> &'static str {
+        r#"
+    {
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721138476,
+        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721382922,
+        "narHash": "sha256-GYpibTC0YYKRpFR9aftym9jjRdUk67ejw1IWiaQkaiU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "50104496fb55c9140501ea80d183f3223d13ff65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}
+    "#
+    }
+
+    #[test]
+    fn parse_minimal() {
+        let minimal_lock = minimal_lock();
+        FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+    }
+    #[test]
+    fn parse_minimal_version() {
+        let minimal_lock = minimal_lock();
+        let parsed_lock =
+            FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+        assert_eq!(7, parsed_lock.version);
+    }
+    #[test]
+    fn parse_minimal_root() {
+        let minimal_lock = minimal_lock();
+        let parsed_lock =
+            FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+        assert_eq!("root", parsed_lock.root);
+    }
+    #[test]
+    fn minimal_ref() {
+        let minimal_lock = minimal_lock();
+        let parsed_lock =
+            FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+        assert_eq!(
+            "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
+            parsed_lock
+                .get_rev_by_id("nixpkgs")
+                .expect("Id: nixpkgs is in the lockfile.")
+        );
+    }
+    #[test]
+    fn parse_minimal_independent_lock_no_overrides() {
+        let minimal_lock = minimal_independent_lock_no_overrides();
+        FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+    }
+    #[test]
+    fn minimal_independent_lock_no_overrides_ref() {
+        let minimal_lock = minimal_independent_lock_no_overrides();
+        let parsed_lock =
+            FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+        assert_eq!(
+            "ad0b5eed1b6031efaed382844806550c3dcb4206",
+            parsed_lock
+                .get_rev_by_id("nixpkgs")
+                .expect("Id: nixpkgs is in the lockfile.")
+        );
+    }
+    #[test]
+    fn parse_minimal_independent_lock_nixpkgs_overridden() {
+        let minimal_lock = minimal_independent_lock_nixpkgs_overridden();
+        FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
+    }
+}


### PR DESCRIPTION
Add a new subcommand:
```
flake-edit pin [id] [rev]
```

That will pin the specified input to either it's current rev,
if the rev is omitted, or the specified rev.