### PR TITLE
update: Allow any string prefix until the first `-` for semver

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -123,6 +123,13 @@ fn query_tags(repo: &str, owner: &str) -> Result<IntermediaryTags, ()> {
 
 impl From<IntermediaryTags> for Tags {
     fn from(value: IntermediaryTags) -> Self {
+        fn strip_until_char(s: &str, c: char) -> Option<(String, String)> {
+            s.find(c).map(|index| {
+                let prefix = s[..index].to_string();
+                let remaining = s[index + 1..].to_string();
+                (prefix, remaining)
+            })
+        }
         let mut versions = vec![];
         let mut prefix = String::new();
         for itag in value.0 {
@@ -131,6 +138,11 @@ impl From<IntermediaryTags> for Tags {
             if let Some(new_tag) = tag.strip_prefix('v') {
                 tag = new_tag.to_string();
                 prefix = "v".to_string();
+            }
+
+            if let Some((new_prefix, new_tag)) = strip_until_char(&tag, '-') {
+                tag = new_tag;
+                prefix = format!("{new_prefix}-").to_string();
             }
 
             match Version::parse(&tag) {

--- a/src/update.rs
+++ b/src/update.rs
@@ -85,6 +85,9 @@ impl Updater {
     }
     /// Query a forge api for the latest release and update, if necessary.
     pub fn query_and_update_all_inputs(&mut self, input: &UpdateInput, init: bool) {
+        fn strip_until_char(s: &str, c: char) -> Option<String> {
+            s.find(c).map(|index| s[index + 1..].to_string())
+        }
         let uri = self
             .text
             .slice(
@@ -110,6 +113,10 @@ impl Updater {
                 }
 
                 if let Some(normalized_version) = maybe_version.strip_prefix('v') {
+                    maybe_version = normalized_version.to_string();
+                }
+
+                if let Some(normalized_version) = strip_until_char(&maybe_version, '-') {
                     maybe_version = normalized_version.to_string();
                 }
 


### PR DESCRIPTION
Allow any string prefix until the first `-` for semver versions.

Closes: #189

Possible follow up:
Allow for a list of semver separation characters.
