### PR TITLE
update: convert rnix byte offsets to ropey char indices

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -13,7 +13,8 @@ use crate::version::parse_ref;
 pub struct Updater {
     text: Rope,
     inputs: Vec<UpdateInput>,
-    /// Cumulative byte delta from edits applied earlier in the current pass.
+    /// Cumulative char delta from edits applied earlier in the current pass.
+    /// Measured in *characters*, since ropey indexes by char.
     offset: i32,
 }
 
@@ -186,13 +187,30 @@ impl Updater {
             if !input.has_editable_url() {
                 continue;
             }
-            inputs.push(UpdateInput { input });
+            // `Input::range` carries rnix `TextRange` *byte* offsets, but ropey
+            // indexes by *character*. Convert once against the pristine text so
+            // later in-place edits can use simple char-offset arithmetic.
+            let url_start = text.byte_to_char(input.range.start) + 1;
+            let url_end = text.byte_to_char(input.range.end) - 1;
+            inputs.push(UpdateInput {
+                input,
+                url_start,
+                url_end,
+            });
         }
         Self {
             inputs,
             text,
             offset: 0,
         }
+    }
+
+    /// Char-index range of the URL string *contents* (without the surrounding `"`),
+    /// adjusted for earlier in-place edits.
+    fn url_char_range(&self, input: &UpdateInput) -> (usize, usize) {
+        let start = (input.url_start as i32 + self.offset) as usize;
+        let end = (input.url_end as i32 + self.offset) as usize;
+        (start, end)
     }
     fn get_index(&self, id: &str) -> Option<usize> {
         let bare = id
@@ -255,12 +273,8 @@ impl Updater {
     }
 
     fn get_input_text(&self, input: &UpdateInput) -> String {
-        self.text
-            .slice(
-                ((input.input.range.start as i32) + 1 + self.offset) as usize
-                    ..((input.input.range.end as i32) + self.offset - 1) as usize,
-            )
-            .to_string()
+        let (start, end) = self.url_char_range(input);
+        self.text.slice(start..end).to_string()
     }
 
     /// Rewrite `input`'s URL to pin it to `rev`.
@@ -400,21 +414,11 @@ impl Updater {
         self.inputs.sort();
     }
     fn update_input(&mut self, input: UpdateInput, change: &str) {
-        self.text.remove(
-            (input.input.range.start as i32 + 1 + self.offset) as usize
-                ..(input.input.range.end as i32 - 1 + self.offset) as usize,
-        );
-        self.text.insert(
-            (input.input.range.start as i32 + 1 + self.offset) as usize,
-            change,
-        );
-        self.update_offset(input.clone(), change);
-    }
-    fn update_offset(&mut self, input: UpdateInput, change: &str) {
-        let previous_len = input.input.range.end as i32 - input.input.range.start as i32 - 2;
-        let len = change.len() as i32;
-        let offset = len - previous_len;
-        self.offset += offset;
+        let (start, end) = self.url_char_range(&input);
+        let previous_len = (end - start) as i32;
+        self.text.remove(start..end);
+        self.text.insert(start, change);
+        self.offset += change.chars().count() as i32 - previous_len;
     }
 }
 
@@ -422,17 +426,22 @@ impl Updater {
 #[derive(Debug, Clone)]
 pub struct UpdateInput {
     input: Input,
+    /// Char index of the first URL character (inside the quotes) in the
+    /// original, unmodified text.
+    url_start: usize,
+    /// Char index one past the last URL character in the original text.
+    url_end: usize,
 }
 
 impl Ord for UpdateInput {
     fn cmp(&self, other: &Self) -> Ordering {
-        (self.input.range.start).cmp(&(other.input.range.start))
+        self.url_start.cmp(&other.url_start)
     }
 }
 
 impl PartialEq for UpdateInput {
     fn eq(&self, other: &Self) -> bool {
-        self.input.range.start == other.input.range.start
+        self.url_start == other.url_start
     }
 }
 

--- a/tests/update.rs
+++ b/tests/update.rs
@@ -139,6 +139,48 @@ fn unpin_quoted_input_by_bare_name() {
     insta::assert_snapshot!(updater.get_changes());
 }
 
+/// Regression: rnix TextRange yields *byte* offsets, but ropey slices by
+/// *char* index. Any multibyte UTF-8 before the URL shifts the window and
+/// pin/unpin would mangle the file.
+#[test]
+fn pin_with_multibyte_chars_before_url() {
+    // "café —" contains a 2-byte and a 3-byte codepoint (3 extra bytes vs chars).
+    let flake = r#"{
+  # café — multibyte comment
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }: { };
+}
+"#
+    .to_string();
+    let mut flake_edit = FlakeEdit::from_text(&flake).unwrap();
+    let inputs = flake_edit.list().clone();
+    let mut updater = Updater::new(Rope::from_str(&flake), inputs);
+
+    updater
+        .pin_input_to_ref("nixpkgs", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+        .expect("pin should succeed");
+
+    let result = updater.get_changes();
+    // nix-uri may render the rev as a path segment or as `?rev=`; either is
+    // valid flake-ref syntax. What matters is that the edit landed on the URL
+    // and not three characters to the side of it.
+    let pinned_path =
+        r#"nixpkgs.url = "github:nixos/nixpkgs/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";"#;
+    let pinned_query =
+        r#"nixpkgs.url = "github:nixos/nixpkgs?rev=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";"#;
+    assert!(
+        result.contains(pinned_path) || result.contains(pinned_query),
+        "URL was corrupted by byte/char offset mismatch:\n{result}"
+    );
+    assert!(
+        result.contains("# café — multibyte comment"),
+        "preceding text was corrupted:\n{result}"
+    );
+}
+
 #[test]
 fn pin_follows_before_url() {
     let flake = r#"{


### PR DESCRIPTION
rnix `TextRange` reports **byte** offsets but `ropey::Rope` slices and edits by **char** index. With any multibyte UTF-8 ahead of an input URL (e.g. a comment containing `é` or `—`) the two diverge and `pin`/`unpin`/`update` sliced a window shifted off the URL. The `FlakeRef` parse then quietly failed and the edit was dropped — or, with the right alignment, the splice landed mid-token.

Convert byte offsets to char indices once against the unmodified rope when building `UpdateInput`, and keep the running edit offset in characters so all arithmetic stays in one unit.

Regression test included (red before this change).