### PR TITLE
pin: improve error message for missing `flake.lock` file

### DIFF
--- a/src/bin/flake-edit/main.rs
+++ b/src/bin/flake-edit/main.rs
@@ -245,7 +245,13 @@ fn main() -> eyre::Result<()> {
         }
     }
     if let Command::Pin { id, rev } = args.subcommand() {
-        let lock = FlakeLock::from_default_path()?;
+        let lock = FlakeLock::from_default_path().map_err(|_|
+            eyre::eyre!(
+                "The input with id: {} could not be pinned.",
+                id,
+            )
+            .suggestion("\nPlease check if a `flake.lock` file exists.\nRun `nix flake lock` to initialize it.")
+        )?;
 
         let target_rev = if let Some(rev) = rev {
             rev.to_string()


### PR DESCRIPTION
Improves the error message, if the `flake.lock` file doesn't exist.

Fixes: #101
