### PR TITLE
feat: Keep `flake.lock` in sync with the `flake.nix` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Options:
       --flake <FLAKE>
           Location of the `flake.nix` file, that will be used
       --diff
-          Print a diff of the changes, will set the apply flag to false
-      --apply
-          Whether to apply possible changes
+          Print a diff of the changes, will not write the changes to disk
+      --no-lock
+          Skip updating the lockfile after editing flake.nix
   -h, --help
           Print help
   -V, --version

--- a/src/bin/flake-edit/cli.rs
+++ b/src/bin/flake-edit/cli.rs
@@ -14,6 +14,9 @@ pub struct CliArgs {
     /// Print a diff of the changes, will not write the changes to disk.
     #[arg(long, default_value_t = false)]
     diff: bool,
+    /// Skip updating the lockfile after editing flake.nix.
+    #[arg(long, default_value_t = false)]
+    no_lock: bool,
 
     #[command(subcommand)]
     subcommand: Command,
@@ -49,6 +52,10 @@ impl CliArgs {
 
     pub fn diff(&self) -> bool {
         self.diff
+    }
+
+    pub fn no_lock(&self) -> bool {
+        self.no_lock
     }
 }
 

--- a/src/bin/flake-edit/main.rs
+++ b/src/bin/flake-edit/main.rs
@@ -128,7 +128,7 @@ fn main() -> eyre::Result<()> {
                 .map_err(|e| eyre::eyre!("Could not write to cache file: {e}"))?;
         }
 
-        app.apply_change_or_diff(&resulting_change, args.diff())?;
+        app.apply_change_or_diff(&resulting_change, args.diff(), args.no_lock())?;
     } else if !args.list() && !args.update() && !args.pin() {
         if change.is_remove() {
             return Err(eyre::eyre!(
@@ -157,7 +157,7 @@ fn main() -> eyre::Result<()> {
         let mut updater = Updater::new(app.text().into(), inputs.clone());
         updater.update_all_inputs_to_latest_semver(id.clone(), *init);
         let change = updater.get_changes();
-        app.apply_change_or_diff(&change, args.diff())?;
+        app.apply_change_or_diff(&change, args.diff(), args.no_lock())?;
     }
     if let Command::Pin { id, rev } = args.subcommand() {
         let lock = FlakeLock::from_default_path().map_err(|_|
@@ -186,7 +186,7 @@ fn main() -> eyre::Result<()> {
 
         updater.pin_input_to_ref(id, &target_rev);
         let change = updater.get_changes();
-        app.apply_change_or_diff(&change, args.diff())?;
+        app.apply_change_or_diff(&change, args.diff(), args.no_lock())?;
     }
     Ok(())
 }


### PR DESCRIPTION
Keep `flake.lock` in sync with the `flake.nix` file.
This is done by running `nix flake lock` after changing the `flake.nix`
file.

This could fail for various valid reasons, we also provide a flag to
turn this behavior off.
