### PR TITLE
ci: only build full devshell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,5 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v7
         with:
           diagnostic-endpoint: ""
-      - name: "build devshell"
-        run: nix develop -Lvv --no-update-lock-file
-      - name: "build devshell full"
+      - name: "build devshells"
         run: nix develop .#full -Lvv --no-update-lock-file


### PR DESCRIPTION
The full devshell inherits inputs from the default devshell.