### PR TITLE
feat: allow updating a single input

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ```
 Edit your flake inputs with ease.
 
-Usage: flake-edit [OPTIONS] [FLAKE_REF] <COMMAND>
+Usage: flake-edit [OPTIONS] <COMMAND>
 
 Commands:
   add
@@ -31,13 +31,9 @@ Commands:
   help
           Print this message or the help of the given subcommand(s)
 
-Arguments:
-  [FLAKE_REF]
-          
-
 Options:
       --flake <FLAKE>
-          
+          Location of the `flake.nix` file, that will be used
       --diff
           Print a diff of the changes, will set the apply flag to false
       --apply
@@ -101,9 +97,15 @@ Options:
 ```
 Update inputs to their latest specified release
 
-Usage: flake-edit update
+Usage: flake-edit update [OPTIONS] [ID]
+
+Arguments:
+  [ID]
+          The id of an input attribute. If omitted will update all inputs
 
 Options:
+      --init
+          Whether the latest semver release of the remote should be used even thought the release itself isn't yet pinned to a specific release
   -h, --help
           Print help
 ```

--- a/assets/completions/fish/completions.fish
+++ b/assets/completions/fish/completions.fish
@@ -16,6 +16,8 @@ complete -c flake-edit -n "__fish_seen_subcommand_from change" -f -a "(__fish_co
 complete -c flake-edit -n "__fish_seen_subcommand_from c" -f -a "(__fish_complete_inputs)" -d Input
 complete -c flake-edit -n "__fish_seen_subcommand_from pin" -f -a "(__fish_complete_inputs_toplevel)" -d Input
 complete -c flake-edit -n "__fish_seen_subcommand_from p" -f -a "(__fish_complete_inputs_toplevel)" -d Input
+complete -c flake-edit -n "__fish_seen_subcommand_from update" -f -a "(__fish_complete_inputs_toplevel)" -d Input
+complete -c flake-edit -n "__fish_seen_subcommand_from u" -f -a "(__fish_complete_inputs_toplevel)" -d Input
 
 set -x ignore_space true
 complete -c flake-edit -n "__fish_seen_subcommand_from a" -f -r --keep-order -a "(__fish_complete_add)" -d Add

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721322122,
-        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
+        "lastModified": 1721842668,
+        "narHash": "sha256-k3oiD2z2AAwBFLa4+xfU+7G5fisRXfkvrMTCJrjZzXo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
+        "rev": "529c1a0b1f29f0d78fa3086b8f6a134c71ef3aaf",
         "type": "github"
       },
       "original": {

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,12 +16,13 @@ pub struct Tags {
 }
 
 impl Tags {
-    pub fn get_latest_tag(&mut self) -> String {
+    pub fn get_latest_tag(&mut self) -> Option<String> {
         self.sort();
         let mut buf = String::new();
         buf.push_str(&self.prefix);
-        buf.push_str(&self.versions.iter().last().unwrap().to_string());
-        buf
+        let latest_version = &self.versions.iter().last()?;
+        buf.push_str(&latest_version.to_string());
+        Some(buf)
     }
     pub fn sort(&mut self) {
         self.versions.sort_by(Version::cmp_precedence);
@@ -83,7 +84,8 @@ pub fn get_gh_token() -> Option<String> {
 }
 
 // https://api.github.com/repos/{OWNER}/{REPO}/tags
-// Query tags for
+// Query tags for github currently.
+// TODO: support other forges.
 fn query_tags(repo: &str, owner: &str) -> Result<IntermediaryTags, ()> {
     let client = Client::new();
     let mut headers = HeaderMap::new();

--- a/src/bin/flake-edit/cli.rs
+++ b/src/bin/flake-edit/cli.rs
@@ -88,7 +88,15 @@ pub(crate) enum Command {
     },
     /// Update inputs to their latest specified release.
     #[clap(alias = "u")]
-    Update {},
+    Update {
+        /// The id of an input attribute.
+        /// If omitted will update all inputs.
+        id: Option<String>,
+        /// Whether the latest semver release of the remote should be used even thought the release
+        /// itself isn't yet pinned to a specific release.
+        #[arg(long)]
+        init: bool,
+    },
     /// Pin inputs to their current or a specified rev.
     #[clap(alias = "p")]
     Pin {

--- a/src/bin/flake-edit/main.rs
+++ b/src/bin/flake-edit/main.rs
@@ -221,7 +221,7 @@ fn main() -> eyre::Result<()> {
             }
         }
     }
-    if let Command::Update {} = args.subcommand() {
+    if let Command::Update { id, init } = args.subcommand() {
         let inputs = editor.list();
         let mut buf = String::new();
         flake_edit::api::get_gh_token();
@@ -232,7 +232,7 @@ fn main() -> eyre::Result<()> {
             buf.push_str(input.id());
         }
         let mut updater = Updater::new(app.root().text().clone(), inputs.clone());
-        updater.update_all_inputs_to_latest_semver();
+        updater.update_all_inputs_to_latest_semver(id.clone(), *init);
         let change = updater.get_changes();
         if args.diff() {
             let old = text.clone();


### PR DESCRIPTION
Allow updating a single input, and pinning it based on its current
latest tag.

Also add a `--init` flag, that will try to query it's current latest
release regardless, if a semver tag has already been specified.

Fixes: #96
