### PR TITLE
follow: Support auto follows of more than one level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "smallvec",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ serde = { version = "1.0.228", default-features = false, features = [
   "alloc",
 ] }
 serde_json = { version = "1.0.149" }
+smallvec = { version = "1.13", features = ["const_generics", "union"] }
 toml = "1.1"
 thiserror = "2.0.18"
 tracing = "0.1.44"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -38,7 +38,7 @@ fn add_input() {
 fn remove_input() {
     let mut walker = Walker::new(INPUTS);
     let change = Change::Remove {
-        ids: vec!["nixpkgs".to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse("nixpkgs").unwrap()],
     };
     let _ = walker.walk(&change);
     // a simple sanity check

--- a/benches/divan.rs
+++ b/benches/divan.rs
@@ -44,7 +44,7 @@ fn add_input() {
 fn remove_input() {
     let mut walker = Walker::new(INPUTS);
     let change = Change::Remove {
-        ids: vec!["nixpkgs".to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse("nixpkgs").unwrap()],
     };
     let _ = walker.walk(&change);
     // a simple sanity check

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod editor;
+pub mod follow;
 pub mod handler;
 pub mod state;
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -1,13 +1,13 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
+use std::path::PathBuf;
 
 use nix_uri::urls::UrlWrapper;
 use nix_uri::{FlakeRef, NixUriResult};
 use ropey::Rope;
 
-use crate::change::{Change, split_quoted_path};
+use crate::change::{Change, ChangeId};
 use crate::edit::{FlakeEdit, InputMap, sorted_input_ids, sorted_input_ids_owned};
 use crate::error::FlakeEditError;
-use crate::input::Follows;
 use crate::lock::{FlakeLock, NestedInput};
 use crate::tui;
 use crate::update::Updater;
@@ -62,10 +62,25 @@ pub enum CommandError {
 
     #[error("The input could not be removed: {0}")]
     CouldNotRemove(String),
+
+    /// Aggregated failures from a `follow [PATHS...]` batch. Each entry
+    /// pairs the offending path with the error processing it produced.
+    #[error("{} file(s) failed during batch processing:\n{}", failures.len(), format_batch_failures(failures))]
+    Batch {
+        failures: Vec<(PathBuf, CommandError)>,
+    },
 }
 
-/// Load the flake.lock file, using the path from state if provided.
-fn load_flake_lock(state: &AppState) -> std::result::Result<FlakeLock, FlakeEditError> {
+fn format_batch_failures(failures: &[(PathBuf, CommandError)]) -> String {
+    failures
+        .iter()
+        .map(|(path, err)| format!("  - {}: {}", path.display(), err))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Load `flake.lock`, using the path from `state` if provided.
+pub(super) fn load_flake_lock(state: &AppState) -> std::result::Result<FlakeLock, FlakeEditError> {
     if let Some(lock_path) = &state.lock_file {
         FlakeLock::from_file(lock_path)
     } else {
@@ -73,49 +88,15 @@ fn load_flake_lock(state: &AppState) -> std::result::Result<FlakeLock, FlakeEdit
     }
 }
 
-struct FollowContext {
-    nested_inputs: Vec<NestedInput>,
-    top_level_inputs: HashSet<String>,
-    /// Full input map for checking URLs (needed for cycle detection)
-    inputs: crate::edit::InputMap,
-}
-
-/// Check if a top-level input's URL is a follows reference to a specific parent input.
-/// For example, `treefmt-nix.follows = "clan-core/treefmt-nix"` has URL `"clan-core/treefmt-nix"`
-/// which is a follows reference to the `clan-core` parent.
-fn is_follows_reference_to_parent(url: &str, parent: &str) -> bool {
-    let url_trimmed = url.trim_matches('"');
-    url_trimmed.starts_with(&format!("{}/", parent))
-}
-
-/// Collect nested follows paths already declared in flake.nix.
-///
-/// Paths are normalised so that they can be compared against lock-file
-/// paths regardless of whether the Nix source quotes the attribute names.
-fn collect_existing_follows(inputs: &InputMap) -> HashSet<String> {
-    let mut existing = HashSet::new();
-    for (input_id, input) in inputs {
-        for follows in input.follows() {
-            if let Follows::Indirect(nested_name, _target) = follows {
-                let raw = format!("{}.{}", input_id, nested_name);
-                existing.insert(normalize_nested_path(&raw));
-            }
-        }
-    }
-    existing
-}
-
-/// Convert a lockfile follows path like "parent.child" to flake follows syntax "parent/child".
-fn lock_follows_to_flake_target(target: &str) -> String {
-    if target.contains('.') {
-        target.replace('.', "/")
-    } else {
-        target.to_string()
-    }
+pub(super) struct FollowContext {
+    pub(super) nested_inputs: Vec<NestedInput>,
+    pub(super) top_level_inputs: HashSet<String>,
+    /// Full input map. Cycle detection needs URLs.
+    pub(super) inputs: crate::edit::InputMap,
 }
 
 /// Load nested inputs from lockfile and top-level inputs from flake.nix.
-fn load_follow_context(
+pub(super) fn load_follow_context(
     flake_edit: &mut FlakeEdit,
     state: &AppState,
 ) -> Result<Option<FollowContext>> {
@@ -141,8 +122,12 @@ fn load_follow_context(
     let inputs = flake_edit.list().clone();
     let top_level_inputs: HashSet<String> = inputs.keys().cloned().collect();
 
+    // Inputless flakes (templates, NUR-style overlays, outputs-only
+    // libraries) are legitimate; treat them as a no-op rather than an
+    // error so batch invocations don't abort on the first one.
+    // Symmetric with the `nested_inputs.is_empty()` short-circuit above.
     if top_level_inputs.is_empty() {
-        return Err(CommandError::NoInputs);
+        return Ok(None);
     }
 
     Ok(Some(FollowContext {
@@ -152,7 +137,7 @@ fn load_follow_context(
     }))
 }
 
-/// Result of running the confirm-or-apply workflow.
+/// Outcome of [`confirm_or_apply`].
 enum ConfirmResult {
     /// Change was applied successfully.
     Applied,
@@ -162,11 +147,11 @@ enum ConfirmResult {
     Back,
 }
 
-/// Run an interactive single-select loop with confirmation.
+/// Interactive single-select loop with confirmation.
 ///
 /// 1. Show selection screen
 /// 2. User selects an item
-/// 3. Create change based on selection
+/// 3. Build a change from the selection
 /// 4. Show confirmation (with diff if requested)
 /// 5. Apply or go back
 fn interactive_single_select<F, OnApplied, ExtraData>(
@@ -205,7 +190,7 @@ where
     Ok(())
 }
 
-/// Like `interactive_single_select` but for multi-selection.
+/// Multi-select counterpart of [`interactive_single_select`].
 fn interactive_multi_select<F>(
     editor: &Editor,
     state: &AppState,
@@ -241,9 +226,6 @@ where
 ///
 /// If `show_diff` is true, shows a confirmation screen with the diff.
 /// Otherwise applies the change directly.
-///
-/// Returns `Back` if user wants to go back to selection, `Applied` if the
-/// change was applied, or `Cancelled` if the user cancelled.
 fn confirm_or_apply(
     editor: &Editor,
     state: &AppState,
@@ -273,7 +255,7 @@ fn confirm_or_apply(
     }
 }
 
-/// Apply URI options (ref_or_rev, shallow) to a FlakeRef.
+/// Apply `ref_or_rev` and `shallow` options to a [`FlakeRef`].
 fn apply_uri_options(
     mut flake_ref: FlakeRef,
     ref_or_rev: Option<&str>,
@@ -295,11 +277,10 @@ fn apply_uri_options(
     Ok(flake_ref)
 }
 
-/// Transform a URI string by applying ref_or_rev and shallow options if specified.
+/// Apply `ref_or_rev` and `shallow` to a URI string.
 ///
-/// Always validates the URI through nix-uri parsing.
-/// If neither option is set, returns the original URI unchanged after validation.
-/// Otherwise, applies the options and returns the transformed string.
+/// Always validates the URI through `nix-uri` parsing. If neither option
+/// is set, returns the original URI unchanged.
 fn transform_uri(uri: String, ref_or_rev: Option<&str>, shallow: bool) -> Result<String> {
     let flake_ref: FlakeRef = uri
         .parse()
@@ -330,15 +311,14 @@ pub fn add(
     opts: UriOptions<'_>,
 ) -> Result<()> {
     let change = match (id, uri, state.interactive) {
-        // Both ID and URI provided - non-interactive add
+        // Both ID and URI provided: non-interactive add.
         (Some(id_val), Some(uri_str), _) => add_with_id_and_uri(id_val, uri_str, &opts)?,
-        // Interactive mode - show TUI (with or without prefill)
+        // Interactive: show TUI (with or without prefill).
         (id, None, true) | (None, id, true) => {
             add_interactive(editor, state, id.as_deref(), &opts)?
         }
-        // Non-interactive with only one arg (could be in id or uri position) - infer ID
+        // Non-interactive with only one positional arg: infer ID from URI.
         (Some(uri), None, false) | (None, Some(uri), false) => add_infer_id(uri, &opts)?,
-        // No arguments and non-interactive
         (None, None, false) => {
             return Err(CommandError::NoUri);
         }
@@ -364,11 +344,11 @@ fn add_interactive(
 ) -> Result<Change> {
     let tui_app = tui::App::add("Add", editor.text(), prefill_uri, state.cache_config());
     let Some(tui::AppResult::Change(tui_change)) = tui::run(tui_app)? else {
-        // User cancelled - return a no-op change
+        // User cancelled.
         return Ok(Change::None);
     };
 
-    // Apply CLI options to the TUI result
+    // CLI options override the TUI result.
     if let Change::Add { id, uri, flake } = tui_change {
         let final_uri = uri
             .map(|u| transform_uri(u, opts.ref_or_rev, opts.shallow))
@@ -383,7 +363,7 @@ fn add_interactive(
     }
 }
 
-/// Add with only URI provided, inferring ID from the flake reference.
+/// Add with only URI: infer ID from the parsed flake reference.
 fn add_infer_id(uri: String, opts: &UriOptions<'_>) -> Result<Change> {
     let flake_ref: NixUriResult<FlakeRef> = UrlWrapper::convert_or_parse(&uri);
 
@@ -416,51 +396,55 @@ pub fn remove(
     state: &AppState,
     id: Option<String>,
 ) -> Result<()> {
-    let change = if let Some(id) = id {
-        Change::Remove {
-            ids: vec![id.into()],
-        }
-    } else if state.interactive {
-        let inputs = flake_edit.list();
-        let mut removable: Vec<String> = Vec::new();
-        for input_id in sorted_input_ids(inputs) {
-            let input = &inputs[input_id];
-            removable.push(input_id.clone());
-            for follows in input.follows() {
-                if let crate::input::Follows::Indirect(from, to) = follows {
-                    removable.push(format!("{}.{} => {}", input_id, from, to));
+    let change =
+        if let Some(id) = id {
+            Change::Remove {
+                ids: vec![ChangeId::parse(&id).map_err(|e| {
+                    CommandError::InvalidUri(format!("invalid input id `{id}`: {e}"))
+                })?],
+            }
+        } else if state.interactive {
+            let inputs = flake_edit.list();
+            let mut removable: Vec<String> = Vec::new();
+            for input_id in sorted_input_ids(inputs) {
+                let input = &inputs[input_id];
+                removable.push(input_id.clone());
+                for follows in input.follows() {
+                    if let crate::input::Follows::Indirect { path, target } = follows {
+                        let target_str = match target {
+                            Some(t) => t.to_string(),
+                            None => "\"\"".to_string(),
+                        };
+                        removable.push(format!("{}.{} => {}", input_id, path, target_str));
+                    }
                 }
             }
-        }
-        if removable.is_empty() {
-            return Err(CommandError::NoInputs);
-        }
+            if removable.is_empty() {
+                return Err(CommandError::NoInputs);
+            }
 
-        let tui_app = tui::App::remove("Remove", editor.text(), removable);
-        let Some(tui::AppResult::Change(tui_change)) = tui::run(tui_app)? else {
-            return Ok(());
-        };
+            let tui_app = tui::App::remove("Remove", editor.text(), removable);
+            let Some(tui::AppResult::Change(tui_change)) = tui::run(tui_app)? else {
+                return Ok(());
+            };
 
-        // Strip " => target" suffix for follows entries
-        if let Change::Remove { ids } = tui_change {
-            let stripped_ids: Vec<_> = ids
-                .iter()
-                .map(|id| {
-                    id.to_string()
-                        .split(" => ")
-                        .next()
-                        .unwrap_or(&id.to_string())
-                        .to_string()
-                        .into()
-                })
-                .collect();
-            Change::Remove { ids: stripped_ids }
+            // Strip the " => target" suffix on follows entries.
+            if let Change::Remove { ids } = tui_change {
+                let stripped_ids: Vec<_> = ids
+                    .iter()
+                    .filter_map(|id| {
+                        let s = id.to_string();
+                        let stripped = s.split(" => ").next().unwrap_or(&s);
+                        ChangeId::parse(stripped).ok()
+                    })
+                    .collect();
+                Change::Remove { ids: stripped_ids }
+            } else {
+                tui_change
+            }
         } else {
-            tui_change
-        }
-    } else {
-        return Err(CommandError::NoId);
-    };
+            return Err(CommandError::NoId);
+        };
 
     apply_change(editor, flake_edit, state, change)
 }
@@ -477,24 +461,23 @@ pub fn change(
     let inputs = flake_edit.list();
 
     let change = match (id, uri, state.interactive) {
-        // Full interactive: select input, then enter URI
-        // Also handles case where only URI provided interactively (need to select input)
+        // Full interactive: select input, then enter URI. Also covers the
+        // case where only URI was provided interactively (need to select input).
         (None, None, true) | (None, Some(_), true) => {
             change_full_interactive(editor, state, inputs, ref_or_rev, shallow)?
         }
-        // ID provided, no URI, interactive: show URI input for that ID
+        // ID provided, no URI, interactive: show URI input for that ID.
         (Some(id), None, true) => {
             change_uri_interactive(editor, state, inputs, &id, ref_or_rev, shallow)?
         }
-        // Both ID and URI provided - non-interactive
+        // Both ID and URI provided: non-interactive.
         (Some(id_val), Some(uri_str), _) => {
             change_with_id_and_uri(id_val, uri_str, ref_or_rev, shallow)?
         }
-        // Only one positional arg (in id position), infer ID from URI
+        // Only one positional arg: infer ID from URI.
         (Some(uri), None, false) | (None, Some(uri), false) => {
             change_infer_id(uri, ref_or_rev, shallow)?
         }
-        // No arguments and non-interactive
         (None, None, false) => {
             return Err(CommandError::NoId);
         }
@@ -503,7 +486,7 @@ pub fn change(
     apply_change(editor, flake_edit, state, change)
 }
 
-/// Full interactive change: select input from list, then enter new URI.
+/// Interactive change: pick an input from the list, then enter the new URI.
 fn change_full_interactive(
     editor: &Editor,
     state: &AppState,
@@ -525,7 +508,7 @@ fn change_full_interactive(
         return Ok(Change::None);
     };
 
-    // Apply CLI options to the TUI result
+    // CLI options override the TUI result.
     if let Change::Change { id, uri, .. } = tui_change {
         let final_uri = uri
             .map(|u| transform_uri(u, ref_or_rev, shallow))
@@ -540,7 +523,7 @@ fn change_full_interactive(
     }
 }
 
-/// Interactive change with ID already known: show URI input.
+/// Interactive change with the ID already known: show only the URI input.
 fn change_uri_interactive(
     editor: &Editor,
     state: &AppState,
@@ -563,7 +546,7 @@ fn change_uri_interactive(
         return Ok(Change::None);
     };
 
-    // Apply CLI options to the TUI result
+    // CLI options override the TUI result.
     if let Change::Change {
         uri: Some(new_uri), ..
     } = tui_change
@@ -593,7 +576,7 @@ fn change_with_id_and_uri(
     })
 }
 
-/// Change with only URI provided, inferring ID from the flake reference.
+/// Change with only URI: infer ID from the parsed flake reference.
 fn change_infer_id(uri: String, ref_or_rev: Option<&str>, shallow: bool) -> Result<Change> {
     let flake_ref: NixUriResult<FlakeRef> = UrlWrapper::convert_or_parse(&uri);
 
@@ -660,7 +643,7 @@ pub fn update(
             "Space select, U all, ^D diff",
             display_items,
             |selected| {
-                // Strip version suffix from display strings to get IDs
+                // Strip the trailing version suffix from each display string.
                 let ids: Vec<String> = selected
                     .iter()
                     .map(|s| s.split(" - ").next().unwrap_or(s).to_string())
@@ -821,7 +804,7 @@ pub fn list(flake_edit: &mut FlakeEdit, format: &crate::cli::ListFormat) -> Resu
     Ok(())
 }
 
-/// Handle the `config` subcommand.
+/// Handler for the `config` subcommand.
 pub fn config(print_default: bool, path: bool) -> Result<()> {
     use crate::config::{Config, DEFAULT_CONFIG_TOML};
 
@@ -831,7 +814,6 @@ pub fn config(print_default: bool, path: bool) -> Result<()> {
     }
 
     if path {
-        // Show where config would be loaded from
         let project_path = Config::project_config_path();
         let user_path = Config::user_config_path();
 
@@ -857,662 +839,17 @@ pub fn config(print_default: bool, path: bool) -> Result<()> {
     Ok(())
 }
 
-/// Manually add a single follows declaration.
-pub fn add_follow(
-    editor: &Editor,
-    flake_edit: &mut FlakeEdit,
-    state: &AppState,
-    input: Option<String>,
-    target: Option<String>,
-) -> Result<()> {
-    let change = if let (Some(input_val), Some(target_val)) = (input.clone(), target) {
-        // Both provided - non-interactive
-        Change::Follows {
-            input: input_val.into(),
-            target: target_val,
-        }
-    } else if state.interactive {
-        // Interactive mode
-        let Some(ctx) = load_follow_context(flake_edit, state)? else {
-            return Ok(());
-        };
-        let top_level_vec: Vec<String> = ctx.top_level_inputs.into_iter().collect();
-
-        let tui_app = if let Some(input_val) = input {
-            tui::App::follow_target("Follow", editor.text(), input_val, top_level_vec)
-        } else {
-            tui::App::follow("Follow", editor.text(), ctx.nested_inputs, top_level_vec)
-        };
-
-        let Some(tui::AppResult::Change(tui_change)) = tui::run(tui_app)? else {
-            return Ok(());
-        };
-        tui_change
-    } else {
-        return Err(CommandError::NoId);
-    };
-
-    apply_change(editor, flake_edit, state, change)
-}
-
-/// Strip surrounding double-quotes from a Nix attribute name.
-///
-/// AST-extracted identifiers may carry quotes (e.g. `"nixpkgs"`), while
-/// lock-file paths only quote names that contain dots.  Stripping quotes
-/// before comparison prevents false mismatches.
-fn strip_attr_quotes(s: &str) -> &str {
-    s.strip_prefix('"')
-        .and_then(|s| s.strip_suffix('"'))
-        .unwrap_or(s)
-}
-
-/// Normalise a `parent.nested` path into the canonical form used by the
-/// lock file: each segment is quoted only when it contains a dot.
-fn normalize_nested_path(path: &str) -> String {
-    let (parent, child) = split_quoted_path(path).unwrap_or((path, path));
-    let p = strip_attr_quotes(parent);
-    let c = strip_attr_quotes(child);
-    let fmt_segment = |s: &str| -> String {
-        if s.contains('.') {
-            format!("\"{}\"", s)
-        } else {
-            s.to_string()
-        }
-    };
-    format!("{}.{}", fmt_segment(p), fmt_segment(c))
-}
-
-/// Collect follows declarations that reference nested inputs
-/// no longer present in the lock file.
-fn collect_stale_follows(
-    inputs: &InputMap,
-    existing_nested_paths: &HashSet<String>,
-) -> Vec<String> {
-    let normalized_existing: HashSet<String> = existing_nested_paths
-        .iter()
-        .map(|p| normalize_nested_path(p))
-        .collect();
-    let mut stale = Vec::new();
-    for (input_id, input) in inputs {
-        for follows in input.follows() {
-            if let Follows::Indirect(nested_name, _target) = follows {
-                let nested_path = format!("{}.{}", input_id, nested_name);
-                if !normalized_existing.contains(&normalize_nested_path(&nested_path)) {
-                    stale.push(nested_path);
-                }
-            }
-        }
-    }
-    stale
-}
-
-/// Automatically follow inputs based on lockfile information.
-///
-/// For each nested input (e.g., "crane.nixpkgs"), if there's a matching
-/// top-level input with the same name (e.g., "nixpkgs"), create a follows
-/// relationship. Skips inputs that already have follows set.
-/// Also removes stale follows declarations that reference nested inputs
-/// no longer present in the lock file.
-///
-/// The config file controls behavior:
-/// - `follow.ignore`: List of input names to skip
-/// - `follow.aliases`: Map of canonical names to alternatives (e.g., nixpkgs = ["nixpkgs-lib"])
-/// - `follow.transitive_min`: Minimum number of matching transitive follows before adding a
-///   top-level follows input (set to 0 to disable)
-pub fn follow_auto(editor: &Editor, flake_edit: &mut FlakeEdit, state: &AppState) -> Result<()> {
-    follow_auto_impl(editor, flake_edit, state, false)
-}
-
-/// Internal implementation with quiet flag for batch processing.
-fn follow_auto_impl(
-    editor: &Editor,
-    flake_edit: &mut FlakeEdit,
-    state: &AppState,
-    quiet: bool,
-) -> Result<()> {
-    let Some(ctx) = load_follow_context(flake_edit, state)? else {
-        if !quiet {
-            println!("Nothing to deduplicate.");
-        }
-        return Ok(());
-    };
-
-    let existing_nested_paths: HashSet<String> = load_flake_lock(state)
-        .map(|l| l.nested_input_paths().into_iter().collect())
-        .unwrap_or_default();
-
-    let to_unfollow = collect_stale_follows(&ctx.inputs, &existing_nested_paths);
-
-    let follow_config = &state.config.follow;
-    let existing_follows = collect_existing_follows(&ctx.inputs);
-    let transitive_min = follow_config.transitive_min();
-    let mut seen_nested: HashSet<String> = HashSet::new();
-
-    // Collect candidates: nested inputs that match a top-level input
-    let mut to_follow: Vec<(String, String)> = ctx
-        .nested_inputs
-        .iter()
-        .filter_map(|nested| {
-            let (parent, nested_name) =
-                split_quoted_path(&nested.path).unwrap_or((&nested.path, &nested.path));
-
-            // Skip ignored inputs (supports both full path and simple name)
-            if follow_config.is_ignored(&nested.path, nested_name) {
-                tracing::debug!("Skipping {}: ignored by config", nested.path);
-                return None;
-            }
-
-            // Skip if already configured in flake.nix
-            if existing_follows.contains(&normalize_nested_path(&nested.path)) {
-                tracing::debug!("Skipping {}: already follows in flake.nix", nested.path);
-                return None;
-            }
-
-            // Find matching top-level input (direct match or via alias)
-            let matching_top_level = ctx
-                .top_level_inputs
-                .iter()
-                .find(|top| follow_config.can_follow(nested_name, top));
-
-            let target = matching_top_level?;
-
-            // Skip if target already follows from parent (would create cycle)
-            // e.g., treefmt-nix.follows = "clan-core/treefmt-nix" means we can't
-            // add clan-core.inputs.treefmt-nix.follows = "treefmt-nix"
-            if let Some(target_input) = ctx.inputs.get(target.as_str())
-                && is_follows_reference_to_parent(target_input.url(), parent)
-            {
-                tracing::debug!(
-                    "Skipping {} -> {}: would create cycle (target follows {}/...)",
-                    nested.path,
-                    target,
-                    parent
-                );
-                return None;
-            }
-
-            Some((nested.path.clone(), target.clone()))
-        })
-        .collect();
-
-    for (nested_path, _target) in &to_follow {
-        seen_nested.insert(nested_path.clone());
-    }
-
-    let mut transitive_groups: HashMap<String, HashMap<String, Vec<String>>> = HashMap::new();
-
-    if transitive_min > 0 {
-        for nested in ctx.nested_inputs.iter() {
-            let nested_name = nested.path.split('.').next_back().unwrap_or(&nested.path);
-            let parent = nested.path.split('.').next().unwrap_or(&nested.path);
-
-            if follow_config.is_ignored(&nested.path, nested_name) {
-                continue;
-            }
-
-            if existing_follows.contains(&normalize_nested_path(&nested.path))
-                || seen_nested.contains(&nested.path)
-            {
-                continue;
-            }
-
-            let matching_top_level = ctx
-                .top_level_inputs
-                .iter()
-                .find(|top| follow_config.can_follow(nested_name, top));
-
-            if matching_top_level.is_some() {
-                continue;
-            }
-
-            let Some(transitive_target) = nested.follows.as_ref() else {
-                continue;
-            };
-
-            // Only consider transitive follows (path with a parent segment).
-            if !transitive_target.contains('.') {
-                continue;
-            }
-
-            // Avoid self-follow situations.
-            if transitive_target == nested_name {
-                continue;
-            }
-
-            let top_level_name = follow_config
-                .resolve_alias(nested_name)
-                .unwrap_or(nested_name)
-                .to_string();
-
-            // Skip if a top-level input already exists with that name.
-            if ctx.top_level_inputs.contains(&top_level_name) {
-                continue;
-            }
-
-            // Skip if target already follows from parent (would create cycle)
-            if let Some(target_input) = ctx.inputs.get(transitive_target.as_str())
-                && is_follows_reference_to_parent(target_input.url(), parent)
-            {
-                continue;
-            }
-
-            transitive_groups
-                .entry(top_level_name)
-                .or_default()
-                .entry(transitive_target.clone())
-                .or_default()
-                .push(nested.path.clone());
-        }
-    }
-
-    // Pass 2b: Group Direct references (follows: None) by canonical name.
-    // These are nested inputs that point to separate lock nodes rather than
-    // following an existing path. When multiple parents share the same
-    // dependency (e.g., treefmt.nixpkgs and treefmt-nix.nixpkgs), we can
-    // promote one to top-level and have the others follow it.
-    // Each entry: canonical_name -> Vec<(path, url)>
-    let mut direct_groups: HashMap<String, Vec<(String, Option<String>)>> = HashMap::new();
-
-    if transitive_min > 0 {
-        for nested in ctx.nested_inputs.iter() {
-            let nested_name = nested.path.split('.').next_back().unwrap_or(&nested.path);
-
-            if nested.follows.is_some() {
-                continue;
-            }
-
-            if follow_config.is_ignored(&nested.path, nested_name) {
-                continue;
-            }
-
-            if existing_follows.contains(&normalize_nested_path(&nested.path))
-                || seen_nested.contains(&nested.path)
-            {
-                continue;
-            }
-
-            let matching_top_level = ctx
-                .top_level_inputs
-                .iter()
-                .find(|top| follow_config.can_follow(nested_name, top));
-
-            if matching_top_level.is_some() {
-                continue;
-            }
-
-            let canonical_name = follow_config
-                .resolve_alias(nested_name)
-                .unwrap_or(nested_name)
-                .to_string();
-
-            if ctx.top_level_inputs.contains(&canonical_name) {
-                continue;
-            }
-
-            direct_groups
-                .entry(canonical_name)
-                .or_default()
-                .push((nested.path.clone(), nested.url.clone()));
-        }
-    }
-
-    let mut toplevel_follows: Vec<(String, String)> = Vec::new();
-    let mut toplevel_adds: Vec<(String, String)> = Vec::new();
-
-    if transitive_min > 0 {
-        for (top_name, targets) in transitive_groups {
-            let mut eligible: Vec<(String, Vec<String>)> = targets
-                .into_iter()
-                .filter(|(_, paths)| paths.len() >= transitive_min)
-                .collect();
-
-            if eligible.len() != 1 {
-                continue;
-            }
-
-            let (target_path, paths) = eligible.pop().unwrap();
-            let follow_target = lock_follows_to_flake_target(&target_path);
-
-            if follow_target == top_name {
-                continue;
-            }
-
-            toplevel_follows.push((top_name.clone(), follow_target));
-
-            for path in paths {
-                if seen_nested.insert(path.clone()) {
-                    to_follow.push((path, top_name.clone()));
-                }
-            }
-        }
-
-        // Promote Direct reference groups: add a new top-level input with the
-        // URL from one of the nested references, then have all paths follow it.
-        // Only promote if at least one follows can actually be applied.
-        let mut direct_groups_sorted: Vec<_> = direct_groups.into_iter().collect();
-        direct_groups_sorted.sort_by(|a, b| a.0.cmp(&b.0));
-        for (canonical_name, mut entries) in direct_groups_sorted {
-            if entries.len() < transitive_min {
-                continue;
-            }
-
-            entries.sort_by(|a, b| a.0.cmp(&b.0));
-
-            let url = entries.iter().find_map(|(_, u)| u.clone());
-            let Some(url) = url else {
-                continue;
-            };
-
-            // Dry-run: check that at least one follows can be applied.
-            let can_follow = entries.iter().any(|(path, _)| {
-                let change = Change::Follows {
-                    input: path.clone().into(),
-                    target: canonical_name.clone(),
-                };
-                FlakeEdit::from_text(&editor.text())
-                    .ok()
-                    .and_then(|mut fe| fe.apply_change(change).ok().flatten())
-                    .is_some()
-            });
-            if !can_follow {
-                continue;
-            }
-
-            toplevel_adds.push((canonical_name.clone(), url));
-
-            for (path, _) in &entries {
-                if seen_nested.insert(path.clone()) {
-                    to_follow.push((path.clone(), canonical_name.clone()));
-                }
-            }
-        }
-    }
-
-    if to_follow.is_empty()
-        && to_unfollow.is_empty()
-        && toplevel_follows.is_empty()
-        && toplevel_adds.is_empty()
-    {
-        if !quiet {
-            println!("All inputs are already deduplicated.");
-        }
-        return Ok(());
-    }
-
-    // Apply all changes in memory
-    let mut current_text = editor.text();
-    let mut applied: Vec<(&str, &str)> = Vec::new();
-
-    // First, add new top-level inputs (from Direct reference promotion).
-    // These must be added before follows declarations that reference them.
-    for (id, url) in &toplevel_adds {
-        let change = Change::Add {
-            id: Some(id.clone()),
-            uri: Some(url.clone()),
-            flake: true,
-        };
-
-        let mut temp_flake_edit =
-            FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
-
-        match temp_flake_edit.apply_change(change) {
-            Ok(Some(resulting_text)) => {
-                let validation = validate::validate(&resulting_text);
-                if validation.is_ok() {
-                    current_text = resulting_text;
-                } else {
-                    for err in validation.errors {
-                        eprintln!("Error adding top-level input {}: {}", id, err);
-                    }
-                }
-            }
-            Ok(None) => eprintln!("Could not add top-level input {}", id),
-            Err(e) => eprintln!("Error adding top-level input {}: {}", id, e),
-        }
-    }
-
-    let mut follow_changes: Vec<(String, String)> = Vec::new();
-    follow_changes.extend(toplevel_follows);
-    follow_changes.extend(to_follow);
-
-    for (input_path, target) in &follow_changes {
-        let change = Change::Follows {
-            input: input_path.clone().into(),
-            target: target.clone(),
-        };
-
-        let mut temp_flake_edit =
-            FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
-
-        match temp_flake_edit.apply_change(change) {
-            Ok(Some(resulting_text)) => {
-                if resulting_text == current_text {
-                    // No-op: follows already exists with the same target
-                    continue;
-                }
-                let validation = validate::validate(&resulting_text);
-                if validation.is_ok() {
-                    current_text = resulting_text;
-                    applied.push((input_path, target));
-                } else {
-                    for err in validation.errors {
-                        eprintln!("Error applying follows for {}: {}", input_path, err);
-                    }
-                }
-            }
-            Ok(None) => eprintln!("Could not create follows for {}", input_path),
-            Err(e) => eprintln!("Error applying follows for {}: {}", input_path, e),
-        }
-    }
-
-    let mut unfollowed: Vec<&str> = Vec::new();
-
-    for nested_path in &to_unfollow {
-        let change = Change::Remove {
-            ids: vec![nested_path.clone().into()],
-        };
-
-        let mut temp_flake_edit =
-            FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
-
-        match temp_flake_edit.apply_change(change) {
-            Ok(Some(resulting_text)) => {
-                let validation = validate::validate(&resulting_text);
-                if validation.is_ok() {
-                    current_text = resulting_text;
-                    unfollowed.push(nested_path);
-                }
-            }
-            Ok(None) => {}
-            Err(e) => eprintln!("Error removing stale follows for {}: {}", nested_path, e),
-        }
-    }
-
-    if applied.is_empty() && unfollowed.is_empty() {
-        return Ok(());
-    }
-
-    if state.diff {
-        let original = editor.text();
-        let diff = crate::diff::Diff::new(&original, &current_text);
-        diff.compare();
-    } else {
-        editor.apply_or_diff(&current_text, state)?;
-
-        if !quiet {
-            if !applied.is_empty() {
-                println!(
-                    "Deduplicated {} {}.",
-                    applied.len(),
-                    if applied.len() == 1 {
-                        "input"
-                    } else {
-                        "inputs"
-                    }
-                );
-                for (input_path, target) in &applied {
-                    if input_path.contains('.') {
-                        let (parent, nested_name) =
-                            split_quoted_path(input_path).unwrap_or((input_path, input_path));
-                        println!("  {}.{} → {}", parent, nested_name, target);
-                    } else {
-                        println!("  {} → {}", input_path, target);
-                    }
-                }
-            }
-
-            if !unfollowed.is_empty() {
-                println!(
-                    "Removed {} stale follows {}.",
-                    unfollowed.len(),
-                    if unfollowed.len() == 1 {
-                        "declaration"
-                    } else {
-                        "declarations"
-                    }
-                );
-                for path in &unfollowed {
-                    println!("  {} (input no longer exists)", path);
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// Process multiple flake files in batch mode.
-///
-/// Each file is processed independently with its own Editor/AppState.
-/// Errors are collected and reported at the end, but processing continues
-/// for all files. Returns error if any file failed.
-pub fn follow_auto_batch(
-    paths: &[std::path::PathBuf],
-    transitive: Option<usize>,
-    args: &crate::cli::CliArgs,
-) -> Result<()> {
-    use std::path::PathBuf;
-
-    let mut errors: Vec<(PathBuf, CommandError)> = Vec::new();
-
-    for flake_path in paths {
-        let lock_path = flake_path
-            .parent()
-            .map(|p| p.join("flake.lock"))
-            .unwrap_or_else(|| PathBuf::from("flake.lock"));
-
-        let editor = match Editor::from_path(flake_path.clone()) {
-            Ok(e) => e,
-            Err(e) => {
-                errors.push((flake_path.clone(), e.into()));
-                continue;
-            }
-        };
-
-        let mut flake_edit = match editor.create_flake_edit() {
-            Ok(fe) => fe,
-            Err(e) => {
-                errors.push((flake_path.clone(), e.into()));
-                continue;
-            }
-        };
-
-        let mut state = match AppState::new(
-            editor.text(),
-            flake_path.clone(),
-            args.config().map(PathBuf::from),
-        ) {
-            Ok(s) => s
-                .with_diff(args.diff())
-                .with_no_lock(args.no_lock())
-                .with_interactive(false)
-                .with_lock_file(Some(lock_path))
-                .with_no_cache(args.no_cache())
-                .with_cache_path(args.cache().map(PathBuf::from)),
-            Err(e) => {
-                errors.push((flake_path.clone(), e.into()));
-                continue;
-            }
-        };
-
-        if let Some(min) = transitive {
-            state.config.follow.transitive_min = min;
-        }
-
-        if let Err(e) = follow_auto_impl(&editor, &mut flake_edit, &state, true) {
-            errors.push((flake_path.clone(), e));
-        }
-    }
-
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        for (path, err) in &errors {
-            eprintln!("Error processing {}: {}", path.display(), err);
-        }
-        // Return the first error
-        Err(errors.into_iter().next().unwrap().1)
-    }
-}
-
-fn apply_change(
+pub(super) fn apply_change(
     editor: &Editor,
     flake_edit: &mut FlakeEdit,
     state: &AppState,
     change: Change,
 ) -> Result<()> {
     let original_content = flake_edit.source_text();
-    match flake_edit.apply_change(change.clone()) {
-        Ok(Some(resulting_change)) => {
-            if change.is_follows() && resulting_change == original_content {
-                if let Some(id) = change.id() {
-                    println!(
-                        "Already follows: {}.inputs.{}.follows = \"{}\"",
-                        id.input(),
-                        id.follows().unwrap_or("?"),
-                        change.follows_target().unwrap_or(&"?".to_string())
-                    );
-                }
-                return Ok(());
-            }
-
-            let validation = validate::validate(&resulting_change);
-            if validation.has_errors() {
-                eprintln!("There are errors in the changes:");
-                for e in &validation.errors {
-                    tracing::error!("Error: {e}");
-                }
-                eprintln!("{}", resulting_change);
-                eprintln!("There were errors in the changes, the changes have not been applied.");
-                std::process::exit(1);
-            }
-
-            editor.apply_or_diff(&resulting_change, state)?;
-
-            if !state.diff {
-                // Cache added entries for future completions
-                if let Change::Add {
-                    id: Some(id),
-                    uri: Some(uri),
-                    ..
-                } = &change
-                {
-                    let mut cache = crate::cache::Cache::load();
-                    cache.add_entry(id.clone(), uri.clone());
-                    if let Err(e) = cache.commit() {
-                        tracing::debug!("Could not write to cache: {}", e);
-                    }
-                }
-
-                for msg in change.success_messages() {
-                    println!("{}", msg);
-                }
-            }
-        }
-        Err(e) => {
-            return Err(e.into());
-        }
-        Ok(None) => {
+    let outcome = flake_edit.apply_change(change.clone())?;
+    let resulting_change = match outcome.text {
+        Some(t) => t,
+        None => {
             if change.is_remove() {
                 return Err(CommandError::CouldNotRemove(
                     change.id().map(|id| id.to_string()).unwrap_or_default(),
@@ -1529,6 +866,60 @@ fn apply_change(
                 std::process::exit(1);
             }
             println!("Nothing changed.");
+            return Ok(());
+        }
+    };
+
+    if change.is_follows() && resulting_change == original_content {
+        if let Some(id) = change.id() {
+            let follows_str = id
+                .follows()
+                .map(|s| s.render())
+                .unwrap_or_else(|| "?".to_string());
+            let target_str = change
+                .follows_target()
+                .map(|t| t.to_string())
+                .unwrap_or_else(|| "?".to_string());
+            println!(
+                "Already follows: {}.inputs.{}.follows = \"{}\"",
+                id.input().render(),
+                follows_str,
+                target_str,
+            );
+        }
+        return Ok(());
+    }
+
+    let validation = validate::validate(&resulting_change);
+    if validation.has_errors() {
+        eprintln!("There are errors in the changes:");
+        for e in &validation.errors {
+            tracing::error!("Error: {e}");
+        }
+        eprintln!("{}", resulting_change);
+        eprintln!("There were errors in the changes, the changes have not been applied.");
+        std::process::exit(1);
+    }
+
+    editor.apply_or_diff(&resulting_change, state)?;
+
+    if !state.diff {
+        // Cache added entries for future completions.
+        if let Change::Add {
+            id: Some(id),
+            uri: Some(uri),
+            ..
+        } = &change
+        {
+            let mut cache = crate::cache::Cache::load();
+            cache.add_entry(id.clone(), uri.clone());
+            if let Err(e) = cache.commit() {
+                tracing::debug!("Could not write to cache: {}", e);
+            }
+        }
+
+        for msg in change.success_messages() {
+            println!("{}", msg);
         }
     }
 
@@ -1538,105 +929,27 @@ fn apply_change(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::follows::AttrPath;
 
     #[test]
-    fn test_is_follows_reference_to_parent() {
-        // Test case: treefmt-nix.follows = "clan-core/treefmt-nix"
-        // The URL would be stored as "\"clan-core/treefmt-nix\""
-        assert!(is_follows_reference_to_parent(
-            "\"clan-core/treefmt-nix\"",
-            "clan-core"
-        ));
+    fn existing_follows_via_graph_handles_quoted_attrs() {
+        use crate::follows::{FollowsGraph, Segment};
+        use crate::input::{Follows, Input};
 
-        // Also test without surrounding quotes (defensive)
-        assert!(is_follows_reference_to_parent(
-            "clan-core/treefmt-nix",
-            "clan-core"
-        ));
-
-        // Test with different parent
-        assert!(is_follows_reference_to_parent(
-            "\"some-input/nixpkgs\"",
-            "some-input"
-        ));
-
-        // Negative test: regular URL should not match
-        assert!(!is_follows_reference_to_parent(
-            "\"github:nixos/nixpkgs\"",
-            "clan-core"
-        ));
-
-        // Negative test: URL that contains the parent but doesn't start with it
-        assert!(!is_follows_reference_to_parent(
-            "\"github:foo/clan-core-utils\"",
-            "clan-core"
-        ));
-
-        // Negative test: parent name matches but not followed by /
-        assert!(!is_follows_reference_to_parent(
-            "\"clan-core-extended\"",
-            "clan-core"
-        ));
-
-        // Edge case: empty URL
-        assert!(!is_follows_reference_to_parent("", "clan-core"));
-
-        // Edge case: just quotes
-        assert!(!is_follows_reference_to_parent("\"\"", "clan-core"));
-    }
-
-    #[test]
-    fn test_strip_attr_quotes() {
-        assert_eq!(strip_attr_quotes("\"nixpkgs\""), "nixpkgs");
-        assert_eq!(strip_attr_quotes("nixpkgs"), "nixpkgs");
-        assert_eq!(strip_attr_quotes("\"hls-1.10\""), "hls-1.10");
-        assert_eq!(strip_attr_quotes(""), "");
-    }
-
-    #[test]
-    fn test_normalize_nested_path() {
-        // Unquoted segments stay unquoted
-        assert_eq!(normalize_nested_path("crane.nixpkgs"), "crane.nixpkgs");
-
-        // Unnecessarily quoted segments get stripped
-        assert_eq!(
-            normalize_nested_path("\"home-manager\".nixpkgs"),
-            "home-manager.nixpkgs"
-        );
-        assert_eq!(
-            normalize_nested_path("\"home-manager\".\"nixpkgs\""),
-            "home-manager.nixpkgs"
-        );
-
-        // Segments with dots stay quoted
-        assert_eq!(
-            normalize_nested_path("\"hls-1.10\".nixpkgs"),
-            "\"hls-1.10\".nixpkgs"
-        );
-    }
-
-    #[test]
-    fn test_collect_stale_follows_quoted_attrs() {
-        use crate::input::Input;
-
-        // Simulate: flake.nix has `"home-manager".inputs.nixpkgs.follows = "nixpkgs"`
-        // Lock file reports the nested path as `home-manager.nixpkgs`.
+        // `"home-manager".inputs.nixpkgs.follows = "nixpkgs"` must resolve to
+        // a typed-AttrPath edge sourced at `home-manager.nixpkgs`, not at the
+        // quoted form.
         let mut inputs = InputMap::new();
-        let mut hm_input = Input::new("\"home-manager\"".to_string());
-        hm_input.follows.push(Follows::Indirect(
-            "nixpkgs".to_string(),
-            "nixpkgs".to_string(),
-        ));
-        inputs.insert("\"home-manager\"".to_string(), hm_input);
+        let hm_seg = Segment::from_unquoted("home-manager").unwrap();
+        let mut hm_input = Input::new(hm_seg.clone());
+        hm_input.follows.push(Follows::Indirect {
+            path: AttrPath::new(Segment::from_unquoted("nixpkgs").unwrap()),
+            target: Some(AttrPath::parse("nixpkgs").unwrap()),
+        });
+        inputs.insert("home-manager".to_string(), hm_input);
 
-        // Lock file paths (no unnecessary quotes)
-        let existing: HashSet<String> = ["home-manager.nixpkgs".to_string()].into_iter().collect();
-
-        let stale = collect_stale_follows(&inputs, &existing);
-        assert!(
-            stale.is_empty(),
-            "Expected no stale follows, but got: {:?}",
-            stale
-        );
+        let graph = FollowsGraph::from_declared(&inputs);
+        let sources: HashSet<AttrPath> = graph.edges().map(|e| e.source.clone()).collect();
+        assert!(sources.contains(&AttrPath::parse("home-manager.nixpkgs").unwrap()));
     }
 }

--- a/src/app/follow.rs
+++ b/src/app/follow.rs
@@ -1,0 +1,74 @@
+//! Implementations of `flake-edit follow` and `flake-edit add-follow`.
+//!
+//! - [`add_follow`] is the single-shot explicit-path command, fronting both
+//!   the scripted `<input> <target>` form and the interactive TUI flow.
+//! - [`auto`] is the auto-deduplication subsystem: planner, applier, and
+//!   batch driver for `flake-edit follow [PATHS...]`.
+//!
+//! Both share `FollowContext` plumbing in [`super::commands`].
+
+pub mod auto;
+
+use crate::change::{Change, ChangeId};
+use crate::edit::FlakeEdit;
+use crate::error::FlakeEditError;
+use crate::follows::AttrPath;
+use crate::tui;
+
+use super::commands::{self, CommandError, Result};
+use super::editor::Editor;
+use super::state::AppState;
+
+/// Manually add a single follows declaration.
+pub fn add_follow(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    input: Option<String>,
+    target: Option<String>,
+) -> Result<()> {
+    let change = if let (Some(input_val), Some(target_val)) = (input.clone(), target) {
+        let input_id = ChangeId::parse(&input_val).map_err(|e| {
+            CommandError::InvalidUri(format!("invalid follows path `{input_val}`: {e}"))
+        })?;
+        let target_path = AttrPath::parse(&target_val).map_err(|e| {
+            CommandError::InvalidUri(format!("invalid follows target `{target_val}`: {e}"))
+        })?;
+        // Reject paths deeper than 2 segments so a typo can't sneak through.
+        // [`auto::run`] bypasses this guard via direct `apply_change` calls
+        // and is gated by `config.follow.max_depth` instead.
+        let segments = input_id.path().len();
+        if segments > 2 {
+            return Err(CommandError::FlakeEdit(
+                FlakeEditError::AddFollowDepthLimit {
+                    path: input_id.to_string(),
+                    segments,
+                },
+            ));
+        }
+        Change::Follows {
+            input: input_id,
+            target: target_path,
+        }
+    } else if state.interactive {
+        let Some(ctx) = commands::load_follow_context(flake_edit, state)? else {
+            return Ok(());
+        };
+        let top_level_vec: Vec<String> = ctx.top_level_inputs.into_iter().collect();
+
+        let tui_app = if let Some(input_val) = input {
+            tui::App::follow_target("Follow", editor.text(), input_val, top_level_vec)
+        } else {
+            tui::App::follow("Follow", editor.text(), ctx.nested_inputs, top_level_vec)
+        };
+
+        let Some(tui::AppResult::Change(tui_change)) = tui::run(tui_app)? else {
+            return Ok(());
+        };
+        tui_change
+    } else {
+        return Err(CommandError::NoId);
+    };
+
+    commands::apply_change(editor, flake_edit, state, change)
+}

--- a/src/app/follow/auto.rs
+++ b/src/app/follow/auto.rs
@@ -1,0 +1,1149 @@
+//! Auto-deduplication of nested follows.
+//!
+//! Three structs thread through the pipeline:
+//!
+//! - `AnalysisCtx`: read-only inputs (graph, config, bounds).
+//! - `FollowPlan`: mutable accumulator threaded through collection.
+//! - `AppliedPlan`: outcomes of the apply step, consumed by `render_summary`.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::change::{Change, ChangeId};
+use crate::config::FollowConfig;
+use crate::edit::FlakeEdit;
+use crate::follows::{
+    AttrPath, Edge, EdgeOrigin, FollowsGraph, Segment, is_follows_reference_to_parent,
+};
+use crate::input::Range;
+use crate::lock::{FlakeLock, NestedInput};
+use crate::validate;
+
+use super::super::commands::{self, CommandError, Result};
+use super::super::editor::Editor;
+use super::super::state::AppState;
+
+/// Entry point for `flake-edit follow` on a single in-memory flake.
+pub fn run(editor: &Editor, flake_edit: &mut FlakeEdit, state: &AppState) -> Result<()> {
+    run_impl(editor, flake_edit, state, false)
+}
+
+/// Entry point for batch mode (`flake-edit follow [PATHS...]`).
+///
+/// Each file is processed independently with its own [`Editor`] and
+/// [`AppState`]; processing continues past per-file failures. Any
+/// failures are bundled into a single [`CommandError::Batch`].
+pub fn run_batch(
+    paths: &[std::path::PathBuf],
+    transitive: Option<usize>,
+    depth: Option<usize>,
+    args: &crate::cli::CliArgs,
+) -> Result<()> {
+    use std::path::PathBuf;
+
+    let mut errors: Vec<(PathBuf, CommandError)> = Vec::new();
+
+    for flake_path in paths {
+        let lock_path = flake_path
+            .parent()
+            .map(|p| p.join("flake.lock"))
+            .unwrap_or_else(|| PathBuf::from("flake.lock"));
+
+        let editor = match Editor::from_path(flake_path.clone()) {
+            Ok(e) => e,
+            Err(e) => {
+                errors.push((flake_path.clone(), e.into()));
+                continue;
+            }
+        };
+
+        let mut flake_edit = match editor.create_flake_edit() {
+            Ok(fe) => fe,
+            Err(e) => {
+                errors.push((flake_path.clone(), e.into()));
+                continue;
+            }
+        };
+
+        let mut state = match AppState::new(
+            editor.text(),
+            flake_path.clone(),
+            args.config().map(PathBuf::from),
+        ) {
+            Ok(s) => s
+                .with_diff(args.diff())
+                .with_no_lock(args.no_lock())
+                .with_interactive(false)
+                .with_lock_file(Some(lock_path))
+                .with_no_cache(args.no_cache())
+                .with_cache_path(args.cache().map(PathBuf::from)),
+            Err(e) => {
+                errors.push((flake_path.clone(), e.into()));
+                continue;
+            }
+        };
+
+        if let Some(min) = transitive {
+            state.config.follow.transitive_min = min;
+        }
+        if let Some(max) = depth {
+            state.config.follow.max_depth = max;
+        }
+
+        if let Err(e) = run_impl(&editor, &mut flake_edit, &state, true) {
+            errors.push((flake_path.clone(), e));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CommandError::Batch { failures: errors })
+    }
+}
+
+/// Inputs threaded through analysis.
+///
+/// `top_level_inputs` is owned because [`run_impl`] extends it with names
+/// minted by [`emit_direct_promotions`] before the later passes consult it
+/// (see the pass ordering in [`run_impl`]). The other fields are derived
+/// once from the on-disk text and the lockfile and stay put.
+struct AnalysisCtx<'a> {
+    nested_inputs: &'a [NestedInput],
+    /// Top-level input names. Initialized from the parsed `flake.nix` and
+    /// extended in-place between [`emit_direct_promotions`] and the
+    /// passes that read it ([`collect_transitive_groups`] and
+    /// [`collect_direct_candidates`]).
+    top_level_inputs: HashSet<String>,
+    /// Full input map. Cycle detection needs URLs.
+    inputs: &'a crate::edit::InputMap,
+    /// Lock-augmented graph: union of edges declared in `flake.nix` and edges
+    /// the lockfile resolved. Used for cycle detection and stale-edge queries
+    /// that need the fully-resolved view.
+    graph: &'a FollowsGraph,
+    /// Edges already written in the `flake.nix` source. Distinct from `graph`
+    /// because a follows existing only in the lockfile (declared by an
+    /// upstream flake) is still a candidate to write into the user's
+    /// `flake.nix`.
+    existing_follows: &'a HashSet<AttrPath>,
+    follow_config: &'a FollowConfig,
+    /// Maximum depth of follows declarations to write. `1` (default) writes
+    /// depth-1 only. `2` or higher also writes grandchild and deeper.
+    max_depth: usize,
+    transitive_min: usize,
+}
+
+/// Mutable plan accumulated across the collection functions.
+///
+/// The four output buckets (`to_follow`, `to_unfollow`, `toplevel_follows`,
+/// `toplevel_adds`) feed [`apply_plan`]. `seen_nested` is a dedup guard
+/// threaded through [`collect_direct_candidates`],
+/// [`collect_transitive_groups`], [`collect_direct_groups`],
+/// [`emit_direct_promotions`], and [`emit_transitive_promotions`] to prevent
+/// scheduling the same nested path twice
+/// when both a direct-name match and a transitive group claim it.
+/// It is dedup state, not applied output, so [`FollowPlan::has_pending`]
+/// excludes it.
+#[derive(Default)]
+struct FollowPlan {
+    to_follow: Vec<(AttrPath, AttrPath)>,
+    to_unfollow: Vec<AttrPath>,
+    toplevel_follows: Vec<(AttrPath, AttrPath)>,
+    toplevel_adds: Vec<(String, String)>,
+    seen_nested: HashSet<AttrPath>,
+}
+
+impl FollowPlan {
+    /// True if at least one applicable change was scheduled. `seen_nested`
+    /// is dedup state, not pending output, so it is excluded.
+    fn has_pending(&self) -> bool {
+        !self.to_follow.is_empty()
+            || !self.to_unfollow.is_empty()
+            || !self.toplevel_follows.is_empty()
+            || !self.toplevel_adds.is_empty()
+    }
+}
+
+/// What [`apply_plan`] committed to the working text.
+#[derive(Default)]
+struct AppliedPlan {
+    /// Working text after every successful change. Equal to the original
+    /// when no per-step change applied.
+    current_text: String,
+    /// `(source_path, target)` follows that were successfully applied,
+    /// for the success summary.
+    applied_follows: Vec<(AttrPath, AttrPath)>,
+    /// Stale follows declarations that were removed.
+    unfollowed: Vec<AttrPath>,
+    /// Validation warnings observed across speculative applications, in
+    /// arrival order. The caller deduplicates for display.
+    warnings: Vec<validate::ValidationError>,
+}
+
+fn run_impl(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    quiet: bool,
+) -> Result<()> {
+    let Some(ctx) = commands::load_follow_context(flake_edit, state)? else {
+        if !quiet {
+            println!("Nothing to deduplicate.");
+        }
+        return Ok(());
+    };
+
+    // Two graphs serve two questions. `graph` (lock-augmented) answers
+    // "would proposing edge X create a cycle, and which existing edges are
+    // stale?". That needs the full resolved view. `existing_follows`
+    // (declared-only) answers "is this nested input already followed in
+    // flake.nix?". Emission must not be suppressed for an edge that the
+    // lock resolved but the source never declared.
+    let graph = match commands::load_flake_lock(state) {
+        Ok(lock) => FollowsGraph::from_flake(&ctx.inputs, &lock),
+        Err(_) => FollowsGraph::from_declared(&ctx.inputs),
+    };
+
+    // Filter the merged graph by `EdgeOrigin::Declared` rather than rebuilding
+    // a separate declared-only graph. The declared subset is already in
+    // `graph`. Use [`FollowsGraph::declared_sources`] (not
+    // [`FollowsGraph::declared_edges`]) so nulled `follows = ""`
+    // declarations also count as already-handled and the
+    // auto-deduplicator does not silently retarget them.
+    let existing_follows: HashSet<AttrPath> = graph.declared_sources();
+
+    let follow_config = &state.config.follow;
+    let transitive_min = follow_config.transitive_min();
+    let max_depth = follow_config.max_depth.max(1);
+
+    // `to_unfollow` carries two removal classes: stale declared edges
+    // (source absent from the lockfile) and depth-N edges that the
+    // lockfile already routes via upstream propagation. The
+    // [`FollowsGraph::lock_routes_to`] call passes `Some(edge)` so the
+    // edge under test is excluded; without that the user's own
+    // declaration counts as the route and every declared edge would
+    // qualify.
+    //
+    // Seeding runs against the original `graph`: the post-removal clone
+    // built below would chicken-and-egg this loop.
+    let mut to_unfollow: Vec<AttrPath> = graph
+        .stale_edges()
+        .into_iter()
+        .map(|e| e.source.clone())
+        .collect();
+    // Nulled twin of [`FollowsGraph::stale_edges`]: target-less follows
+    // skip [`FollowsGraph::declared_edges`], so seed them separately.
+    to_unfollow.extend(graph.stale_nulled_sources().into_iter().cloned());
+    let stale_set: HashSet<AttrPath> = to_unfollow.iter().cloned().collect();
+    for edge in graph.declared_edges() {
+        if stale_set.contains(&edge.source) {
+            continue;
+        }
+        // Depth-1 has no upstream parent to propagate from.
+        if edge.source.len() < 3 {
+            continue;
+        }
+        if edge.source.len() > max_depth + 1 {
+            continue;
+        }
+        if graph.lock_routes_to(&edge.source, &edge.follows, Some(edge), &[]) {
+            tracing::debug!(
+                "Marking redundant follow for removal: {} -> {} (covered by upstream propagation)",
+                edge.source,
+                edge.follows,
+            );
+            to_unfollow.push(edge.source.clone());
+        }
+    }
+    to_unfollow.sort();
+    to_unfollow.dedup();
+
+    // Discovery must see the post-removal graph. Without this, an edge
+    // marked for removal still shapes the cycle and routing checks
+    // below and can suppress a candidate the apply phase would
+    // otherwise unblock, forcing a second `flake-edit follow`
+    // invocation to converge. The clone is a discovery-only artifact:
+    // the apply phase still runs `Change::Remove` against the
+    // unmodified `editor.text()`.
+    let mut graph_for_discovery = graph.clone();
+    graph_for_discovery.drop_edges_with_sources(&to_unfollow);
+
+    let mut ax = AnalysisCtx {
+        nested_inputs: &ctx.nested_inputs,
+        top_level_inputs: ctx.top_level_inputs.clone(),
+        inputs: &ctx.inputs,
+        graph: &graph_for_discovery,
+        existing_follows: &existing_follows,
+        follow_config,
+        max_depth,
+        transitive_min,
+    };
+
+    let mut plan = FollowPlan {
+        to_unfollow,
+        ..FollowPlan::default()
+    };
+
+    // Run the minter (`emit_direct_promotions`) first and extend
+    // `ax.top_level_inputs` with its new names before the readers
+    // (`emit_transitive_promotions`, `collect_direct_candidates`) consult
+    // it. Otherwise the readers would need a second pipeline iteration to
+    // see the minted names.
+    if transitive_min > 0 {
+        let direct_groups = collect_direct_groups(&ax, &plan);
+        emit_direct_promotions(&ax, editor, direct_groups, &mut plan);
+
+        for (name, _) in &plan.toplevel_adds {
+            ax.top_level_inputs.insert(name.clone());
+        }
+
+        let transitive_groups = collect_transitive_groups(&ax, &plan);
+        emit_transitive_promotions(&ax, transitive_groups, &mut plan);
+    }
+
+    collect_direct_candidates(&ax, &mut plan);
+
+    scrub_redundant(&graph_for_discovery, &mut plan);
+
+    if !plan.has_pending() {
+        if !quiet {
+            println!("All inputs are already deduplicated.");
+        }
+        return Ok(());
+    }
+
+    let applied = apply_plan(editor, state, &ctx.inputs, &plan)?;
+    render_summary(editor, state, &applied, quiet)
+}
+
+/// Depth-bounded path-shape filter shared by every collection function.
+///
+/// Path length encodes depth: `parent.nested` is depth 1 (length 2),
+/// `parent.middle.grandchild` is depth 2 (length 3). The bound
+/// `len() <= max_depth + 1` admits exactly the configured depth.
+fn within_depth(path: &AttrPath, max_depth: usize) -> bool {
+    path.len() >= 2 && path.len() <= max_depth + 1
+}
+
+/// True when an ancestor of `nested_path` already declares a follows
+/// that contradicts the proposed `target`. An ancestor here is a path
+/// formed by truncating one or more middle segments while preserving
+/// the leading parent and the trailing name.
+///
+/// "Contradicts" means: the ancestor declares a different follows
+/// target, or the ancestor declares `follows = ""` (nulled). In either
+/// case the user has explicitly chosen a value for that subtree's
+/// mapping of the trailing name, and a deeper proposal pointing
+/// somewhere else would silently override that choice.
+///
+/// Ancestor declarations pointing at the same `target` do not count:
+/// they reinforce, rather than override, the deeper proposal, so the
+/// auto-deduplicator should still be free to emit the deeper edge.
+///
+/// For `[parent, mid1, ..., name]` of length `n >= 3`, checks every
+/// candidate `[parent, mid1, ..., midk, name]` of length `2..n - 1`.
+fn ancestor_overrides_subtree(
+    nested_path: &AttrPath,
+    target: &AttrPath,
+    graph: &FollowsGraph,
+) -> bool {
+    if nested_path.len() < 3 {
+        return false;
+    }
+    let segs = nested_path.segments();
+    let last = nested_path.last();
+    let nulled = graph.declared_nulled();
+    for prefix_len in 1..nested_path.len() - 1 {
+        let mut candidate = AttrPath::new(segs[0].clone());
+        for seg in &segs[1..prefix_len] {
+            candidate.push(seg.clone());
+        }
+        candidate.push(last.clone());
+        if nulled.contains(&candidate) {
+            return true;
+        }
+        for edge in graph.outgoing(&candidate) {
+            if !matches!(edge.origin, EdgeOrigin::Declared { .. }) {
+                continue;
+            }
+            if &edge.follows != target {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn collect_direct_candidates(ax: &AnalysisCtx<'_>, plan: &mut FollowPlan) {
+    // Shallowest-first: depth-1 emissions must land in `plan.to_follow`
+    // before depth-N candidates consult `extra_edges` below.
+    let mut iter: Vec<&NestedInput> = ax.nested_inputs.iter().collect();
+    iter.sort_by(|a, b| {
+        a.path
+            .len()
+            .cmp(&b.path.len())
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    for nested in iter {
+        if !within_depth(&nested.path, ax.max_depth) {
+            continue;
+        }
+        let parent = nested.path.first().as_str();
+        let nested_name = nested.path.last().as_str();
+        let path_display = nested.path.to_string();
+
+        if ax.follow_config.is_ignored(&path_display, nested_name) {
+            tracing::debug!("Skipping {}: ignored by config", path_display);
+            continue;
+        }
+
+        if ax.existing_follows.contains(&nested.path) {
+            tracing::debug!("Skipping {}: already follows in flake.nix", path_display);
+            continue;
+        }
+
+        let Some(target) = ax
+            .top_level_inputs
+            .iter()
+            .find(|top| ax.follow_config.can_follow(nested_name, top))
+        else {
+            continue;
+        };
+
+        if let Some(target_input) = ax.inputs.get(target.as_str())
+            && is_follows_reference_to_parent(target_input.url(), parent)
+        {
+            tracing::debug!(
+                "Skipping {} -> {}: would create cycle (target follows {}/...)",
+                path_display,
+                target,
+                parent,
+            );
+            continue;
+        }
+
+        // Top-level input names parse as a single-segment attr path. A
+        // failure here would mean an invalid Nix identifier slipped in, so
+        // skip rather than queue something the apply step would discard.
+        let target_path = match AttrPath::parse(target) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("Skipping {path_display} -> {target}: invalid attr path: {e}");
+                continue;
+            }
+        };
+
+        if ancestor_overrides_subtree(&nested.path, &target_path, ax.graph) {
+            tracing::debug!(
+                "Skipping {} -> {}: ancestor declares a different follows for the same trailing name",
+                path_display,
+                target,
+            );
+            continue;
+        }
+
+        // Multi-hop / lockfile-only cycle detection. The URL-prefix check
+        // above catches only the immediate-parent case. The merged graph
+        // DFS catches the rest.
+        let proposed = Edge {
+            source: nested.path.clone(),
+            follows: target_path.clone(),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        };
+        if ax.graph.would_create_cycle(&proposed) {
+            tracing::debug!(
+                "Skipping {} -> {}: would create cycle (multi-hop or lockfile-resolved)",
+                path_display,
+                target,
+            );
+            continue;
+        }
+        // Same-run depth-1 emissions can close a depth-N chain.
+        let extra_edges: Vec<(AttrPath, AttrPath)> = if nested.path.len() >= 3 {
+            plan.to_follow
+                .iter()
+                .map(|(src, tgt)| (src.clone(), tgt.clone()))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        if ax
+            .graph
+            .lock_routes_to(&nested.path, &target_path, None, &extra_edges)
+        {
+            tracing::debug!(
+                "Skipping {} -> {}: lockfile already routes via upstream propagation",
+                path_display,
+                target,
+            );
+            continue;
+        }
+
+        plan.seen_nested.insert(nested.path.clone());
+        plan.to_follow.push((nested.path.clone(), target_path));
+    }
+}
+
+fn collect_transitive_groups(
+    ax: &AnalysisCtx<'_>,
+    plan: &FollowPlan,
+) -> HashMap<String, HashMap<AttrPath, Vec<AttrPath>>> {
+    let mut groups: HashMap<String, HashMap<AttrPath, Vec<AttrPath>>> = HashMap::new();
+
+    for nested in ax.nested_inputs.iter() {
+        if !within_depth(&nested.path, ax.max_depth) {
+            continue;
+        }
+        let nested_name = nested.path.last().as_str();
+        let parent = nested.path.first().as_str();
+        let path_display = nested.path.to_string();
+
+        if ax.follow_config.is_ignored(&path_display, nested_name) {
+            continue;
+        }
+        if ax.existing_follows.contains(&nested.path) || plan.seen_nested.contains(&nested.path) {
+            continue;
+        }
+        // Handled by [`collect_direct_candidates`].
+        if ax
+            .top_level_inputs
+            .iter()
+            .any(|top| ax.follow_config.can_follow(nested_name, top))
+        {
+            continue;
+        }
+
+        let Some(transitive_target) = nested.follows.as_ref() else {
+            continue;
+        };
+        if ancestor_overrides_subtree(&nested.path, transitive_target, ax.graph) {
+            continue;
+        }
+        // Only transitive follows (path with a parent segment).
+        if transitive_target.len() < 2 {
+            continue;
+        }
+        // Skip self-follow.
+        if transitive_target.last().as_str() == nested_name {
+            continue;
+        }
+
+        let top_level_name = ax
+            .follow_config
+            .resolve_alias(nested_name)
+            .unwrap_or(nested_name)
+            .to_string();
+        if ax.top_level_inputs.contains(&top_level_name) {
+            continue;
+        }
+
+        if let Some(target_input) = ax.inputs.get(transitive_target.first().as_str())
+            && is_follows_reference_to_parent(target_input.url(), parent)
+        {
+            continue;
+        }
+
+        // Multi-hop / lockfile-only cycle detection, mirroring the
+        // direct-candidate filter applied to transitive promotions.
+        let proposed = Edge {
+            source: nested.path.clone(),
+            follows: transitive_target.clone(),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        };
+        if ax.graph.would_create_cycle(&proposed) {
+            continue;
+        }
+
+        groups
+            .entry(top_level_name)
+            .or_default()
+            .entry(transitive_target.clone())
+            .or_default()
+            .push(nested.path.clone());
+    }
+
+    groups
+}
+
+/// When several parents share the same dependency (e.g. `treefmt.nixpkgs`
+/// and `treefmt-nix.nixpkgs`), one can be promoted to top-level and the
+/// others follow it.
+fn collect_direct_groups(
+    ax: &AnalysisCtx<'_>,
+    plan: &FollowPlan,
+) -> HashMap<String, Vec<(AttrPath, Option<String>)>> {
+    let mut groups: HashMap<String, Vec<(AttrPath, Option<String>)>> = HashMap::new();
+
+    for nested in ax.nested_inputs.iter() {
+        if !within_depth(&nested.path, ax.max_depth) {
+            continue;
+        }
+        if nested.follows.is_some() {
+            continue;
+        }
+        let nested_name = nested.path.last().as_str();
+        let path_display = nested.path.to_string();
+
+        if ax.follow_config.is_ignored(&path_display, nested_name) {
+            continue;
+        }
+        if ax.existing_follows.contains(&nested.path) || plan.seen_nested.contains(&nested.path) {
+            continue;
+        }
+        if ax
+            .top_level_inputs
+            .iter()
+            .any(|top| ax.follow_config.can_follow(nested_name, top))
+        {
+            continue;
+        }
+
+        let canonical_name = ax
+            .follow_config
+            .resolve_alias(nested_name)
+            .unwrap_or(nested_name)
+            .to_string();
+        if ax.top_level_inputs.contains(&canonical_name) {
+            continue;
+        }
+
+        groups
+            .entry(canonical_name)
+            .or_default()
+            .push((nested.path.clone(), nested.url.clone()));
+    }
+
+    groups
+}
+
+/// Turn transitive groups into top-level follows and back-fill
+/// `plan.to_follow` with the per-nested follows hanging off them.
+///
+/// Must run after [`emit_direct_promotions`] so the top-level names it
+/// minted are visible in `ax.top_level_inputs`.
+fn emit_transitive_promotions(
+    ax: &AnalysisCtx<'_>,
+    transitive_groups: HashMap<String, HashMap<AttrPath, Vec<AttrPath>>>,
+    plan: &mut FollowPlan,
+) {
+    for (top_name, targets) in transitive_groups {
+        let mut eligible: Vec<(AttrPath, Vec<AttrPath>)> = targets
+            .into_iter()
+            .filter(|(_, paths)| paths.len() >= ax.transitive_min)
+            .collect();
+
+        if eligible.len() != 1 {
+            continue;
+        }
+
+        let (target_path, paths) = eligible.pop().unwrap();
+        let follow_target_str = target_path.to_flake_follows_string();
+
+        if follow_target_str == top_name {
+            continue;
+        }
+
+        let top_seg = match Segment::from_unquoted(top_name.clone()) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping toplevel follow promotion for `{top_name}`: invalid segment: {e}"
+                );
+                continue;
+            }
+        };
+        // `to_flake_follows_string` produces a `/`-joined target like
+        // `a/b`. Pack it into a single segment so `AttrPath::Display`
+        // emits it as the quoted form `"a/b"` rather than splitting on
+        // the slash as if it were a dotted path.
+        let follow_target_seg = match Segment::from_unquoted(follow_target_str) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("Skipping toplevel follow promotion for `{top_name}`: {e}");
+                continue;
+            }
+        };
+        let follow_target_path = AttrPath::new(follow_target_seg);
+        plan.toplevel_follows
+            .push((AttrPath::new(top_seg.clone()), follow_target_path));
+
+        let top_path = AttrPath::new(top_seg);
+        for path in paths {
+            if plan.seen_nested.insert(path.clone()) {
+                plan.to_follow.push((path, top_path.clone()));
+            }
+        }
+    }
+}
+
+/// Turn direct-reference groups into new top-level adds and back-fill
+/// `plan.to_follow` with the per-nested follows hanging off them. Promote
+/// only if at least one follows can be applied (probed via a speculative
+/// `apply_change` against `editor.text()`).
+///
+/// Runs before [`emit_transitive_promotions`] and
+/// [`collect_direct_candidates`] so the names this function pushes into
+/// `plan.toplevel_adds` can be folded into `ax.top_level_inputs` before
+/// the later passes consult it.
+fn emit_direct_promotions(
+    ax: &AnalysisCtx<'_>,
+    editor: &Editor,
+    direct_groups: HashMap<String, Vec<(AttrPath, Option<String>)>>,
+    plan: &mut FollowPlan,
+) {
+    let mut direct_groups_sorted: Vec<_> = direct_groups.into_iter().collect();
+    direct_groups_sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    for (canonical_name, mut entries) in direct_groups_sorted {
+        if entries.len() < ax.transitive_min {
+            continue;
+        }
+
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+        let Some(url) = entries.iter().find_map(|(_, u)| u.clone()) else {
+            continue;
+        };
+
+        let target_attr = match AttrPath::parse(&canonical_name) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping direct-reference promotion for `{canonical_name}`: invalid attr path: {e}"
+                );
+                continue;
+            }
+        };
+
+        let can_follow = entries.iter().any(|(path, _)| {
+            let change = Change::Follows {
+                input: ChangeId::new(path.clone()),
+                target: target_attr.clone(),
+            };
+            FlakeEdit::from_text(&editor.text())
+                .ok()
+                .and_then(|mut fe| fe.apply_change(change).ok())
+                .and_then(|outcome| outcome.text)
+                .is_some()
+        });
+        if !can_follow {
+            continue;
+        }
+
+        plan.toplevel_adds.push((canonical_name.clone(), url));
+
+        // Skip entries whose ancestor is also in this group: the
+        // ancestor's follow already rewrites the descendant's prefix.
+        let entry_paths: HashSet<AttrPath> = entries.iter().map(|(p, _)| p.clone()).collect();
+        for (path, _) in &entries {
+            let mut covered_by_ancestor = false;
+            let mut anc = path.parent();
+            while let Some(a) = anc.clone() {
+                if entry_paths.contains(&a) {
+                    covered_by_ancestor = true;
+                    break;
+                }
+                anc = a.parent();
+            }
+            if covered_by_ancestor {
+                tracing::debug!(
+                    "Skipping promotion {} -> {}: ancestor in same group covers it",
+                    path,
+                    canonical_name,
+                );
+                plan.seen_nested.insert(path.clone());
+                continue;
+            }
+            if plan.seen_nested.insert(path.clone()) {
+                plan.to_follow.push((path.clone(), target_attr.clone()));
+            }
+        }
+    }
+}
+
+/// Drop entries from [`FollowPlan::to_follow`] whose chain is already
+/// covered by the rest of the plan plus the lockfile (passed to
+/// [`FollowsGraph::lock_routes_to`] as `extra_edges`).
+///
+/// Catches cross-entry overlaps that [`collect_direct_candidates`],
+/// [`emit_direct_promotions`], and [`emit_transitive_promotions`] cannot see
+/// from a single candidate's perspective.
+/// Idempotent: dropping entries only shrinks `extra_edges`, so a surviving
+/// entry stays surviving.
+fn scrub_redundant(graph: &FollowsGraph, plan: &mut FollowPlan) {
+    if plan.to_follow.is_empty() {
+        return;
+    }
+    let mut keep: Vec<bool> = vec![true; plan.to_follow.len()];
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for i in 0..plan.to_follow.len() {
+            if !keep[i] {
+                continue;
+            }
+            let (src_i, target_path) = (plan.to_follow[i].0.clone(), plan.to_follow[i].1.clone());
+            let extras: Vec<(AttrPath, AttrPath)> = (0..plan.to_follow.len())
+                .filter(|&j| j != i && keep[j])
+                .map(|j| (plan.to_follow[j].0.clone(), plan.to_follow[j].1.clone()))
+                .collect();
+            if graph.lock_routes_to(&src_i, &target_path, None, &extras) {
+                tracing::debug!(
+                    "Scrubbing {} -> {}: redundant given the rest of the plan",
+                    src_i,
+                    target_path,
+                );
+                keep[i] = false;
+                changed = true;
+            }
+        }
+    }
+    let mut keep_iter = keep.into_iter();
+    plan.to_follow.retain(|_| keep_iter.next().unwrap_or(true));
+}
+
+/// Apply each scheduled change against a working text buffer, validating
+/// between steps.
+///
+/// Lock-drift lints run once on the pre-batch text via
+/// [`validate::validate_full`]. Per-step validation uses
+/// [`validate::validate_speculative`], which skips them: mid-batch the
+/// in-memory text contains follows the on-disk lockfile has not seen yet,
+/// and re-running the lock-drift lints would flag every in-progress edit
+/// as drift.
+///
+/// The cycle lint runs every step against the post-change `temp.curr_list()`
+/// and catches any cycle introduced by the in-progress batch, skipping the
+/// offending change.
+fn apply_plan(
+    editor: &Editor,
+    state: &AppState,
+    inputs: &crate::edit::InputMap,
+    plan: &FollowPlan,
+) -> Result<AppliedPlan> {
+    let mut current_text = editor.text();
+    let batch_lock: Option<FlakeLock> = commands::load_flake_lock(state).ok();
+    let mut warnings: Vec<validate::ValidationError> = Vec::new();
+
+    // Lock-drift lints fire only on the pre-batch text. Mid-batch they would
+    // flag every in-progress edit as drift against the on-disk lockfile.
+    let pre_validation = validate::validate_full(&current_text, inputs, batch_lock.as_ref());
+    warnings.extend(pre_validation.warnings);
+
+    // Top-level adds must precede follows that name them.
+    for (id, url) in &plan.toplevel_adds {
+        let change = Change::Add {
+            id: Some(id.clone()),
+            uri: Some(url.clone()),
+            flake: true,
+        };
+
+        let mut temp = FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
+        match temp.apply_change(change) {
+            Ok(outcome) => match outcome.text {
+                Some(resulting_text) => {
+                    let validation = validate::validate_speculative(
+                        &resulting_text,
+                        temp.curr_list(),
+                        batch_lock.as_ref(),
+                    );
+                    if validation.is_ok() {
+                        warnings.extend(validation.warnings);
+                        current_text = resulting_text;
+                    } else {
+                        for err in validation.errors {
+                            eprintln!("Error adding top-level input {}: {}", id, err);
+                        }
+                    }
+                }
+                None => eprintln!("Could not add top-level input {}", id),
+            },
+            Err(e) => eprintln!("Error adding top-level input {}: {}", id, e),
+        }
+    }
+
+    let mut follow_changes: Vec<(AttrPath, AttrPath)> = plan.toplevel_follows.clone();
+    follow_changes.extend(plan.to_follow.iter().cloned());
+
+    let mut applied_follows: Vec<(AttrPath, AttrPath)> = Vec::new();
+
+    for (input_path, target) in &follow_changes {
+        let change = Change::Follows {
+            input: ChangeId::new(input_path.clone()),
+            target: target.clone(),
+        };
+
+        let mut temp = FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
+        match temp.apply_change(change) {
+            Ok(outcome) => match outcome.text {
+                Some(resulting_text) => {
+                    if resulting_text == current_text {
+                        continue;
+                    }
+                    let validation = validate::validate_speculative(
+                        &resulting_text,
+                        temp.curr_list(),
+                        batch_lock.as_ref(),
+                    );
+                    if validation.is_ok() {
+                        warnings.extend(validation.warnings);
+                        current_text = resulting_text;
+                        applied_follows.push((input_path.clone(), target.clone()));
+                    } else {
+                        for err in validation.errors {
+                            eprintln!("{}", format_apply_error(input_path, &err));
+                        }
+                    }
+                }
+                None => eprintln!("Could not create follows for {}", input_path),
+            },
+            Err(e) => eprintln!("Error applying follows for {}: {}", input_path, e),
+        }
+    }
+
+    let mut unfollowed: Vec<AttrPath> = Vec::new();
+
+    for nested_path in &plan.to_unfollow {
+        let change = Change::Remove {
+            ids: vec![ChangeId::new(nested_path.clone())],
+        };
+
+        let mut temp = FlakeEdit::from_text(&current_text).map_err(CommandError::FlakeEdit)?;
+        match temp.apply_change(change) {
+            Ok(outcome) => {
+                if let Some(resulting_text) = outcome.text {
+                    let validation = validate::validate_speculative(
+                        &resulting_text,
+                        temp.curr_list(),
+                        batch_lock.as_ref(),
+                    );
+                    if validation.is_ok() {
+                        warnings.extend(validation.warnings);
+                        current_text = resulting_text;
+                        unfollowed.push(nested_path.clone());
+                    }
+                }
+            }
+            Err(e) => eprintln!("Error removing stale follows for {}: {}", nested_path, e),
+        }
+    }
+
+    Ok(AppliedPlan {
+        current_text,
+        applied_follows,
+        unfollowed,
+        warnings,
+    })
+}
+
+fn render_summary(
+    editor: &Editor,
+    state: &AppState,
+    applied: &AppliedPlan,
+    quiet: bool,
+) -> Result<()> {
+    if !applied.warnings.is_empty() && !quiet {
+        let mut seen: HashSet<String> = HashSet::new();
+        for warning in &applied.warnings {
+            if seen.insert(warning_dedup_key(warning)) {
+                eprintln!("warning: {}", warning);
+            }
+        }
+    }
+
+    if applied.applied_follows.is_empty() && applied.unfollowed.is_empty() {
+        return Ok(());
+    }
+
+    if state.diff {
+        let original = editor.text();
+        let diff = crate::diff::Diff::new(&original, &applied.current_text);
+        diff.compare();
+        return Ok(());
+    }
+
+    editor.apply_or_diff(&applied.current_text, state)?;
+
+    if quiet {
+        return Ok(());
+    }
+
+    if !applied.applied_follows.is_empty() {
+        println!(
+            "Deduplicated {} {}.",
+            applied.applied_follows.len(),
+            if applied.applied_follows.len() == 1 {
+                "input"
+            } else {
+                "inputs"
+            }
+        );
+        for (input_path, target) in &applied.applied_follows {
+            println!("  {} → {}", input_path, target);
+        }
+    }
+
+    if !applied.unfollowed.is_empty() {
+        println!(
+            "Removed {} stale follows {}.",
+            applied.unfollowed.len(),
+            if applied.unfollowed.len() == 1 {
+                "declaration"
+            } else {
+                "declarations"
+            }
+        );
+        for path in &applied.unfollowed {
+            println!("  {} (input no longer exists)", path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Source path of the malformed declaration named by `err`, or `None`
+/// for variants that carry no source (parse errors, duplicate attributes).
+fn offending_source(err: &validate::ValidationError) -> Option<&AttrPath> {
+    use validate::ValidationError as V;
+    match err {
+        V::FollowsTargetNotToplevel { edge, .. }
+        | V::FollowsStale { edge, .. }
+        | V::FollowsDepthExceeded { edge, .. } => Some(&edge.source),
+        V::FollowsContradiction { edges, .. } => edges.first().map(|e| &e.source),
+        V::FollowsCycle { cycle, .. } => cycle.edges.first().map(|e| &e.source),
+        V::FollowsStaleLock { source, .. } => Some(source),
+        V::ParseError { .. } | V::DuplicateAttribute(_) => None,
+    }
+}
+
+/// Format a per-step speculative validation error for stderr.
+///
+/// `validate_speculative` lints the whole graph, so a pre-existing
+/// malformed edge surfaces in every iteration of the apply loop. When the
+/// error names a source path other than `applying`, blame the malformed
+/// edge's owner so the message points at the actual offender.
+fn format_apply_error(applying: &AttrPath, err: &validate::ValidationError) -> String {
+    match offending_source(err) {
+        Some(source) if source != applying => {
+            format!(
+                "Malformed follows declaration in {}: {}",
+                source.first(),
+                err
+            )
+        }
+        _ => format!("Error applying follows for {}: {}", applying, err),
+    }
+}
+
+/// Stable identity for a follows-related warning, ignoring source-text
+/// location. Two warnings with the same lint kind and key fields collapse
+/// to one in the auto-follow output even if their reported lines differ
+/// across iterations of [`validate::validate_full`].
+fn warning_dedup_key(err: &validate::ValidationError) -> String {
+    use validate::ValidationError as V;
+    match err {
+        V::FollowsStale { edge, .. } => format!("stale|{}|{}", edge.source, edge.follows),
+        V::FollowsStaleLock {
+            source,
+            declared_target,
+            lock_target,
+            ..
+        } => {
+            let lock = lock_target
+                .as_ref()
+                .map(|t| t.to_string())
+                .unwrap_or_default();
+            format!("stale-lock|{source}|{declared_target}|{lock}")
+        }
+        other => format!("other|{other}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::Range;
+    use crate::validate::Location;
+    use clap::Parser;
+
+    fn declared_edge(source: &str, follows: &str) -> Edge {
+        Edge {
+            source: AttrPath::parse(source).expect("source"),
+            follows: AttrPath::parse(follows).expect("follows"),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        }
+    }
+
+    fn loc() -> Location {
+        Location {
+            line: 60,
+            column: 13,
+        }
+    }
+
+    #[test]
+    fn malformed_edge_blames_its_owner_not_iteration_target() {
+        let applying = AttrPath::parse("browservice.flake-utils").unwrap();
+        let err = validate::ValidationError::FollowsTargetNotToplevel {
+            edge: declared_edge(
+                "mac-app-util.cl-nix-lite",
+                r#""github:verymucho/cl-nix-lite""#,
+            ),
+            location: loc(),
+        };
+
+        let message = format_apply_error(&applying, &err);
+
+        assert!(
+            !message.contains("browservice"),
+            "must not blame iteration target, got: {message}",
+        );
+        assert!(
+            message.contains("mac-app-util"),
+            "must name the malformed edge's owner, got: {message}",
+        );
+    }
+
+    #[test]
+    fn self_caused_error_keeps_apply_framing() {
+        let applying = AttrPath::parse("crane.nixpkgs").unwrap();
+        let err = validate::ValidationError::FollowsTargetNotToplevel {
+            edge: declared_edge("crane.nixpkgs", "missing"),
+            location: loc(),
+        };
+
+        let message = format_apply_error(&applying, &err);
+
+        assert!(
+            message.contains("Error applying follows for crane.nixpkgs"),
+            "self-caused error must keep apply framing, got: {message}",
+        );
+    }
+
+    #[test]
+    fn run_batch_surfaces_every_failure() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing_a = tmp.path().join("a/flake.nix");
+        let missing_b = tmp.path().join("b/flake.nix");
+        let paths = vec![missing_a.clone(), missing_b.clone()];
+        let args = crate::cli::CliArgs::parse_from(["flake-edit", "follow"]);
+
+        let err = run_batch(&paths, None, None, &args).expect_err("expected batch failure");
+        let CommandError::Batch { failures } = err else {
+            panic!("expected CommandError::Batch, got: {err:?}");
+        };
+
+        assert_eq!(
+            failures.len(),
+            2,
+            "every per-file failure must reach the caller, got: {failures:?}",
+        );
+        let collected: Vec<&std::path::PathBuf> = failures.iter().map(|(p, _)| p).collect();
+        assert!(collected.contains(&&missing_a));
+        assert!(collected.contains(&&missing_b));
+    }
+}

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -1,6 +1,8 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use serde::Serialize;
+
 use crate::cli::{CliArgs, Command, ListFormat};
 use crate::config::ConfigError;
 use crate::edit::{InputMap, sorted_input_ids};
@@ -9,7 +11,92 @@ use crate::tui;
 
 use super::commands::{self, CommandError};
 use super::editor::Editor;
+use super::follow;
 use super::state::AppState;
+
+/// JSON output for `flake-edit list --format json`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ListOutput {
+    pub inputs: BTreeMap<String, InputView>,
+    pub follows: Vec<FollowEdge>,
+}
+
+/// One entry in [`ListOutput::inputs`].
+///
+/// `id` and `url` are unquoted (the in-memory invariant). `flake` mirrors the
+/// `inputs.<id>.flake = false;` source-form attribute.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct InputView {
+    pub id: String,
+    pub url: String,
+    pub flake: bool,
+}
+
+/// One edge in [`ListOutput::follows`].
+///
+/// - `parent` is the top-level input the follows is *declared on*.
+/// - `nested` is the nested input being redirected.
+/// - `target` is the rendered [`crate::follows::AttrPath`] the nested input
+///   is redirected to.
+/// - `kind` distinguishes indirect (URL-less, follows another input) from
+///   direct (URL-bearing) declarations.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct FollowEdge {
+    pub parent: String,
+    pub nested: String,
+    pub target: String,
+    pub kind: FollowEdgeKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum FollowEdgeKind {
+    Indirect,
+    Direct,
+}
+
+impl From<&InputMap> for ListOutput {
+    fn from(inputs: &InputMap) -> Self {
+        let mut input_views: BTreeMap<String, InputView> = BTreeMap::new();
+        let mut follows: Vec<FollowEdge> = Vec::new();
+        for key in sorted_input_ids(inputs) {
+            let input = &inputs[key];
+            let parent_id = input.id().as_str().to_string();
+            input_views.insert(
+                key.clone(),
+                InputView {
+                    id: parent_id.clone(),
+                    url: input.url().to_string(),
+                    flake: input.flake,
+                },
+            );
+            for f in input.follows() {
+                match f {
+                    Follows::Indirect { path, target } => {
+                        follows.push(FollowEdge {
+                            parent: parent_id.clone(),
+                            nested: path.to_string(),
+                            target: target.as_ref().map(|t| t.to_string()).unwrap_or_default(),
+                            kind: FollowEdgeKind::Indirect,
+                        });
+                    }
+                    Follows::Direct(name, child) => {
+                        follows.push(FollowEdge {
+                            parent: parent_id.clone(),
+                            nested: name.clone(),
+                            target: child.url().to_string(),
+                            kind: FollowEdgeKind::Direct,
+                        });
+                    }
+                }
+            }
+        }
+        ListOutput {
+            inputs: input_views,
+            follows,
+        }
+    }
+}
 
 mod root;
 
@@ -36,22 +123,26 @@ pub enum HandlerError {
     IncompatibleFollowOptions,
 }
 
-/// Main entry point for the application.
+/// Application entry point.
 ///
 /// Parses CLI arguments, initializes state, and dispatches to command handlers.
 pub fn run(args: CliArgs) -> Result<()> {
-    // Handle batch mode for follow [paths...] early, before creating Editor/AppState
-    if let Command::Follow { paths, transitive } = args.subcommand()
+    // Batch `follow [PATHS...]` runs before creating Editor/AppState because
+    // it owns its own per-file Editor/AppState pairs.
+    if let Command::Follow {
+        paths,
+        transitive,
+        depth,
+    } = args.subcommand()
         && !paths.is_empty()
     {
         if args.flake().is_some() || args.lock_file().is_some() {
             return Err(HandlerError::IncompatibleFollowOptions);
         }
-        return commands::follow_auto_batch(paths, *transitive, &args)
+        return follow::auto::run_batch(paths, *transitive, *depth, &args)
             .map_err(HandlerError::Command);
     }
 
-    // Find flake.nix path
     let flake_path = if let Some(flake) = args.flake() {
         let path = PathBuf::from(flake);
         if path.is_dir() {
@@ -72,7 +163,6 @@ pub fn run(args: CliArgs) -> Result<()> {
         binding.path().to_path_buf()
     };
 
-    // Create editor and state
     let editor = Editor::from_path(flake_path.clone())?;
     let mut flake_edit = editor.create_flake_edit()?;
     let interactive = tui::is_interactive(args.non_interactive());
@@ -86,7 +176,6 @@ pub fn run(args: CliArgs) -> Result<()> {
         .with_no_cache(no_cache)
         .with_cache_path(args.cache().map(PathBuf::from));
 
-    // Dispatch to command
     match args.subcommand() {
         Command::Add {
             uri,
@@ -149,16 +238,20 @@ pub fn run(args: CliArgs) -> Result<()> {
         Command::Follow {
             paths: _,
             transitive,
+            depth,
         } => {
-            // Batch mode with paths is handled above; here we run on the current flake
+            // The batch path is handled above. This branch runs on the current flake.
             if let Some(min) = transitive {
                 state.config.follow.transitive_min = *min;
             }
-            commands::follow_auto(&editor, &mut flake_edit, &state)?;
+            if let Some(max) = depth {
+                state.config.follow.max_depth = *max;
+            }
+            follow::auto::run(&editor, &mut flake_edit, &state)?;
         }
 
         Command::AddFollow { input, target } => {
-            commands::add_follow(
+            follow::add_follow(
                 &editor,
                 &mut flake_edit,
                 &state,
@@ -183,7 +276,6 @@ pub fn run(args: CliArgs) -> Result<()> {
                 }
                 CompletionMode::Change => {
                     let inputs = flake_edit.list();
-                    // Cache inputs while we have them
                     crate::cache::populate_cache_from_input_map(inputs, no_cache);
                     for id in inputs.keys() {
                         println!("{}", id);
@@ -191,7 +283,6 @@ pub fn run(args: CliArgs) -> Result<()> {
                     std::process::exit(0);
                 }
                 CompletionMode::Follow => {
-                    // Get nested input paths from lockfile for follow completions
                     if let Ok(lock) = crate::lock::FlakeLock::from_default_path() {
                         for path in lock.nested_input_paths() {
                             println!("{}", path);
@@ -212,9 +303,8 @@ pub fn run(args: CliArgs) -> Result<()> {
         }
     }
 
-    // Cache any inputs we've seen during this command.
-    // This helps build up the completion cache over time as users interact
-    // with different flakes, not just when they explicitly add inputs.
+    // Build up the completion cache as users interact with different flakes,
+    // not only when they add inputs explicitly.
     crate::cache::populate_cache_from_input_map(flake_edit.curr_list(), no_cache);
 
     Ok(())
@@ -239,10 +329,10 @@ fn list_simple(inputs: &InputMap) {
         if !buf.is_empty() {
             buf.push('\n');
         }
-        buf.push_str(input.bare_id());
+        buf.push_str(input.id().as_str());
         for follows in input.follows() {
-            if let Follows::Indirect(id, _) = follows {
-                let id = format!("{}.{}", input.bare_id(), id);
+            if let Follows::Indirect { path, .. } = follows {
+                let id = format!("{}.{}", input.id().as_str(), path);
                 if !buf.is_empty() {
                     buf.push('\n');
                 }
@@ -254,9 +344,8 @@ fn list_simple(inputs: &InputMap) {
 }
 
 fn list_json(inputs: &InputMap) {
-    let sorted: BTreeMap<_, _> = inputs.iter().collect();
-    let json = serde_json::to_string(&sorted).unwrap();
-    println!("{json}");
+    let out: ListOutput = inputs.into();
+    println!("{}", serde_json::to_string(&out).unwrap());
 }
 
 fn list_toplevel(inputs: &InputMap) {
@@ -275,14 +364,11 @@ fn list_raw(inputs: &InputMap) {
     println!("{:#?}", sorted);
 }
 
-/// Check if a URL is a top-level follows reference (e.g., "harmonia/treefmt-nix")
-/// rather than a real URL (which would have a protocol like "github:" or "git+").
+/// True if `url` is a top-level follows reference (e.g.,
+/// `harmonia/treefmt-nix`) rather than a real URL with a `github:` or `git+`
+/// protocol prefix.
 fn is_toplevel_follows(url: &str) -> bool {
-    let url_trimmed = url.trim_matches('"');
-    !url_trimmed.is_empty()
-        && !url_trimmed.contains(':')
-        && url_trimmed.contains('/')
-        && !url_trimmed.starts_with('/')
+    !url.is_empty() && !url.contains(':') && url.contains('/') && !url.starts_with('/')
 }
 
 fn list_detailed(inputs: &InputMap) {
@@ -293,14 +379,20 @@ fn list_detailed(inputs: &InputMap) {
             buf.push('\n');
         }
         let line = if is_toplevel_follows(input.url()) {
-            format!("· {} <= {}", input.id(), input.url())
+            format!("· {} <= {}", input.id().as_str(), input.url())
         } else {
-            format!("· {} - {}", input.id(), input.url())
+            format!("· {} - {}", input.id().as_str(), input.url())
         };
         buf.push_str(&line);
         for follows in input.follows() {
-            if let Follows::Indirect(id, follow_id) = follows {
-                let id = format!("{}{} => {}", " ".repeat(5), id, follow_id);
+            if let Follows::Indirect { path, target } = follows {
+                // Render an empty `follows = ""` as `=> ""` to mirror the
+                // source-flake form. Non-empty targets render bare.
+                let target_str = match target {
+                    Some(t) => t.to_string(),
+                    None => "\"\"".to_string(),
+                };
+                let id = format!("{}{} => {}", " ".repeat(5), path, target_str);
                 if !buf.is_empty() {
                     buf.push('\n');
                 }
@@ -314,30 +406,149 @@ fn list_detailed(inputs: &InputMap) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::edit::FlakeEdit;
+    use crate::follows::{AttrPath, Segment};
+    use crate::input::{Follows, Input, Range};
+    use serde_json::json;
+
+    #[test]
+    fn list_output_empty_inputs_is_empty_shape() {
+        let inputs: InputMap = InputMap::new();
+        let out: ListOutput = (&inputs).into();
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(v, json!({ "inputs": {}, "follows": [] }));
+    }
+
+    #[test]
+    fn list_output_single_toplevel_no_follows() {
+        let mut inputs = InputMap::new();
+        let id = Segment::from_unquoted("nixpkgs").unwrap();
+        let mut input = Input::new(id);
+        input.url = "github:nixos/nixpkgs/nixos-unstable".into();
+        inputs.insert("nixpkgs".into(), input);
+        let v = serde_json::to_value(ListOutput::from(&inputs)).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "inputs": {
+                    "nixpkgs": {
+                        "id": "nixpkgs",
+                        "url": "github:nixos/nixpkgs/nixos-unstable",
+                        "flake": true,
+                    }
+                },
+                "follows": [],
+            })
+        );
+    }
+
+    #[test]
+    fn list_output_renders_indirect_follows_as_flat_array() {
+        let mut inputs = InputMap::new();
+        let crane = Segment::from_unquoted("crane").unwrap();
+        let mut input = Input::new(crane);
+        input.url = "github:ipetkov/crane".into();
+        input.range = Range {
+            start: 100,
+            end: 120,
+        };
+        input.follows.push(Follows::Indirect {
+            path: AttrPath::new(Segment::from_unquoted("nixpkgs").unwrap()),
+            target: Some(AttrPath::parse("nixpkgs").unwrap()),
+        });
+        inputs.insert("crane".into(), input);
+        let v = serde_json::to_value(ListOutput::from(&inputs)).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "inputs": {
+                    "crane": {
+                        "id": "crane",
+                        "url": "github:ipetkov/crane",
+                        "flake": true,
+                    }
+                },
+                "follows": [
+                    {
+                        "parent": "crane",
+                        "nested": "nixpkgs",
+                        "target": "nixpkgs",
+                        "kind": "indirect"
+                    }
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn list_output_url_is_unquoted() {
+        // URLs are stored unquoted in memory. The ListOutput JSON wire form
+        // surfaces them unquoted too.
+        let mut inputs = InputMap::new();
+        let id = Segment::from_unquoted("nixpkgs").unwrap();
+        let mut input = Input::new(id);
+        input.url = "github:nixos/nixpkgs".into();
+        inputs.insert("nixpkgs".into(), input);
+        let s = serde_json::to_string(&ListOutput::from(&inputs)).unwrap();
+        assert!(!s.contains("\\\"github:"));
+        assert!(s.contains("\"url\":\"github:nixos/nixpkgs\""));
+    }
+
+    #[test]
+    fn list_output_kind_serialises_kebab_case() {
+        let edge = FollowEdge {
+            parent: "a".into(),
+            nested: "b".into(),
+            target: "c".into(),
+            kind: FollowEdgeKind::Indirect,
+        };
+        let v = serde_json::to_value(&edge).unwrap();
+        assert_eq!(v.get("kind").unwrap(), &json!("indirect"));
+    }
+
+    #[test]
+    fn list_output_inputs_sorted_by_id() {
+        let content = r#"{
+            inputs.zzz.url = "github:ex/zzz";
+            inputs.aaa.url = "github:ex/aaa";
+            outputs = { ... }: { };
+        }
+        "#;
+        let mut fe = FlakeEdit::from_text(content).unwrap();
+        let v = serde_json::to_value(ListOutput::from(fe.list())).unwrap();
+        let keys: Vec<&str> = v
+            .get("inputs")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(keys, vec!["aaa", "zzz"]);
+    }
 
     #[test]
     fn test_is_toplevel_follows() {
-        // Positive: follows references look like "parent/nested"
-        assert!(is_toplevel_follows("\"harmonia/treefmt-nix\""));
-        assert!(is_toplevel_follows("\"clan-core/treefmt-nix\""));
-        assert!(is_toplevel_follows("clan-core/systems"));
-
-        // Negative: real URLs have protocols
-        assert!(!is_toplevel_follows("\"github:NixOS/nixpkgs\""));
-        assert!(!is_toplevel_follows(
-            "\"git+https://git.clan.lol/clan/clan-core\""
-        ));
-        assert!(!is_toplevel_follows("\"path:/some/local/path\""));
-        assert!(!is_toplevel_follows("\"https://github.com/pinpox.keys\""));
-
-        // Negative: absolute paths
-        assert!(!is_toplevel_follows("\"/nix/store/abc\""));
-
-        // Negative: no slash (just a name)
-        assert!(!is_toplevel_follows("\"nixpkgs\""));
-
-        // Negative: empty
-        assert!(!is_toplevel_follows(""));
-        assert!(!is_toplevel_follows("\"\""));
+        for url in [
+            "harmonia/treefmt-nix",
+            "clan-core/treefmt-nix",
+            "clan-core/systems",
+        ] {
+            assert!(is_toplevel_follows(url), "{url} should be a follows ref");
+        }
+        for url in [
+            "github:NixOS/nixpkgs",
+            "git+https://git.clan.lol/clan/clan-core",
+            "path:/some/local/path",
+            "https://github.com/pinpox.keys",
+            "/nix/store/abc",
+            "nixpkgs",
+            "",
+        ] {
+            assert!(
+                !is_toplevel_follows(url),
+                "{url} should not be a follows ref",
+            );
+        }
     }
 }

--- a/src/assets/config.toml
+++ b/src/assets/config.toml
@@ -17,3 +17,8 @@
 # Example: if nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
 # follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs
 # aliases = { nixpkgs = ["nixpkgs-lib"] }
+
+# Maximum depth of follows declarations to write.
+#   1: depth-1 only, e.g. `parent.nested.follows = "target"`
+#   2: also depth-2, e.g. `parent.middle.grandchild.follows = "target"`
+# max_depth = 1

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -27,24 +27,23 @@ struct CacheEntry {
     hit: u32,
 }
 
-/// Generate the cache entry key from an id and uri.
-///
-/// The key format is `{id}.{uri}` which allows multiple URIs per input ID
-/// (e.g., both a github: and path: URI for the same input).
+/// Build the cache entry key as `{id}.{uri}`. Keying by `(id, uri)` allows
+/// multiple URIs per input id (e.g. both a `github:` and a `path:` URI).
 fn entry_key(id: &str, uri: &str) -> String {
     format!("{}.{}", id, uri)
 }
 
-/// Cache for storing previously used flake URIs.
+/// Persistent store of previously seen flake URIs.
 ///
-/// Used for shell completions to suggest frequently used inputs.
+/// Powers shell-completion suggestions, ranked by hit count.
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Cache {
     entries: HashMap<String, CacheEntry>,
 }
 
 impl Cache {
-    /// Save the cache to disk.
+    /// Write the cache to its on-disk location, creating the parent directory
+    /// if needed.
     pub fn commit(&self) -> std::io::Result<()> {
         let cache_dir = cache_dir();
         if !cache_dir.exists() {
@@ -57,12 +56,13 @@ impl Cache {
         Ok(())
     }
 
-    /// Load the cache from the default location, or return a default empty cache.
+    /// Load the cache from the default location, or return an empty cache on
+    /// any failure.
     pub fn load() -> Self {
         Self::from_path(cache_file())
     }
 
-    /// Load the cache from a specific file path, or return a default empty cache.
+    /// Load the cache from `path`, or return an empty cache on any failure.
     pub fn from_path(path: &std::path::Path) -> Self {
         Self::try_from_path(path).unwrap_or_else(|e| {
             tracing::warn!("Could not read cache file {:?}: {}", path, e);
@@ -70,13 +70,18 @@ impl Cache {
         })
     }
 
-    /// Try to load the cache from a specific file path.
+    /// Load the cache from `path`, surfacing read or parse errors.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::io::Error`] if `path` cannot be opened or its JSON
+    /// payload cannot be deserialized.
     pub fn try_from_path(path: &std::path::Path) -> std::io::Result<Self> {
         let file = std::fs::File::open(path)?;
         serde_json::from_reader(file).map_err(|e| std::io::Error::other(e.to_string()))
     }
 
-    /// Add or update a cache entry.
+    /// Insert or bump the hit count of the `(id, uri)` entry.
     pub fn add_entry(&mut self, id: String, uri: String) {
         let key = entry_key(&id, &uri);
         match self.entries.get_mut(&key) {
@@ -88,34 +93,32 @@ impl Cache {
         }
     }
 
-    /// List cached URIs sorted by hit count (most used first).
+    /// All cached URIs sorted by descending hit count.
     pub fn list_uris(&self) -> Vec<String> {
         let mut entries: Vec<_> = self.entries.values().collect();
         entries.sort_by(|a, b| b.hit.cmp(&a.hit));
         entries.iter().map(|e| e.uri.clone()).collect()
     }
 
-    /// List cached URIs for a specific input ID, sorted by hit count (most used first).
+    /// Cached URIs for `id` sorted by descending hit count.
     ///
-    /// This is useful for the "change" workflow where we want to suggest URIs
-    /// that were previously used for the same input ID (e.g., both the remote
-    /// github: URI and a local path: URI for testing).
+    /// Useful for the `change` workflow, which suggests URIs that have been
+    /// used for the same input id (e.g. both a remote `github:` and a local
+    /// `path:` URI for testing).
     pub fn list_uris_for_id(&self, id: &str) -> Vec<String> {
         let mut entries: Vec<_> = self.entries.values().filter(|e| e.id == id).collect();
         entries.sort_by(|a, b| b.hit.cmp(&a.hit));
         entries.iter().map(|e| e.uri.clone()).collect()
     }
 
-    /// Add entries for all inputs without incrementing hit counts.
+    /// Insert any `(id, uri)` pairs not already present, without bumping hit
+    /// counts on existing entries.
     ///
-    /// This is used to populate the cache with inputs discovered while
-    /// running any command (list, change, update, etc.), not just add.
-    /// Unlike `add_entry`, this does NOT increment hit counts for existing
-    /// entries - it only adds new entries that don't exist yet.
+    /// Use this when populating the cache as a side effect of any command
+    /// that reads inputs (`list`, `change`, `update`, ...), not only `add`.
     pub fn populate_from_inputs<'a>(&mut self, inputs: impl Iterator<Item = (&'a str, &'a str)>) {
         for (id, uri) in inputs {
             let key = entry_key(id, uri);
-            // Only add if not already present (don't increment hit count)
             self.entries.entry(key).or_insert_with(|| CacheEntry {
                 id: id.to_string(),
                 uri: uri.to_string(),
@@ -125,14 +128,10 @@ impl Cache {
     }
 }
 
-/// Populate the cache with inputs from a flake.
+/// Load the on-disk cache, add any new `(id, uri)` pairs, and commit.
 ///
-/// This is a convenience function that loads the cache, adds any new inputs,
-/// and commits the changes. It's designed to be called from any command that
-/// reads inputs, helping build up the cache over time.
-///
-/// Errors are logged but don't cause failures - caching is best-effort.
-/// If `no_cache` is true, this function does nothing.
+/// Best-effort: I/O failures are logged, not propagated. A `no_cache` of
+/// `true` makes the call a no-op.
 pub fn populate_cache_from_inputs<'a>(
     inputs: impl Iterator<Item = (&'a str, &'a str)>,
     no_cache: bool,
@@ -145,7 +144,6 @@ pub fn populate_cache_from_inputs<'a>(
     let initial_len = cache.entries.len();
     cache.populate_from_inputs(inputs);
 
-    // Only write if we added new entries
     if cache.entries.len() > initial_len
         && let Err(e) = cache.commit()
     {
@@ -153,22 +151,17 @@ pub fn populate_cache_from_inputs<'a>(
     }
 }
 
-/// Populate the cache from an InputMap.
-///
-/// Convenience wrapper around `populate_cache_from_inputs` for use with
-/// the `FlakeEdit::list()` result. URIs are trimmed of surrounding quotes
-/// since the raw syntax representation includes them.
-/// If `no_cache` is true, this function does nothing.
+/// Convenience wrapper over [`populate_cache_from_inputs`] for the result of
+/// [`crate::edit::FlakeEdit::list`]. A `no_cache` of `true` makes the call a
+/// no-op.
 pub fn populate_cache_from_input_map(inputs: &crate::edit::InputMap, no_cache: bool) {
     populate_cache_from_inputs(
-        inputs
-            .iter()
-            .map(|(id, input)| (id.as_str(), input.url().trim_matches('"'))),
+        inputs.iter().map(|(id, input)| (id.as_str(), input.url())),
         no_cache,
     );
 }
 
-/// Default flake URI type prefixes for completion.
+/// Flake URI type prefixes offered by completion.
 pub const DEFAULT_URI_TYPES: [&str; 14] = [
     "github:",
     "gitlab:",
@@ -186,17 +179,15 @@ pub const DEFAULT_URI_TYPES: [&str; 14] = [
     "flake:",
 ];
 
-/// Configuration for cache usage.
-///
-/// Controls whether and where to read/write the URI completion cache.
+/// Where to read and write the URI completion cache.
 #[derive(Debug, Clone, Default)]
 pub enum CacheConfig {
-    /// Use the default cache location (~/.local/share/flake-edit/)
+    /// Default XDG location (`~/.local/share/flake-edit/`).
     #[default]
     Default,
-    /// Don't use any cache (for --no-cache flag)
+    /// Disable caching entirely (`--no-cache`).
     None,
-    /// Use a custom cache file path (for --cache flag or testing)
+    /// Read and write at a custom path (`--cache`, or tests).
     Custom(std::path::PathBuf),
 }
 

--- a/src/change.rs
+++ b/src/change.rs
@@ -1,38 +1,5 @@
+use crate::follows::{AttrPath, AttrPathParseError, Segment};
 use crate::walk::Context;
-
-/// Split an input path at the first `.` that is outside double quotes.
-///
-/// Nix attributes containing dots must be quoted (e.g. `"hls-1.10"`).
-/// A naive `split_once('.')` would split inside the quotes, so we skip
-/// any dot that appears between an opening and closing `"`.
-///
-/// Examples:
-///   `"hls-1.10".nixpkgs` -> `("hls-1.10", "nixpkgs")`
-///   `crane.nixpkgs`      -> `("crane", "nixpkgs")`
-///   `"hls-1.10"`         -> `None`
-///   `nixpkgs`            -> `None`
-pub fn split_quoted_path(s: &str) -> Option<(&str, &str)> {
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'"' {
-            // Skip to closing quote
-            i += 1;
-            while i < bytes.len() && bytes[i] != b'"' {
-                i += 1;
-            }
-            // Skip the closing quote itself
-            if i < bytes.len() {
-                i += 1;
-            }
-        } else if bytes[i] == b'.' {
-            return Some((&s[..i], &s[i + 1..]));
-        } else {
-            i += 1;
-        }
-    }
-    None
-}
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Change {
@@ -52,33 +19,53 @@ pub enum Change {
         uri: Option<String>,
         ref_or_rev: Option<String>,
     },
-    /// Add a follows relationship to an input.
-    /// Example: `flake-edit follow rust-overlay.nixpkgs nixpkgs`
-    /// Creates: `rust-overlay.inputs.nixpkgs.follows = "nixpkgs";`
+    /// Redirect a nested input to follow another input.
+    ///
+    /// Applying `Follows { input: "rust-overlay.nixpkgs", target: "nixpkgs" }`
+    /// writes `rust-overlay.inputs.nixpkgs.follows = "nixpkgs";`.
     Follows {
-        /// The input path (e.g., "rust-overlay.nixpkgs" for rust-overlay's nixpkgs input)
+        /// Path to the nested input being redirected (e.g.
+        /// `rust-overlay.nixpkgs`).
         input: ChangeId,
-        /// The target input to follow (e.g., "nixpkgs")
-        target: String,
+        /// The input to follow.
+        target: AttrPath,
     },
 }
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-pub struct ChangeId(String);
+/// Identifier for an input or nested-input target of a [`Change`].
+///
+/// Wraps an [`AttrPath`]: a non-empty sequence of unquoted segments matching
+/// flake-side attribute path grammar.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ChangeId(AttrPath);
 
 impl ChangeId {
-    /// Get the part after the dot (e.g., "nixpkgs" from "poetry2nix.nixpkgs").
-    pub fn follows(&self) -> Option<&str> {
-        split_quoted_path(&self.0).map(|(_, post)| post)
+    pub fn new(path: AttrPath) -> Self {
+        ChangeId(path)
     }
 
-    /// Get the input part (before the dot, or the whole thing if no dot).
-    pub fn input(&self) -> &str {
-        split_quoted_path(&self.0).map_or(&self.0, |(pre, _)| pre)
+    /// Parse a dotted attribute path. Quoted segments (e.g. `"hls-1.10"`)
+    /// retain dots that would otherwise act as separators.
+    pub fn parse(s: &str) -> Result<Self, AttrPathParseError> {
+        Ok(ChangeId(AttrPath::parse(s)?))
     }
 
-    /// Check if this ChangeId matches the given input and optional follows.
-    fn matches(&self, input: &str, follows: Option<&str>) -> bool {
+    pub fn path(&self) -> &AttrPath {
+        &self.0
+    }
+
+    /// Top-level input segment: the segment before the first dot, or the whole
+    /// path if it has only one segment.
+    pub fn input(&self) -> &Segment {
+        self.0.first()
+    }
+
+    /// Second segment, if the path has more than one segment.
+    pub fn follows(&self) -> Option<&Segment> {
+        self.0.child()
+    }
+
+    fn matches(&self, input: &Segment, follows: Option<&Segment>) -> bool {
         if self.input() != input {
             return false;
         }
@@ -89,13 +76,15 @@ impl ChangeId {
         }
     }
 
-    pub fn matches_with_follows(&self, input: &str, follows: Option<String>) -> bool {
-        self.matches(input, follows.as_deref())
+    /// Match against an explicit `(input, follows)` pair.
+    pub fn matches_with_follows(&self, input: &Segment, follows: Option<&Segment>) -> bool {
+        self.matches(input, follows)
     }
 
-    /// Match against context. The context carries the input attribute.
-    pub fn matches_with_ctx(&self, follows: &str, ctx: Option<Context>) -> bool {
-        let ctx_input = ctx.and_then(|f| f.level().first().cloned());
+    /// Match against the surrounding walker [`Context`], which carries the
+    /// enclosing top-level input.
+    pub fn matches_with_ctx(&self, follows: &Segment, ctx: Option<Context>) -> bool {
+        let ctx_input = ctx.and_then(|c| c.first().cloned());
         match ctx_input {
             Some(input) => self.matches(&input, Some(follows)),
             None => self.input() == follows,
@@ -109,9 +98,31 @@ impl std::fmt::Display for ChangeId {
     }
 }
 
-impl From<String> for ChangeId {
-    fn from(value: String) -> Self {
+impl TryFrom<String> for ChangeId {
+    type Error = AttrPathParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        ChangeId::parse(&value)
+    }
+}
+
+impl TryFrom<&str> for ChangeId {
+    type Error = AttrPathParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        ChangeId::parse(value)
+    }
+}
+
+impl From<AttrPath> for ChangeId {
+    fn from(value: AttrPath) -> Self {
         ChangeId(value)
+    }
+}
+
+impl From<Segment> for ChangeId {
+    fn from(value: Segment) -> Self {
+        ChangeId(AttrPath::new(value))
     }
 }
 
@@ -119,9 +130,9 @@ impl Change {
     pub fn id(&self) -> Option<ChangeId> {
         match self {
             Change::None => None,
-            Change::Add { id, .. } => id.clone().map(|id| id.into()),
+            Change::Add { id, .. } => id.clone().and_then(|id| ChangeId::parse(&id).ok()),
             Change::Remove { ids } => ids.first().cloned(),
-            Change::Change { id, .. } => id.clone().map(|id| id.into()),
+            Change::Change { id, .. } => id.clone().and_then(|id| ChangeId::parse(&id).ok()),
             Change::Follows { input, .. } => Some(input.clone()),
         }
     }
@@ -154,7 +165,7 @@ impl Change {
             _ => None,
         }
     }
-    pub fn follows_target(&self) -> Option<&String> {
+    pub fn follows_target(&self) -> Option<&AttrPath> {
         match self {
             Change::Follows { target, .. } => Some(target),
             _ => None,
@@ -182,21 +193,24 @@ impl Change {
                 )]
             }
             Change::Follows { input, target } => {
-                let msg = if let Some(nested) = input.follows() {
-                    format!(
-                        "Added follows: {}.inputs.{}.follows = \"{}\"",
-                        input.input(),
-                        nested,
-                        target
-                    )
+                // Interleave segments with `.inputs.`: `[a, b, c]` renders as
+                // `a.inputs.b.inputs.c`. Length-1 paths get an `inputs.` prefix.
+                let segments = input.path().segments();
+                let path = if segments.len() == 1 {
+                    format!("inputs.{}", segments[0].render())
                 } else {
-                    format!(
-                        "Added follows: inputs.{}.follows = \"{}\"",
-                        input.input(),
-                        target
-                    )
+                    let mut out = String::new();
+                    for (i, seg) in segments.iter().enumerate() {
+                        if i == 0 {
+                            out.push_str(&seg.render());
+                        } else {
+                            out.push_str(".inputs.");
+                            out.push_str(&seg.render());
+                        }
+                    }
+                    out
                 };
-                vec![msg]
+                vec![format!("Added follows: {}.follows = \"{}\"", path, target)]
             }
             Change::None => vec![],
         }
@@ -208,27 +222,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn split_plain() {
-        assert_eq!(
-            split_quoted_path("crane.nixpkgs"),
-            Some(("crane", "nixpkgs"))
-        );
-        assert_eq!(split_quoted_path("nixpkgs"), None);
-    }
-
-    #[test]
-    fn split_quoted_dot_in_name() {
-        assert_eq!(
-            split_quoted_path("\"hls-1.10\".nixpkgs"),
-            Some(("\"hls-1.10\"", "nixpkgs"))
-        );
-        assert_eq!(split_quoted_path("\"hls-1.10\""), None);
-    }
-
-    #[test]
     fn change_id_quoted_dot() {
-        let id = ChangeId::from("\"hls-1.10\".nixpkgs".to_string());
-        assert_eq!(id.input(), "\"hls-1.10\"");
-        assert_eq!(id.follows(), Some("nixpkgs"));
+        let id = ChangeId::parse("\"hls-1.10\".nixpkgs").unwrap();
+        assert_eq!(id.input().as_str(), "hls-1.10");
+        assert_eq!(id.follows().unwrap().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn change_id_single_segment_no_follows() {
+        let id = ChangeId::parse("nixpkgs").unwrap();
+        assert_eq!(id.input().as_str(), "nixpkgs");
+        assert!(id.follows().is_none());
+    }
+
+    #[test]
+    fn success_message_depth_three_has_two_inputs_separators() {
+        let change = Change::Follows {
+            input: ChangeId::parse("neovim.nixvim.flake-parts").unwrap(),
+            target: AttrPath::parse("flake-parts").unwrap(),
+        };
+        let msgs = change.success_messages();
+        assert_eq!(msgs.len(), 1);
+        let msg = &msgs[0];
+        let inputs_count = msg.matches(".inputs.").count();
+        assert_eq!(
+            inputs_count, 2,
+            "depth-3 message should contain exactly two `.inputs.` separators, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn success_message_depth_two_has_one_inputs_separator() {
+        let change = Change::Follows {
+            input: ChangeId::parse("crane.nixpkgs").unwrap(),
+            target: AttrPath::parse("nixpkgs").unwrap(),
+        };
+        let msgs = change.success_messages();
+        let msg = &msgs[0];
+        assert_eq!(msg.matches(".inputs.").count(), 1);
+    }
+
+    #[test]
+    fn success_message_depth_one_uses_inputs_prefix() {
+        let change = Change::Follows {
+            input: ChangeId::parse("nixpkgs").unwrap(),
+            target: AttrPath::parse("foo").unwrap(),
+        };
+        let msgs = change.success_messages();
+        let msg = &msgs[0];
+        assert!(
+            msg.starts_with("Added follows: inputs.nixpkgs.follows ="),
+            "depth-1 message should start with `inputs.<id>.follows =`, got: {msg}"
+        );
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ pub struct CliArgs {
     /// Defaults to `flake.lock` in the current directory.
     #[arg(long)]
     lock_file: Option<String>,
-    /// Print a diff of the changes, will not write the changes to disk.
+    /// Print a diff of the changes instead of writing them to disk.
     #[arg(long, default_value_t = false)]
     diff: bool,
     /// Skip updating the lockfile after editing flake.nix.
@@ -41,12 +41,12 @@ pub struct CliArgs {
 
 #[allow(unused)]
 impl CliArgs {
-    /// Surface current version together with the current git revision and date, if available
+    /// Version string with embedded git revision and date, when available.
     fn unstable_version() -> &'static str {
         const VERSION: &str = env!("CARGO_PKG_VERSION");
         let date = option_env!("GIT_DATE").unwrap_or("no_date");
         let rev = option_env!("GIT_REV").unwrap_or("no_rev");
-        // This is a memory leak, only use sparingly.
+        // Leaks per call. Only invoked once at startup.
         Box::leak(format!("{VERSION} - {date} - {rev}").into_boxed_str())
     }
 
@@ -188,6 +188,12 @@ pub enum Command {
         /// `follow.transitive_min`.
         #[arg(long, num_args = 0..=1, default_missing_value = "2")]
         transitive: Option<usize>,
+        /// Maximum depth of follows declarations to write: 1 writes only
+        /// `parent.child.follows`, 2 also writes
+        /// `parent.child.grandchild.follows`. Defaults to 2 if no value is
+        /// given. Overrides the config file's `follow.max_depth`.
+        #[arg(long, num_args = 0..=1, default_missing_value = "2")]
+        depth: Option<usize>,
         /// Flake.nix paths to process. If empty, runs on current directory.
         #[arg(trailing_var_arg = true, num_args = 0..)]
         paths: Vec<std::path::PathBuf>,
@@ -227,8 +233,8 @@ pub enum Command {
     },
 }
 
+/// Which subcommand to complete.
 #[derive(Debug, Clone, Default)]
-/// Which command should be completed
 pub enum CompletionMode {
     #[default]
     None,
@@ -249,6 +255,7 @@ impl From<String> for CompletionMode {
     }
 }
 
+/// Output format for the `list` subcommand.
 #[derive(Debug, Clone, Default)]
 pub enum ListFormat {
     None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,18 +2,20 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-/// Default configuration embedded in the binary.
+/// Default configuration TOML embedded in the binary.
 pub const DEFAULT_CONFIG_TOML: &str = include_str!("assets/config.toml");
 
-/// Error type for configuration loading failures.
+/// Configuration loading failures.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigError {
+    /// Failed to read the configuration file from disk.
     #[error("Failed to read config file '{path}': {source}")]
     Io {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
+    /// Failed to parse a configuration file as TOML.
     #[error("Failed to parse config file '{path}':\n{source}")]
     Parse {
         path: PathBuf,
@@ -22,9 +24,10 @@ pub enum ConfigError {
     },
 }
 
-/// Filenames to search for project-level configuration.
+/// Filenames searched for project-level configuration, in priority order.
 const CONFIG_FILENAMES: &[&str] = &["flake-edit.toml", ".flake-edit.toml"];
 
+/// Top-level `flake-edit.toml` configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -32,23 +35,34 @@ pub struct Config {
     pub follow: FollowConfig,
 }
 
-/// Configuration for the `follow` command.
+/// `[follow]` section of [`Config`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FollowConfig {
-    /// Inputs to ignore during follow.
+    /// Inputs to skip during follow analysis.
+    ///
+    /// See [`Self::is_ignored`] for the matching rules.
     #[serde(default)]
     pub ignore: Vec<String>,
 
-    /// Minimum number of transitive follows needed to add a top-level follows input.
-    /// Set to 0 to disable transitive follows deduplication.
+    /// Minimum number of transitive references required before a shared
+    /// nested input is promoted to top-level. `0` disables transitive
+    /// deduplication.
     #[serde(default = "default_transitive_min")]
     pub transitive_min: usize,
 
-    /// Alias mappings: canonical_name -> [alternative_names]
-    /// e.g., nixpkgs = ["nixpkgs-lib"] means nixpkgs-lib can follow nixpkgs
+    /// Alias mappings: canonical name to alternative names. For example,
+    /// `nixpkgs = ["nixpkgs-lib"]` lets `nixpkgs-lib` follow `nixpkgs`.
     #[serde(default)]
     pub aliases: HashMap<String, Vec<String>>,
+
+    /// Maximum depth of follows declarations to write.
+    ///
+    /// `1` (default) writes only `parent.nested.follows = "target"`. `2` or
+    /// higher also writes deeper paths such as
+    /// `parent.middle.grandchild.follows = "target"`.
+    #[serde(default = "default_max_depth")]
+    pub max_depth: usize,
 }
 
 impl Default for FollowConfig {
@@ -57,30 +71,28 @@ impl Default for FollowConfig {
             ignore: Vec::new(),
             transitive_min: default_transitive_min(),
             aliases: HashMap::new(),
+            max_depth: default_max_depth(),
         }
     }
 }
 
 impl FollowConfig {
-    /// Check if an input should be ignored.
+    /// True if the input at `path` (e.g. `crane.nixpkgs`) with simple `name`
+    /// (e.g. `nixpkgs`) is in [`Self::ignore`].
     ///
-    /// Supports two formats:
-    /// - Full path: `"crane.nixpkgs"` - ignores only that specific nested input
-    /// - Simple name: `"nixpkgs"` - ignores all nested inputs with that name
+    /// Entries containing a `.` match the full dotted path. Bare entries
+    /// match by name across all parents.
     pub fn is_ignored(&self, path: &str, name: &str) -> bool {
         self.ignore.iter().any(|ignored| {
-            // Check for full path match first (more specific)
             if ignored.contains('.') {
                 ignored == path
             } else {
-                // Simple name match
                 ignored == name
             }
         })
     }
 
-    /// Find the canonical name for a given input name.
-    /// Returns the canonical name if found in aliases, otherwise returns None.
+    /// Canonical name `name` is an alias of, or `None` if no alias applies.
     pub fn resolve_alias(&self, name: &str) -> Option<&str> {
         for (canonical, alternatives) in &self.aliases {
             if alternatives.iter().any(|alt| alt == name) {
@@ -90,14 +102,12 @@ impl FollowConfig {
         None
     }
 
-    /// Check if `nested_name` can follow `top_level_name`.
-    /// Returns true if they match directly or via alias.
+    /// True if `nested_name` may follow `top_level_name` (direct match or via
+    /// [`Self::aliases`]).
     pub fn can_follow(&self, nested_name: &str, top_level_name: &str) -> bool {
-        // Direct match
         if nested_name == top_level_name {
             return true;
         }
-        // Check if nested_name is an alias for top_level_name
         self.resolve_alias(nested_name) == Some(top_level_name)
     }
 
@@ -107,12 +117,16 @@ impl FollowConfig {
 }
 
 impl Config {
-    /// Load configuration in the following order:
-    /// 1. Project-level config (flake-edit.toml or .flake-edit.toml in current/parent dirs)
-    /// 2. User-level config (~/.config/flake-edit/config.toml)
-    /// 3. Default embedded config
+    /// Load the first available configuration:
+    /// 1. Project-level ([`CONFIG_FILENAMES`], walking upward from the
+    ///    current directory).
+    /// 2. User-level (`~/.config/flake-edit/config.toml`).
+    /// 3. The default embedded config.
     ///
-    /// Returns an error if a config file exists but is malformed.
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if a discovered file cannot be read or
+    /// parsed.
     pub fn load() -> Result<Self, ConfigError> {
         if let Some(path) = Self::project_config_path() {
             return Self::try_load_from_file(&path);
@@ -123,10 +137,12 @@ impl Config {
         Ok(Self::default())
     }
 
-    /// Load configuration from an explicitly specified path.
+    /// Load configuration from `path`, or fall back to [`Self::load`] when
+    /// `path` is `None`.
     ///
-    /// Returns an error if the file doesn't exist or is malformed.
-    /// If no path is specified, falls back to the default load order.
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] if `path` does not exist or cannot be parsed.
     pub fn load_from(path: Option<&Path>) -> Result<Self, ConfigError> {
         match path {
             Some(p) => Self::try_load_from_file(p),
@@ -134,7 +150,6 @@ impl Config {
         }
     }
 
-    /// Try to load config from a file, returning detailed errors on failure.
     fn try_load_from_file(path: &Path) -> Result<Self, ConfigError> {
         let content = std::fs::read_to_string(path).map_err(|e| ConfigError::Io {
             path: path.to_path_buf(),
@@ -146,6 +161,8 @@ impl Config {
         })
     }
 
+    /// Path to the nearest project-level config file, walking upward from
+    /// the current directory.
     pub fn project_config_path() -> Option<PathBuf> {
         let cwd = std::env::current_dir().ok()?;
         Self::find_config_in_ancestors(&cwd)
@@ -156,11 +173,14 @@ impl Config {
         Some(dirs.config_dir().to_path_buf())
     }
 
+    /// Path to `~/.config/flake-edit/config.toml`, or `None` if it does not
+    /// exist.
     pub fn user_config_path() -> Option<PathBuf> {
         let config_path = Self::xdg_config_dir()?.join("config.toml");
         config_path.exists().then_some(config_path)
     }
 
+    /// XDG config directory for flake-edit, regardless of whether it exists.
     pub fn user_config_dir() -> Option<PathBuf> {
         Self::xdg_config_dir()
     }
@@ -186,6 +206,10 @@ fn default_transitive_min() -> usize {
     0
 }
 
+fn default_max_depth() -> usize {
+    1
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,6 +221,19 @@ mod tests {
         assert!(config.follow.ignore.is_empty());
         assert_eq!(config.follow.transitive_min, 0);
         assert!(config.follow.aliases.is_empty());
+        assert_eq!(config.follow.max_depth, 1);
+    }
+
+    #[test]
+    fn max_depth_defaults_to_one() {
+        let cfg = FollowConfig::default();
+        assert_eq!(cfg.max_depth, 1);
+    }
+
+    #[test]
+    fn max_depth_parses_from_toml() {
+        let cfg: Config = toml::from_str("[follow]\nmax_depth = 2\n").unwrap();
+        assert_eq!(cfg.follow.max_depth, 2);
     }
 
     #[test]

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -21,13 +21,15 @@ pub enum Outputs {
 
 pub type InputMap = HashMap<String, Input>;
 
+/// Sorted input ids from `inputs`.
 pub fn sorted_input_ids(inputs: &InputMap) -> Vec<&String> {
     let mut keys: Vec<_> = inputs.keys().collect();
     keys.sort();
     keys
 }
 
-/// Returns owned strings, for contexts where references won't work.
+/// Sorted input ids as owned strings, for callers that can't hold a borrow on
+/// `inputs`.
 pub fn sorted_input_ids_owned(inputs: &InputMap) -> Vec<String> {
     let mut keys: Vec<String> = inputs.keys().cloned().collect();
     keys.sort();
@@ -40,6 +42,15 @@ pub enum OutputChange {
     None,
     Add(String),
     Remove(String),
+}
+
+/// Result of applying a [`Change`].
+///
+/// `text` is the new flake source, or `None` for a no-op (e.g. an
+/// already-existing follows declaration).
+#[derive(Debug, Default)]
+pub struct ApplyOutcome {
+    pub text: Option<String>,
 }
 
 impl FlakeEdit {
@@ -73,17 +84,31 @@ impl FlakeEdit {
         &self.walker.inputs
     }
 
-    /// Will walk and then list the inputs, for listing the current inputs,
-    /// use `curr_list()`.
+    /// Re-walk the source and return the freshly populated input map. Use
+    /// [`Self::curr_list`] to read the cached map without re-walking.
     pub fn list(&mut self) -> &InputMap {
         self.walker.inputs.clear();
         // Walk returns Ok(None) when no changes are made (expected for listing)
         assert!(self.walker.walk(&Change::None).ok().flatten().is_none());
         &self.walker.inputs
     }
-    /// Apply a specific change to a walker, on some inputs it will need to walk
-    /// multiple times, will error, if the edit could not be applied successfully.
-    pub fn apply_change(&mut self, change: Change) -> Result<Option<String>, FlakeEditError> {
+    /// Apply `change` and return the resulting [`ApplyOutcome`].
+    ///
+    /// Some edits require multiple walker passes. This method drives them all.
+    /// A fatal validation failure surfaces as
+    /// [`FlakeEditError::Validation`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlakeEditError`] if the underlying walker fails or the change
+    /// is rejected (e.g. [`FlakeEditError::DuplicateInput`],
+    /// [`FlakeEditError::InputNotFound`]).
+    pub fn apply_change(&mut self, change: Change) -> Result<ApplyOutcome, FlakeEditError> {
+        let text = self.apply_change_text(change)?;
+        Ok(ApplyOutcome { text })
+    }
+
+    fn apply_change_text(&mut self, change: Change) -> Result<Option<String>, FlakeEditError> {
         match change {
             Change::None => Ok(None),
             Change::Add { .. } => {
@@ -91,7 +116,7 @@ impl FlakeEdit {
                 if let Some(input_id) = change.id() {
                     self.ensure_inputs_populated()?;
 
-                    let input_id_string = input_id.to_string();
+                    let input_id_string = input_id.input().as_str().to_string();
                     if self.walker.inputs.contains_key(&input_id_string) {
                         return Err(FlakeEditError::DuplicateInput(input_id_string));
                     }
@@ -101,7 +126,7 @@ impl FlakeEdit {
                     let outputs = self.walker.list_outputs()?;
                     match outputs {
                         Outputs::Multiple(out) => {
-                            let id = change.id().unwrap().to_string();
+                            let id = change.id().unwrap().input().as_str().to_string();
                             if !out.contains(&id) {
                                 self.walker.root = maybe_changed_node.clone();
                                 if let Some(maybe_changed_node) =
@@ -123,7 +148,14 @@ impl FlakeEdit {
             Change::Remove { .. } => {
                 self.ensure_inputs_populated()?;
 
-                let removed_id = change.id().unwrap().to_string();
+                let id = change.id().unwrap();
+                // Outputs-lambda strip and orphan-follows scrubbing only
+                // run for a top-level input remove. A depth-N follows id
+                // shares its first segment with a still-present input;
+                // running the cleanup there would strip that input from
+                // the outputs lambda.
+                let is_toplevel_remove = id.follows().is_none();
+                let removed_id = id.input().as_str().to_string();
 
                 // If we remove a node, it could be a flat structure,
                 // we want to remove all of the references to its toplevel.
@@ -135,31 +167,32 @@ impl FlakeEdit {
                     res = Some(changed_node.clone());
                     self.walker.root = changed_node.clone();
                 }
-                // Removed nodes should be removed from the outputs
-                let outputs = self.walker.list_outputs()?;
-                match outputs {
-                    Outputs::Multiple(out) | Outputs::Any(out) => {
-                        if out.contains(&removed_id)
-                            && let Some(changed_node) = self
-                                .walker
-                                .change_outputs(OutputChange::Remove(removed_id.clone()))?
-                        {
+
+                if is_toplevel_remove {
+                    let outputs = self.walker.list_outputs()?;
+                    match outputs {
+                        Outputs::Multiple(out) | Outputs::Any(out) => {
+                            if out.contains(&removed_id)
+                                && let Some(changed_node) = self
+                                    .walker
+                                    .change_outputs(OutputChange::Remove(removed_id.clone()))?
+                            {
+                                res = Some(changed_node.clone());
+                                self.walker.root = changed_node.clone();
+                            }
+                        }
+                        Outputs::None => {}
+                    }
+
+                    let orphaned_follows = self.collect_orphaned_follows(&removed_id);
+                    for orphan_change in orphaned_follows {
+                        while let Some(changed_node) = self.walker.walk(&orphan_change)? {
+                            if res == Some(changed_node.clone()) {
+                                break;
+                            }
                             res = Some(changed_node.clone());
                             self.walker.root = changed_node.clone();
                         }
-                    }
-                    Outputs::None => {}
-                }
-
-                // Remove orphaned follows references that point to the removed input
-                let orphaned_follows = self.collect_orphaned_follows(&removed_id);
-                for orphan_change in orphaned_follows {
-                    while let Some(changed_node) = self.walker.walk(&orphan_change)? {
-                        if res == Some(changed_node.clone()) {
-                            break;
-                        }
-                        res = Some(changed_node.clone());
-                        self.walker.root = changed_node.clone();
                     }
                 }
 
@@ -168,7 +201,7 @@ impl FlakeEdit {
             Change::Follows { ref input, .. } => {
                 self.ensure_inputs_populated()?;
 
-                let parent_id = input.input();
+                let parent_id = input.input().as_str();
                 if !self.walker.inputs.contains_key(parent_id) {
                     return Err(FlakeEditError::InputNotFound(parent_id.to_string()));
                 }
@@ -183,7 +216,7 @@ impl FlakeEdit {
                 if let Some(input_id) = change.id() {
                     self.ensure_inputs_populated()?;
 
-                    let input_id_string = input_id.to_string();
+                    let input_id_string = input_id.input().as_str().to_string();
                     if !self.walker.inputs.contains_key(&input_id_string) {
                         return Err(FlakeEditError::InputNotFound(input_id_string));
                     }
@@ -202,7 +235,7 @@ impl FlakeEdit {
         &self.walker
     }
 
-    /// Ensure the inputs map is populated by walking if empty.
+    /// Walk once if the inputs map is empty.
     fn ensure_inputs_populated(&mut self) -> Result<(), FlakeEditError> {
         if self.walker.inputs.is_empty() {
             let _ = self.walker.walk(&Change::None)?;
@@ -210,18 +243,28 @@ impl FlakeEdit {
         Ok(())
     }
 
-    /// Collect follows references that point to a removed input.
-    /// Returns a list of Change::Remove for orphaned follows.
+    /// Collect [`Change::Remove`]s for follows declarations whose target
+    /// top-level segment matches `removed_id`.
     fn collect_orphaned_follows(&self, removed_id: &str) -> Vec<Change> {
         let mut orphaned = Vec::new();
         for (input_id, input) in &self.walker.inputs {
             for follows in input.follows() {
-                if let Follows::Indirect(follows_name, target) = follows {
-                    // target is the RHS of `follows = "target"`
-                    if target.trim_matches('"') == removed_id {
-                        let nested_id = format!("{}.{}", input_id, follows_name);
+                if let Follows::Indirect {
+                    path,
+                    target: Some(target),
+                } = follows
+                {
+                    // target is the RHS of `follows = "..."`. Match when its
+                    // top-level segment is the removed input. Empty targets
+                    // (`follows = ""`) have nothing to follow and cannot
+                    // dangle.
+                    if target.first().as_str() == removed_id {
+                        let path_str = format!("{}.{}", input_id, path);
+                        let Ok(change_id) = crate::change::ChangeId::parse(&path_str) else {
+                            continue;
+                        };
                         orphaned.push(Change::Remove {
-                            ids: vec![nested_id.into()],
+                            ids: vec![change_id],
                         });
                     }
                 }
@@ -250,13 +293,13 @@ mod tests {
         let mut fe = FlakeEdit::from_text(flake).unwrap();
         let original = fe.source_text();
         let change = Change::Follows {
-            input: "crane.nixpkgs".to_string().into(),
-            target: "nixpkgs".to_string(),
+            input: crate::change::ChangeId::parse("crane.nixpkgs").unwrap(),
+            target: crate::follows::AttrPath::parse("nixpkgs").unwrap(),
         };
         let result = fe.apply_change(change).unwrap();
-        // Walker signals a no-op as either the unchanged text or `None`;
-        // both are acceptable here.
-        if let Some(text) = result {
+        // Walker signals a no-op as either the unchanged text or `None`.
+        // Both are acceptable here.
+        if let Some(text) = result.text {
             assert_eq!(text, original, "text should be unchanged");
         }
     }
@@ -274,12 +317,12 @@ mod tests {
 }"#;
         let mut fe = FlakeEdit::from_text(flake).unwrap();
         let change = Change::Follows {
-            input: "crane.nixpkgs".to_string().into(),
-            target: "nixpkgs".to_string(),
+            input: crate::change::ChangeId::parse("crane.nixpkgs").unwrap(),
+            target: crate::follows::AttrPath::parse("nixpkgs").unwrap(),
         };
         let result = fe.apply_change(change);
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
-        let text = result.unwrap().unwrap();
+        let text = result.unwrap().text.unwrap();
         assert!(text.contains("inputs.nixpkgs.follows = \"nixpkgs\""));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,26 +3,46 @@ use thiserror::Error;
 use crate::validate::ValidationError;
 use crate::walk::WalkerError;
 
+/// Error for [`crate::edit::FlakeEdit`] operations.
 #[derive(Debug, Error)]
 pub enum FlakeEditError {
+    /// An I/O operation on `flake.nix` or `flake.lock` failed.
     #[error("IoError: {0}")]
     Io(#[from] std::io::Error),
+    /// The CST walker rejected a change. See [`WalkerError`] for details.
     #[error(transparent)]
     Walker(#[from] WalkerError),
+    /// `flake.lock` has no `root` node referenced by `nodes`.
     #[error("Lock file missing root node")]
     LockMissingRoot,
+    /// Generic lockfile-shape failure: missing fields, malformed paths,
+    /// unresolvable input references.
     #[error("There is an error in the Lockfile: {0}")]
     LockError(String),
+    /// JSON deserialization of `flake.lock` failed.
     #[error("Deserialization Error: {0}")]
     Serde(#[from] serde_json::Error),
+    /// Tried to add an input that already exists. The wrapped string is the
+    /// existing input id.
     #[error(
         "Input '{0}' already exists in the flake.\n\nTo replace it:\n  1. Remove it first: flake-edit remove {0}\n  2. Then add it again: flake-edit add {0} <flakeref>\n\nOr add it with a different [ID]:\n  flake-edit add [ID] <flakeref>\n\nTo see all current inputs: flake-edit list"
     )]
     DuplicateInput(String),
+    /// Tried to operate on an input id that is not declared in the flake.
     #[error(
         "Input '{0}' not found in the flake.\n\nTo add it:\n  flake-edit add {0} <flakeref>\n\nTo see all current inputs: flake-edit list"
     )]
     InputNotFound(String),
+    /// The `add-follow` subcommand received a path deeper than `parent.child`.
+    /// `flake-edit follow` accepts deeper paths up to
+    /// [`crate::config::FollowConfig::max_depth`]; this guard catches typos
+    /// in the explicit-path command before they produce nested
+    /// `inputs.*.inputs.*.follows` chains.
+    #[error(
+        "`add-follow` accepts only depth-1 paths of the form `parent.child`; got '{path}' ({segments} segments).\n\nUse `flake-edit follow` for deeper paths (depth bounded by `follow.max_depth` in your config)."
+    )]
+    AddFollowDepthLimit { path: String, segments: usize },
+    /// Pre-edit validation found one or more fatal issues in `flake.nix`.
     #[error("Validation error in flake.nix:\n{}", format_validation_errors(.0))]
     Validation(Vec<ValidationError>),
 }

--- a/src/follows.rs
+++ b/src/follows.rs
@@ -1,0 +1,14 @@
+//! Follows-graph types: typed attribute paths and the edge graph built from them.
+//!
+//! An attribute path is a non-empty sequence of attribute names rooted at a
+//! flake input. Segments are stored unquoted. The `"..."` quotes Nix requires
+//! for names containing dots, leading digits, and similar live on the
+//! rendering boundary.
+pub mod graph;
+pub mod path;
+
+pub use graph::{
+    Cycle, DEFAULT_MAX_DEPTH, Edge, EdgeOrigin, FollowsGraph, StaleLockDeclaration,
+    TransitiveGroup, is_follows_reference_to_parent,
+};
+pub use path::{AttrPath, AttrPathParseError, Segment, SegmentError, strip_outer_quotes};

--- a/src/follows/graph.rs
+++ b/src/follows/graph.rs
@@ -1,0 +1,1500 @@
+//! [`FollowsGraph`]: follows edges with origin tracking.
+//!
+//! Each [`Edge`] records whether it came from `flake.nix`
+//! ([`EdgeOrigin::Declared`]) or `flake.lock` ([`EdgeOrigin::Resolved`]).
+//! Paths are typed [`AttrPath`]s, so equality is structural.
+use std::collections::{HashMap, HashSet};
+
+use crate::edit::InputMap;
+use crate::follows::{AttrPath, Segment};
+use crate::input::{Follows, Input, Range};
+use crate::lock::FlakeLock;
+
+/// Default upper bound on graph traversal depth. The per-emission cap
+/// (`follow.max_depth` in config) is a separate, smaller knob.
+pub const DEFAULT_MAX_DEPTH: usize = 64;
+
+/// Where an [`Edge`] originated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EdgeOrigin {
+    /// Edge declared explicitly in `flake.nix`.
+    Declared {
+        /// Source-text byte range of the declaring `inputs...follows = "..."`
+        /// attrpath/value, when known. An empty range means no source
+        /// location is available (typical in tests and [`FollowsGraph::from_lock`]).
+        range: Range,
+    },
+    /// Edge discovered by walking `flake.lock`.
+    Resolved {
+        /// Lockfile node owning the parent (left) side of the edge.
+        parent_node: Segment,
+        /// Lockfile node the edge resolves to.
+        target_node: Segment,
+    },
+}
+
+/// One follows edge in the graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Edge {
+    /// Where the edge starts, e.g. `crane.nixpkgs` for an
+    /// `inputs.crane.inputs.nixpkgs.follows` declaration.
+    pub source: AttrPath,
+    /// Right-hand side of the `follows`.
+    pub follows: AttrPath,
+    /// Origin metadata: declared edges carry source ranges, resolved edges
+    /// carry lockfile node names.
+    pub origin: EdgeOrigin,
+}
+
+/// A declared follows whose lockfile resolution disagrees with `flake.nix`.
+/// Produced by [`FollowsGraph::stale_lock_declarations`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaleLockDeclaration<'a> {
+    /// The declared edge, carrying its source-text range for diagnostics.
+    pub declared: &'a Edge,
+    /// What the lockfile resolves the same source path to. `None` means the
+    /// lockfile has the path but no follows attached (override never applied).
+    pub lock_target: Option<AttrPath>,
+}
+
+/// A detected cycle, as the sequence of edges that close it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cycle {
+    /// Edges in traversal order. The last edge's `follows` equals the first
+    /// edge's `source`, or is a structural prefix of it.
+    pub edges: Vec<Edge>,
+}
+
+/// A group of nested inputs sharing a transitive follows target. Keyed by
+/// the canonical (alias-resolved) name of the nested input. The value is the
+/// shared `target` plus every contributing nested path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitiveGroup {
+    /// Canonical (post-alias) name the group shares.
+    pub canonical_name: String,
+    /// Lockfile-side follows target every member resolves to.
+    pub target: AttrPath,
+    /// All declared or resolved sources that share this target.
+    pub members: Vec<AttrPath>,
+}
+
+/// Index of follows [`Edge`]s keyed by their `source` path. Construct with
+/// [`Self::from_declared`], [`Self::from_lock`], or [`Self::from_flake`] for
+/// declared-only, resolved-only, or merged views respectively.
+#[derive(Debug, Clone)]
+pub struct FollowsGraph {
+    edges: HashMap<AttrPath, Vec<Edge>>,
+    /// Every nested-input path observed in the lockfile, including those
+    /// without a follows. Populated by [`Self::from_lock`] and
+    /// [`Self::from_flake`]. Consulted by [`Self::stale_edges`] to ask
+    /// whether a declared edge's source path is still represented.
+    resolved_universe: HashSet<AttrPath>,
+    /// Source paths declared as `follows = ""` in `flake.nix`. These do
+    /// not produce edges (no resolved target), but they still encode user
+    /// intent: the auto-deduplicator must treat them as already-handled
+    /// so it does not retarget them.
+    declared_nulled_sources: HashSet<AttrPath>,
+    max_depth: usize,
+}
+
+impl Default for FollowsGraph {
+    fn default() -> Self {
+        FollowsGraph {
+            edges: HashMap::new(),
+            resolved_universe: HashSet::new(),
+            declared_nulled_sources: HashSet::new(),
+            max_depth: DEFAULT_MAX_DEPTH,
+        }
+    }
+}
+
+impl FollowsGraph {
+    /// Build a graph from the declared `inputs = { ... }` block alone.
+    ///
+    /// Each [`Follows::Indirect`] in `inputs` becomes one
+    /// [`EdgeOrigin::Declared`] edge carrying [`Input::range`].
+    pub fn from_declared(inputs: &InputMap) -> Self {
+        let mut graph = FollowsGraph {
+            max_depth: DEFAULT_MAX_DEPTH,
+            ..FollowsGraph::default()
+        };
+        for input in inputs.values() {
+            collect_declared_edges(input, &mut graph);
+        }
+        graph
+    }
+
+    /// Build a graph from the lockfile alone.
+    ///
+    /// Walks `flake.lock` from the root, emitting one [`EdgeOrigin::Resolved`]
+    /// edge per `inputs.X = ["a", "b", ...]` follows override, bounded by
+    /// [`DEFAULT_MAX_DEPTH`]. Every nested-input path is recorded in
+    /// `resolved_universe`, with or without a follows.
+    pub fn from_lock(lock: &FlakeLock) -> Self {
+        let mut graph = FollowsGraph {
+            max_depth: DEFAULT_MAX_DEPTH,
+            ..FollowsGraph::default()
+        };
+        for nested in lock.nested_inputs() {
+            graph.resolved_universe.insert(nested.path.clone());
+            if let Some(target) = nested.follows {
+                graph.insert_edge(Edge {
+                    source: nested.path.clone(),
+                    follows: target,
+                    origin: EdgeOrigin::Resolved {
+                        parent_node: nested.path.first().clone(),
+                        target_node: nested.path.last().clone(),
+                    },
+                });
+            }
+        }
+        graph
+    }
+
+    /// Build the merged graph: declared edges first, then resolved edges
+    /// from the lockfile that no existing edge already covers at the same
+    /// `(source, follows)`. Every nested-input path observed in the
+    /// lockfile is recorded in `resolved_universe`.
+    ///
+    /// Dedup is by `(source, follows)`, not by `source` alone: a declared
+    /// edge and its resolved sibling can share a source but point at
+    /// different targets (the user's depth-N follow points at the user's
+    /// top-level input; the lockfile points at the upstream's intermediate
+    /// path). Both encode distinct reachability and
+    /// [`Self::lock_routes_to`] needs the resolved sibling to survive when
+    /// the declared edge is excluded as a candidate.
+    pub fn from_flake(inputs: &InputMap, lock: &FlakeLock) -> Self {
+        let mut graph = FollowsGraph::from_declared(inputs);
+        for nested in lock.nested_inputs() {
+            graph.resolved_universe.insert(nested.path.clone());
+            if let Some(target) = nested.follows {
+                let already = graph
+                    .outgoing(&nested.path)
+                    .iter()
+                    .any(|e| e.follows == target);
+                if already {
+                    continue;
+                }
+                graph.insert_edge(Edge {
+                    source: nested.path.clone(),
+                    follows: target,
+                    origin: EdgeOrigin::Resolved {
+                        parent_node: nested.path.first().clone(),
+                        target_node: nested.path.last().clone(),
+                    },
+                });
+            }
+        }
+        graph
+    }
+
+    /// Override the traversal depth bound. Default is [`DEFAULT_MAX_DEPTH`].
+    #[must_use]
+    pub fn with_max_depth(mut self, max: usize) -> Self {
+        self.max_depth = max;
+        self
+    }
+
+    /// Outgoing edges from `src`, or an empty slice.
+    pub fn outgoing(&self, src: &AttrPath) -> &[Edge] {
+        self.edges.get(src).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Iterator over every edge, lex-sorted by source.
+    pub fn edges(&self) -> impl Iterator<Item = &Edge> {
+        let mut keys: Vec<&AttrPath> = self.edges.keys().collect();
+        keys.sort();
+        keys.into_iter()
+            .flat_map(|k| self.edges.get(k).unwrap().iter())
+    }
+
+    /// Edges originating from `flake.nix`. Lex-sorted by source.
+    pub fn declared_edges(&self) -> impl Iterator<Item = &Edge> {
+        self.edges()
+            .filter(|e| matches!(e.origin, EdgeOrigin::Declared { .. }))
+    }
+
+    /// Every source path the user has declared a follows for in
+    /// `flake.nix`, regardless of whether it resolves to a target. The
+    /// union of [`Self::declared_edges`] sources and the nulled
+    /// (`follows = ""`) sources tracked alongside them.
+    ///
+    /// Distinct from [`Self::declared_edges`] because the auto-follow
+    /// pipeline must treat a nulled declaration as "already user-owned"
+    /// and skip it; the edges-only view drops nulled sources because
+    /// they have no target to put on the right-hand side of an edge.
+    pub fn declared_sources(&self) -> HashSet<AttrPath> {
+        let mut out: HashSet<AttrPath> = self.declared_edges().map(|e| e.source.clone()).collect();
+        out.extend(self.declared_nulled_sources.iter().cloned());
+        out
+    }
+
+    /// Read-only view of source paths declared as `follows = ""`. The
+    /// auto-deduplicator consults this to distinguish a nulled
+    /// declaration (user explicitly opted out) from a path with a real
+    /// follows target.
+    pub fn declared_nulled(&self) -> &HashSet<AttrPath> {
+        &self.declared_nulled_sources
+    }
+
+    /// Cycles among declared edges only: detects per-segment self-cycles
+    /// where an edge's source equals its follows. Multi-hop and lockfile-only
+    /// cycle detection lives on [`Self::would_create_cycle`].
+    pub fn cycles(&self) -> Vec<Cycle> {
+        let mut found: Vec<Cycle> = Vec::new();
+        let mut seen_keys: HashSet<(AttrPath, AttrPath)> = HashSet::new();
+        let mut declared: Vec<&Edge> = self.declared_edges().collect();
+        declared.sort_by(|a, b| a.source.cmp(&b.source).then(a.follows.cmp(&b.follows)));
+        for edge in declared {
+            if !is_one_step_cycle(edge) {
+                continue;
+            }
+            let key = (edge.source.clone(), edge.follows.clone());
+            if seen_keys.insert(key) {
+                found.push(Cycle {
+                    edges: vec![edge.clone()],
+                });
+            }
+        }
+        found
+    }
+
+    /// Declared edges whose source path no longer appears in the lockfile.
+    /// A follows declaration whose nested input is gone from `flake.lock`
+    /// should be dropped on the next auto-follow pass. Lex-sorted by source.
+    pub fn stale_edges(&self) -> Vec<&Edge> {
+        let mut declared: Vec<&Edge> = self
+            .declared_edges()
+            .filter(|e| !self.resolved_universe.contains(&e.source))
+            .collect();
+        declared.sort_by(|a, b| a.source.cmp(&b.source));
+        declared
+    }
+
+    /// Sibling of [`Self::stale_edges`] for [`Self::declared_nulled`]:
+    /// nulled (`follows = ""`) declarations whose source is absent from
+    /// `resolved_universe`. A nulled declaration backed by an
+    /// `inputs.X = []` lock entry stays in `resolved_universe` and is not
+    /// reported. Lex-sorted.
+    pub fn stale_nulled_sources(&self) -> Vec<&AttrPath> {
+        let mut sources: Vec<&AttrPath> = self
+            .declared_nulled_sources
+            .iter()
+            .filter(|p| !self.resolved_universe.contains(*p))
+            .collect();
+        sources.sort();
+        sources
+    }
+
+    /// Declared follows whose target disagrees with the lockfile's
+    /// resolution for the same source path.
+    ///
+    /// A returned entry means `flake.nix` declares a follows for
+    /// `entry.declared.source` pointing at `entry.declared.follows`, but the
+    /// lock has either:
+    ///
+    /// - `lock_target = Some(other)`: a different resolved target, or
+    /// - `lock_target = None`: no follows at all (override never applied).
+    ///
+    /// Both cases call for `nix flake lock`. Sources missing from the
+    /// lockfile entirely are reported by [`Self::stale_edges`] instead.
+    ///
+    /// Lex-sorted by source.
+    pub fn stale_lock_declarations<'a>(
+        &'a self,
+        lock: &FlakeLock,
+    ) -> Vec<StaleLockDeclaration<'a>> {
+        let lock_targets: HashMap<AttrPath, Option<AttrPath>> = lock
+            .nested_inputs()
+            .into_iter()
+            .map(|n| (n.path, n.follows))
+            .collect();
+
+        let mut out: Vec<StaleLockDeclaration<'a>> = Vec::new();
+        for edge in self.declared_edges() {
+            let Some(lock_target) = lock_targets.get(&edge.source) else {
+                continue;
+            };
+            let diverges = match lock_target {
+                Some(target) => target != &edge.follows,
+                None => true,
+            };
+            if diverges {
+                out.push(StaleLockDeclaration {
+                    declared: edge,
+                    lock_target: lock_target.clone(),
+                });
+            }
+        }
+        out.sort_by(|a, b| a.declared.source.cmp(&b.declared.source));
+        out
+    }
+
+    /// Whether adding `proposed` would close a follows cycle.
+    ///
+    /// Origin-agnostic DFS from `proposed.follows`. Reaching `proposed.source`
+    /// means the new edge closes a cycle. Beyond the trivial self-edge case,
+    /// three classes are covered:
+    ///
+    /// 1. **Dot-named ancestor.** [`AttrPath`] equality is structural, so a
+    ///    participant like `"hls-1.10"` compares by its unquoted segment
+    ///    value, not by URL prefix.
+    /// 2. **Multi-hop chains.** A cycle `A → B → C → ... → A` is found by
+    ///    walking the chain.
+    /// 3. **Lockfile-only cycles.** [`EdgeOrigin::Resolved`] edges are
+    ///    traversed alongside declared ones, so a chain closing only
+    ///    through the lockfile is still reported.
+    ///
+    /// Bounded by [`Self::with_max_depth`] for malformed graphs. Standard
+    /// visited / on-stack sets keep pre-existing cycles from wedging the walk.
+    pub fn would_create_cycle(&self, proposed: &Edge) -> bool {
+        if is_one_step_cycle(proposed) {
+            return true;
+        }
+        // Structural ancestor case: if the target's leading segment matches
+        // any ancestor segment of the source, the edge would point a nested
+        // input back at one of its own ancestors -- a self-reference Nix
+        // forbids. Catches the dot-named ancestor case even on an empty graph.
+        let target_first = proposed.follows.first();
+        let mut ancestor: Option<AttrPath> = proposed.source.parent();
+        while let Some(a) = ancestor {
+            if a.last() == target_first {
+                return true;
+            }
+            ancestor = a.parent();
+        }
+        let mut visited: HashSet<AttrPath> = HashSet::new();
+        let mut on_stack: HashSet<AttrPath> = HashSet::new();
+        self.dfs_reaches(
+            &proposed.follows,
+            &proposed.source,
+            0,
+            &mut visited,
+            &mut on_stack,
+        )
+    }
+
+    fn dfs_reaches(
+        &self,
+        node: &AttrPath,
+        target: &AttrPath,
+        depth: usize,
+        visited: &mut HashSet<AttrPath>,
+        on_stack: &mut HashSet<AttrPath>,
+    ) -> bool {
+        if depth >= self.max_depth {
+            return false;
+        }
+        if node == target {
+            return true;
+        }
+        if visited.contains(node) {
+            return false;
+        }
+        if on_stack.contains(node) {
+            // Pre-existing cycle that doesn't pass through `target`. Skip
+            // without claiming the proposed edge closes a new one.
+            return false;
+        }
+        // Cycle through structural ancestry: a target inside the current
+        // node's subtree, e.g. proposed `c.a -> a` while traversing from `a`
+        // whose subtree contains declared edges sourced at `a.x` reaching
+        // back to `c.a`.
+        if node.is_prefix_of(target) {
+            return true;
+        }
+        on_stack.insert(node.clone());
+        // Expand literal-source edges plus edges whose source starts with
+        // `node`. The second captures the implicit "parent depends on target"
+        // relation a declared `parent.child -> target` follows expresses.
+        for edge in self.expanded_outgoing(node) {
+            if self.dfs_reaches(&edge.follows, target, depth + 1, visited, on_stack) {
+                on_stack.remove(node);
+                visited.insert(node.clone());
+                return true;
+            }
+        }
+        on_stack.remove(node);
+        visited.insert(node.clone());
+        false
+    }
+
+    /// Edges describing outgoing dependencies of `node`: those with source
+    /// equal to `node`, plus those whose source has `node` as a strict
+    /// prefix. The latter encode the implicit "parent depends on target"
+    /// relation in a declared `parent.child.follows = target`.
+    fn expanded_outgoing(&self, node: &AttrPath) -> Vec<&Edge> {
+        let mut out: Vec<&Edge> = Vec::new();
+        for (source, edges) in &self.edges {
+            if source == node || node.is_prefix_of(source) {
+                out.extend(edges.iter());
+            }
+        }
+        out
+    }
+
+    /// Group nested inputs by canonical name, in deterministic order.
+    ///
+    /// `top` is the set of top-level input names already in `flake.nix`.
+    /// Sources whose first segment is in `top` are skipped because no
+    /// promotion is possible.
+    pub fn transitive_groups(&self, top: &HashSet<AttrPath>) -> Vec<TransitiveGroup> {
+        let mut by_canonical: HashMap<String, HashMap<AttrPath, Vec<AttrPath>>> = HashMap::new();
+        for edge in self.edges() {
+            let nested_name = edge.source.last().as_str().to_string();
+            let toplevel_only = AttrPath::parse(&nested_name).ok();
+            if let Some(p) = &toplevel_only
+                && top.contains(p)
+            {
+                continue;
+            }
+            by_canonical
+                .entry(nested_name)
+                .or_default()
+                .entry(edge.follows.clone())
+                .or_default()
+                .push(edge.source.clone());
+        }
+
+        let mut groups: Vec<TransitiveGroup> = Vec::new();
+        let mut canonical_names: Vec<String> = by_canonical.keys().cloned().collect();
+        canonical_names.sort();
+        for name in canonical_names {
+            let buckets = by_canonical.remove(&name).unwrap();
+            let mut bucket_keys: Vec<AttrPath> = buckets.keys().cloned().collect();
+            bucket_keys.sort();
+            for target in bucket_keys {
+                let mut members = buckets.get(&target).cloned().unwrap_or_default();
+                members.sort();
+                groups.push(TransitiveGroup {
+                    canonical_name: name.clone(),
+                    target,
+                    members,
+                });
+            }
+        }
+        groups
+    }
+
+    fn insert_edge(&mut self, edge: Edge) {
+        self.edges
+            .entry(edge.source.clone())
+            .or_default()
+            .push(edge);
+    }
+
+    /// Drop every edge whose `source` is in `sources`.
+    ///
+    /// Hides a known set of edges from [`Self::would_create_cycle`] and
+    /// [`Self::lock_routes_to`] without re-deriving the graph from
+    /// scratch. `resolved_universe` is intentionally untouched: removing
+    /// a declared edge does not retroactively unobserve the lockfile
+    /// path the source was discovered from.
+    pub fn drop_edges_with_sources(&mut self, sources: &[AttrPath]) {
+        for src in sources {
+            self.edges.remove(src);
+        }
+    }
+
+    /// Whether the graph routes `source` transitively to `target`, ignoring
+    /// `exclude` if given. `extra_edges` are treated as additional
+    /// declared-style edges for callers staging follows not yet in the graph.
+    ///
+    /// Walks both [`EdgeOrigin::Declared`] and [`EdgeOrigin::Resolved`] edges:
+    /// [`Self::from_flake`] keeps only one when both encode the same
+    /// `(source, target)`, so restricting the walk to one variant would miss
+    /// chains closing through the deduped edge.
+    pub fn lock_routes_to(
+        &self,
+        source: &AttrPath,
+        target: &AttrPath,
+        exclude: Option<&Edge>,
+        extra_edges: &[(AttrPath, AttrPath)],
+    ) -> bool {
+        let mut visited: HashSet<AttrPath> = HashSet::new();
+        let mut on_stack: HashSet<AttrPath> = HashSet::new();
+        self.dfs_routes_to(
+            source,
+            target,
+            exclude,
+            extra_edges,
+            0,
+            &mut visited,
+            &mut on_stack,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn dfs_routes_to(
+        &self,
+        node: &AttrPath,
+        target: &AttrPath,
+        exclude: Option<&Edge>,
+        extra_edges: &[(AttrPath, AttrPath)],
+        depth: usize,
+        visited: &mut HashSet<AttrPath>,
+        on_stack: &mut HashSet<AttrPath>,
+    ) -> bool {
+        if depth >= self.max_depth {
+            return false;
+        }
+        if node == target {
+            return true;
+        }
+        if visited.contains(node) || on_stack.contains(node) {
+            return false;
+        }
+        if node.is_prefix_of(target) {
+            return true;
+        }
+        on_stack.insert(node.clone());
+        let direct_hops = self.expanded_outgoing(node).into_iter().filter_map(|edge| {
+            if let Some(skip) = exclude
+                && edge.source == skip.source
+                && edge.follows == skip.follows
+            {
+                return None;
+            }
+            Some(edge.follows.clone())
+        });
+        for next in direct_hops.collect::<Vec<_>>() {
+            if self.dfs_routes_to(
+                &next,
+                target,
+                exclude,
+                extra_edges,
+                depth + 1,
+                visited,
+                on_stack,
+            ) {
+                on_stack.remove(node);
+                visited.insert(node.clone());
+                return true;
+            }
+        }
+        for (src, dst) in extra_edges {
+            if src != node && !node.is_prefix_of(src) {
+                continue;
+            }
+            if let Some(skip) = exclude
+                && src == &skip.source
+                && dst == &skip.follows
+            {
+                continue;
+            }
+            if self.dfs_routes_to(
+                dst,
+                target,
+                exclude,
+                extra_edges,
+                depth + 1,
+                visited,
+                on_stack,
+            ) {
+                on_stack.remove(node);
+                visited.insert(node.clone());
+                return true;
+            }
+        }
+        // Ancestor rewriting: when `A.B` follows `C`, `A.B.X` resolves to
+        // `C.X`. Splice the suffix-after-ancestor onto the target and recurse.
+        let mut ancestor: Option<AttrPath> = node.parent();
+        while let Some(anc) = ancestor.clone() {
+            for edge in self.outgoing(&anc) {
+                if let Some(skip) = exclude
+                    && edge.source == skip.source
+                    && edge.follows == skip.follows
+                {
+                    continue;
+                }
+                let mut next = edge.follows.clone();
+                for seg in &node.segments()[anc.len()..] {
+                    next.push(seg.clone());
+                }
+                if self.dfs_routes_to(
+                    &next,
+                    target,
+                    exclude,
+                    extra_edges,
+                    depth + 1,
+                    visited,
+                    on_stack,
+                ) {
+                    on_stack.remove(node);
+                    visited.insert(node.clone());
+                    return true;
+                }
+            }
+            for (src, dst) in extra_edges {
+                if src != &anc {
+                    continue;
+                }
+                if let Some(skip) = exclude
+                    && src == &skip.source
+                    && dst == &skip.follows
+                {
+                    continue;
+                }
+                let mut next = dst.clone();
+                for seg in &node.segments()[anc.len()..] {
+                    next.push(seg.clone());
+                }
+                if self.dfs_routes_to(
+                    &next,
+                    target,
+                    exclude,
+                    extra_edges,
+                    depth + 1,
+                    visited,
+                    on_stack,
+                ) {
+                    on_stack.remove(node);
+                    visited.insert(node.clone());
+                    return true;
+                }
+            }
+            ancestor = anc.parent();
+        }
+        on_stack.remove(node);
+        visited.insert(node.clone());
+        false
+    }
+}
+
+fn collect_declared_edges(input: &Input, graph: &mut FollowsGraph) {
+    for follows in input.follows() {
+        if let Follows::Indirect { path, target } = follows {
+            let mut source = AttrPath::new(input.id().clone());
+            for seg in path.segments() {
+                source.push(seg.clone());
+            }
+            match target {
+                Some(target) => {
+                    graph.insert_edge(Edge {
+                        source,
+                        follows: target.clone(),
+                        origin: EdgeOrigin::Declared {
+                            range: input.range.clone(),
+                        },
+                    });
+                }
+                // `follows = ""`: no edge to insert, but record the
+                // source so [`FollowsGraph::declared_sources`] reports
+                // it as user-owned.
+                None => {
+                    graph.declared_nulled_sources.insert(source);
+                }
+            }
+        }
+    }
+}
+
+/// Self-cycle: source equals follows, structurally.
+fn is_one_step_cycle(edge: &Edge) -> bool {
+    edge.source == edge.follows
+}
+
+/// Whether `url` is a follows reference of the form `"<parent>/<rest>"`.
+/// Exposed for consumers that have only a URL string and no typed target.
+pub fn is_follows_reference_to_parent(url: &str, parent: &str) -> bool {
+    url.starts_with(&format!("{parent}/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::follows::Segment;
+    use crate::input::Range;
+
+    fn seg(s: &str) -> Segment {
+        Segment::from_unquoted(s).unwrap()
+    }
+
+    fn path(s: &str) -> AttrPath {
+        AttrPath::parse(s).unwrap()
+    }
+
+    fn declared_input(id: &str, follows: &[(&str, &str)]) -> Input {
+        let mut input = Input::new(seg(id));
+        for (parent, target) in follows {
+            input.follows.push(Follows::Indirect {
+                path: AttrPath::new(seg(parent)),
+                target: Some(path(target)),
+            });
+        }
+        input.range = Range { start: 1, end: 2 };
+        input
+    }
+
+    fn make_inputs(items: Vec<Input>) -> InputMap {
+        let mut map = InputMap::new();
+        for input in items {
+            map.insert(input.id().as_str().to_string(), input);
+        }
+        map
+    }
+
+    fn declared_edge(source: &str, follows: &str) -> Edge {
+        Edge {
+            source: path(source),
+            follows: path(follows),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        }
+    }
+
+    #[test]
+    fn from_declared_emits_one_edge_per_indirect() {
+        let inputs = make_inputs(vec![declared_input(
+            "crane",
+            &[("nixpkgs", "nixpkgs"), ("flake-utils", "flake-utils")],
+        )]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let mut got: Vec<(String, String)> = g
+            .edges()
+            .map(|e| (e.source.to_string(), e.follows.to_string()))
+            .collect();
+        got.sort();
+        assert_eq!(
+            got,
+            vec![
+                ("crane.flake-utils".to_string(), "flake-utils".to_string()),
+                ("crane.nixpkgs".to_string(), "nixpkgs".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn from_declared_marks_origin_declared() {
+        let inputs = make_inputs(vec![declared_input("crane", &[("nixpkgs", "nixpkgs")])]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let edge = g.edges().next().unwrap();
+        assert!(matches!(edge.origin, EdgeOrigin::Declared { .. }));
+    }
+
+    #[test]
+    fn from_lock_picks_up_nested_follows() {
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "treefmt-nix": {
+      "inputs": { "nixpkgs": ["nixpkgs"] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "def", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "treefmt-nix": "treefmt-nix" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_lock(&lock);
+        let edges: Vec<&Edge> = g.edges().collect();
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].source.to_string(), "treefmt-nix.nixpkgs");
+        assert_eq!(edges[0].follows.to_string(), "nixpkgs");
+        assert!(matches!(edges[0].origin, EdgeOrigin::Resolved { .. }));
+    }
+
+    #[test]
+    fn outgoing_returns_only_matching_source() {
+        let inputs = make_inputs(vec![
+            declared_input("crane", &[("nixpkgs", "nixpkgs")]),
+            declared_input("flake-utils", &[("nixpkgs", "nixpkgs")]),
+        ]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let crane_out = g.outgoing(&path("crane.nixpkgs"));
+        assert_eq!(crane_out.len(), 1);
+        assert_eq!(crane_out[0].follows.to_string(), "nixpkgs");
+        assert!(g.outgoing(&path("nonexistent.nixpkgs")).is_empty());
+    }
+
+    #[test]
+    fn stale_edges_flags_declared_without_resolved() {
+        // `flake.nix` declares `home-manager.nixpkgs.follows`, but the
+        // lockfile has no nested input at that path.
+        let inputs = make_inputs(vec![declared_input(
+            "home-manager",
+            &[("nixpkgs", "nixpkgs")],
+        )]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "home-manager": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        let stale: Vec<&Edge> = g.stale_edges();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].source.to_string(), "home-manager.nixpkgs");
+    }
+
+    #[test]
+    fn stale_nulled_sources_flags_nulled_without_resolved() {
+        let mut input = Input::new(seg("home-manager"));
+        input.follows.push(Follows::Indirect {
+            path: AttrPath::new(seg("nixpkgs")),
+            target: None,
+        });
+        input.range = Range { start: 1, end: 2 };
+        let inputs = make_inputs(vec![input]);
+
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "home-manager": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        let stale: Vec<String> = g
+            .stale_nulled_sources()
+            .iter()
+            .map(|p| p.to_string())
+            .collect();
+        assert_eq!(stale, vec!["home-manager.nixpkgs"]);
+    }
+
+    /// `inputs.X = []` keeps `X` in `resolved_universe`, so a matching
+    /// `follows = ""` is in sync, not stale.
+    #[test]
+    fn stale_nulled_sources_quiet_when_lock_has_empty_indirect() {
+        let mut input = Input::new(seg("home-manager"));
+        input.follows.push(Follows::Indirect {
+            path: AttrPath::new(seg("nixpkgs")),
+            target: None,
+        });
+        input.range = Range { start: 1, end: 2 };
+        let inputs = make_inputs(vec![input]);
+
+        let lock_text = r#"{
+  "nodes": {
+    "home-manager": {
+      "inputs": { "nixpkgs": [] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        assert!(g.stale_nulled_sources().is_empty());
+    }
+
+    #[test]
+    fn self_named_three_segment_declared_round_trips_with_lock() {
+        // Regression: a `parent.parent.leaf` lock path must round-trip through
+        // the declared edge so [`FollowsGraph::stale_edges`] does not flag it.
+        // Hand-build the declared shape the parser produces for
+        // `inputs.agenix.inputs.systems.follows = "systems"` inside an
+        // `agenix = { ... }` block: `Follows::Indirect` whose `path` carries
+        // the full chain `[agenix, systems]`, attached to the owner input
+        // `agenix`. Reconstructed source is `agenix.agenix.systems` (3-seg).
+        let mut input = Input::new(seg("agenix"));
+        input.follows.push(Follows::Indirect {
+            path: AttrPath::parse("agenix.systems").unwrap(),
+            target: Some(path("systems")),
+        });
+        input.range = Range { start: 1, end: 2 };
+        let inputs = make_inputs(vec![input, declared_input("systems", &[])]);
+
+        let lock_text = r#"{
+  "nodes": {
+    "agenix": {
+      "inputs": { "agenix": "agenix_2" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "aaa", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "agenix_2": {
+      "inputs": { "systems": "systems_2" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "bbb", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "systems": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ccc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "systems_2": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "agenix": "agenix", "systems": "systems" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+
+        let declared: Vec<&Edge> = g.declared_edges().collect();
+        assert_eq!(declared.len(), 1);
+        assert_eq!(declared[0].source.to_string(), "agenix.agenix.systems");
+
+        let stale: Vec<&Edge> = g.stale_edges();
+        assert!(
+            stale.is_empty(),
+            "self-named 3-seg declared edge must not be flagged stale, got: {:?}",
+            stale
+                .iter()
+                .map(|e| e.source.to_string())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn transitive_groups_skips_when_canonical_already_top_level() {
+        let inputs = make_inputs(vec![
+            declared_input("crane", &[("nixpkgs", "nixpkgs")]),
+            declared_input("flake-utils", &[("nixpkgs", "nixpkgs")]),
+        ]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let mut top: HashSet<AttrPath> = HashSet::new();
+        top.insert(path("nixpkgs"));
+        let groups = g.transitive_groups(&top);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn transitive_groups_groups_shared_target() {
+        let inputs = make_inputs(vec![
+            declared_input("crane", &[("flake-parts", "flake-parts")]),
+            declared_input("treefmt-nix", &[("flake-parts", "flake-parts")]),
+        ]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let top: HashSet<AttrPath> = HashSet::new();
+        let groups = g.transitive_groups(&top);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].canonical_name, "flake-parts");
+        assert_eq!(groups[0].target.to_string(), "flake-parts");
+        let members: Vec<String> = groups[0].members.iter().map(|p| p.to_string()).collect();
+        assert_eq!(
+            members,
+            vec!["crane.flake-parts", "treefmt-nix.flake-parts"]
+        );
+    }
+
+    #[test]
+    fn transitive_groups_sorted_by_canonical_then_target() {
+        let inputs = make_inputs(vec![
+            declared_input("a", &[("z", "z")]),
+            declared_input("b", &[("z", "z")]),
+            declared_input("c", &[("y", "y")]),
+        ]);
+        let g = FollowsGraph::from_declared(&inputs);
+        let top: HashSet<AttrPath> = HashSet::new();
+        let groups = g.transitive_groups(&top);
+        let names: Vec<&str> = groups.iter().map(|g| g.canonical_name.as_str()).collect();
+        assert_eq!(names, vec!["y", "z"]);
+    }
+
+    #[test]
+    fn would_create_cycle_self_edge() {
+        let g = FollowsGraph::default();
+        let e = declared_edge("nixpkgs", "nixpkgs");
+        assert!(g.would_create_cycle(&e));
+    }
+
+    #[test]
+    fn would_create_cycle_dot_named_ancestor() {
+        // Structural equality on the dot-named segment must catch the
+        // ancestor cycle: source `"hls-1.10".nixpkgs`, target `"hls-1.10"`.
+        let g = FollowsGraph::default();
+        let e = Edge {
+            source: AttrPath::parse("\"hls-1.10\".nixpkgs").unwrap(),
+            follows: AttrPath::parse("\"hls-1.10\"").unwrap(),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        };
+        assert!(g.would_create_cycle(&e));
+    }
+
+    #[test]
+    fn would_create_cycle_no_cycle_for_distinct_target() {
+        let g = FollowsGraph::default();
+        let e = declared_edge("crane.nixpkgs", "nixpkgs");
+        assert!(!g.would_create_cycle(&e));
+    }
+
+    #[test]
+    fn would_create_cycle_ignores_unrelated_ancestor() {
+        let g = FollowsGraph::default();
+        let e = declared_edge("a.b.c", "d");
+        assert!(!g.would_create_cycle(&e));
+    }
+
+    /// Multi-hop cycle through declared edges: `A → B`, `B → C`, propose
+    /// `C → A`. DFS must traverse the chain rather than rely on a
+    /// per-ancestor check on `proposed`.
+    #[test]
+    fn would_create_cycle_multi_hop_declared() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(declared_edge("a", "b"));
+        g.insert_edge(declared_edge("b", "c"));
+        let proposed = declared_edge("c", "a");
+        assert!(g.would_create_cycle(&proposed));
+    }
+
+    /// Multi-hop with a `"hls-1.10"` participant: typed [`AttrPath`]
+    /// equality must survive the embedded dot.
+    #[test]
+    fn would_create_cycle_multi_hop_dot_named() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(declared_edge("\"hls-1.10\"", "b"));
+        g.insert_edge(declared_edge("b", "c"));
+        let proposed = declared_edge("c", "\"hls-1.10\"");
+        assert!(g.would_create_cycle(&proposed));
+    }
+
+    /// Lockfile-only cycle: a 2-hop chain closing only through resolved
+    /// edges. Origin-agnostic DFS must report it.
+    #[test]
+    fn would_create_cycle_lockfile_only() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(Edge {
+            source: AttrPath::parse("treefmt-nix.nixpkgs").unwrap(),
+            follows: AttrPath::parse("harmonia.treefmt-nix").unwrap(),
+            origin: EdgeOrigin::Resolved {
+                parent_node: seg("treefmt-nix"),
+                target_node: seg("harmonia"),
+            },
+        });
+        g.insert_edge(Edge {
+            source: AttrPath::parse("harmonia.treefmt-nix").unwrap(),
+            follows: AttrPath::parse("treefmt-nix").unwrap(),
+            origin: EdgeOrigin::Resolved {
+                parent_node: seg("harmonia"),
+                target_node: seg("treefmt-nix"),
+            },
+        });
+        let proposed = Edge {
+            source: AttrPath::parse("treefmt-nix").unwrap(),
+            follows: AttrPath::parse("treefmt-nix.nixpkgs").unwrap(),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        };
+        assert!(g.would_create_cycle(&proposed));
+    }
+
+    /// DFS terminates and still reports a cycle-closing proposal when the
+    /// graph already contains an unrelated cycle.
+    #[test]
+    fn would_create_cycle_terminates_on_existing_cycle() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(declared_edge("x", "x"));
+        g.insert_edge(declared_edge("a", "b"));
+        g.insert_edge(declared_edge("b", "c"));
+        let proposed = declared_edge("c", "a");
+        assert!(g.would_create_cycle(&proposed));
+    }
+
+    /// `max_depth` bounds DFS so a malformed graph cannot wedge it.
+    #[test]
+    fn would_create_cycle_bounded_by_max_depth() {
+        let mut g = FollowsGraph::default().with_max_depth(2);
+        g.insert_edge(declared_edge("a", "b"));
+        g.insert_edge(declared_edge("b", "c"));
+        g.insert_edge(declared_edge("c", "d"));
+        let proposed = declared_edge("d", "a");
+        assert!(!g.would_create_cycle(&proposed));
+    }
+
+    #[test]
+    fn drop_edges_with_sources_removes_only_listed_sources() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(declared_edge("crane.nixpkgs", "nixpkgs"));
+        g.insert_edge(declared_edge("crane.flake-utils", "flake-utils"));
+        g.insert_edge(declared_edge("treefmt-nix.nixpkgs", "nixpkgs"));
+
+        g.drop_edges_with_sources(&[path("crane.nixpkgs")]);
+
+        let remaining: Vec<String> = g.edges().map(|e| e.source.to_string()).collect();
+        assert_eq!(
+            remaining,
+            vec![
+                "crane.flake-utils".to_string(),
+                "treefmt-nix.nixpkgs".to_string(),
+            ],
+            "only the listed source should be dropped; the rest survive intact"
+        );
+    }
+
+    #[test]
+    fn drop_edges_with_sources_clears_cycle_through_dropped_edge() {
+        // Edges `X.Y -> Y` and `Y.Z -> Z` chain via [`Self::would_create_cycle`]
+        // to reject a `Z.X -> X` candidate (the `Z.is_prefix_of(Z.X)`
+        // shortcut fires at the visited `Z` node). Dropping `X.Y` must
+        // clear the path.
+        let mut g = FollowsGraph::default();
+        g.insert_edge(declared_edge("X.Y", "Y"));
+        g.insert_edge(declared_edge("Y.Z", "Z"));
+        let proposed = declared_edge("Z.X", "X");
+        assert!(g.would_create_cycle(&proposed));
+
+        g.drop_edges_with_sources(&[path("X.Y")]);
+        assert!(!g.would_create_cycle(&proposed));
+    }
+
+    #[test]
+    fn cycles_finds_self_referential_declared_edge() {
+        let mut inputs = InputMap::new();
+        let mut input = Input::new(seg("foo"));
+        input.follows.push(Follows::Indirect {
+            path: AttrPath::new(seg("foo")),
+            target: Some(AttrPath::parse("foo.foo").unwrap()),
+        });
+        input.range = Range { start: 1, end: 2 };
+        inputs.insert("foo".into(), input);
+        let g = FollowsGraph::from_declared(&inputs);
+        let cycles = g.cycles();
+        assert_eq!(cycles.len(), 1);
+        assert_eq!(cycles[0].edges.len(), 1);
+        assert_eq!(cycles[0].edges[0].source.to_string(), "foo.foo");
+    }
+
+    #[test]
+    fn cycles_empty_for_acyclic_declared() {
+        let inputs = make_inputs(vec![declared_input("crane", &[("nixpkgs", "nixpkgs")])]);
+        let g = FollowsGraph::from_declared(&inputs);
+        assert!(g.cycles().is_empty());
+    }
+
+    #[test]
+    fn is_follows_reference_to_parent_url_prefix() {
+        assert!(is_follows_reference_to_parent(
+            "clan-core/treefmt-nix",
+            "clan-core"
+        ));
+        assert!(!is_follows_reference_to_parent("github:nixos/nixpkgs", "x"));
+        assert!(!is_follows_reference_to_parent(
+            "clan-core-extended",
+            "clan-core"
+        ));
+    }
+
+    #[test]
+    fn with_max_depth_overrides_default() {
+        let g = FollowsGraph::default().with_max_depth(7);
+        assert_eq!(g.max_depth, 7);
+    }
+
+    #[test]
+    fn stale_lock_declarations_detects_target_mismatch() {
+        let inputs = make_inputs(vec![declared_input("crane", &[("nixpkgs", "nixpkgs")])]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nixpkgs_2": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "def", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "crane": {
+      "inputs": { "nixpkgs": ["nixpkgs_2"] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ggg", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "crane": "crane" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        let overridden = g.stale_lock_declarations(&lock);
+        assert_eq!(overridden.len(), 1);
+        assert_eq!(overridden[0].declared.source.to_string(), "crane.nixpkgs");
+        assert_eq!(overridden[0].declared.follows.to_string(), "nixpkgs");
+        assert_eq!(
+            overridden[0].lock_target.as_ref().map(|p| p.to_string()),
+            Some("nixpkgs_2".to_string())
+        );
+    }
+
+    #[test]
+    fn stale_lock_declarations_detects_missing_follows() {
+        let inputs = make_inputs(vec![declared_input("crane", &[("nixpkgs", "nixpkgs")])]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nixpkgs_2": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "def", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "crane": {
+      "inputs": { "nixpkgs": "nixpkgs_2" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ggg", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "crane": "crane" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        let overridden = g.stale_lock_declarations(&lock);
+        assert_eq!(overridden.len(), 1);
+        assert_eq!(overridden[0].declared.source.to_string(), "crane.nixpkgs");
+        assert!(overridden[0].lock_target.is_none());
+    }
+
+    #[test]
+    fn stale_lock_declarations_quiet_when_in_sync() {
+        let inputs = make_inputs(vec![declared_input("crane", &[("nixpkgs", "nixpkgs")])]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "crane": {
+      "inputs": { "nixpkgs": ["nixpkgs"] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ggg", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "crane": "crane" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        assert!(g.stale_lock_declarations(&lock).is_empty());
+    }
+
+    #[test]
+    fn stale_lock_declarations_orthogonal_to_stale() {
+        let inputs = make_inputs(vec![declared_input(
+            "home-manager",
+            &[("nixpkgs", "nixpkgs")],
+        )]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "home-manager": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        assert_eq!(g.stale_edges().len(), 1);
+        assert!(g.stale_lock_declarations(&lock).is_empty());
+    }
+
+    #[test]
+    fn merged_prefers_declared_over_resolved() {
+        let inputs = make_inputs(vec![declared_input(
+            "treefmt-nix",
+            &[("nixpkgs", "nixpkgs")],
+        )]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "treefmt-nix": {
+      "inputs": { "nixpkgs": ["nixpkgs"] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "def", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "treefmt-nix": "treefmt-nix" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let g = FollowsGraph::from_flake(&inputs, &lock);
+        let edges: Vec<&Edge> = g.outgoing(&path("treefmt-nix.nixpkgs")).iter().collect();
+        assert_eq!(edges.len(), 1);
+        assert!(matches!(edges[0].origin, EdgeOrigin::Declared { .. }));
+    }
+
+    #[test]
+    fn lock_routes_to_chain_through_user_depth1() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(Edge {
+            source: path("hyprland.aquamarine.nixpkgs"),
+            follows: path("hyprland.nixpkgs"),
+            origin: EdgeOrigin::Resolved {
+                parent_node: seg("aquamarine"),
+                target_node: seg("nixpkgs"),
+            },
+        });
+        g.insert_edge(declared_edge("hyprland.nixpkgs", "nixpkgs"));
+        assert!(g.lock_routes_to(
+            &path("hyprland.aquamarine.nixpkgs"),
+            &path("nixpkgs"),
+            None,
+            &[],
+        ));
+    }
+
+    #[test]
+    fn lock_routes_to_excludes_candidate_edge() {
+        let mut g = FollowsGraph::default();
+        g.insert_edge(Edge {
+            source: path("hyprland.aquamarine.nixpkgs"),
+            follows: path("hyprland.nixpkgs"),
+            origin: EdgeOrigin::Resolved {
+                parent_node: seg("aquamarine"),
+                target_node: seg("nixpkgs"),
+            },
+        });
+        g.insert_edge(declared_edge("hyprland.nixpkgs", "nixpkgs"));
+        let candidate = declared_edge("hyprland.aquamarine.nixpkgs", "nixpkgs");
+        g.insert_edge(candidate.clone());
+        assert!(g.lock_routes_to(&candidate.source, &candidate.follows, Some(&candidate), &[],));
+    }
+
+    /// Auto-remove must not drop a load-bearing follow.
+    #[test]
+    fn lock_routes_to_no_other_path_returns_false_when_candidate_excluded() {
+        let mut g = FollowsGraph::default();
+        let candidate = declared_edge("a.b", "nixpkgs");
+        g.insert_edge(candidate.clone());
+        assert!(!g.lock_routes_to(&candidate.source, &candidate.follows, Some(&candidate), &[]));
+    }
+
+    #[test]
+    fn lock_routes_to_no_route_returns_false() {
+        let g = FollowsGraph::default();
+        assert!(!g.lock_routes_to(&path("a.b.c"), &path("nixpkgs"), None, &[]));
+    }
+
+    /// Deep upstream chain `a.b.c.d -> a.b.c -> a.b -> a`, all Resolved.
+    #[test]
+    fn lock_routes_to_deep_upstream_chain() {
+        let mut g = FollowsGraph::default();
+        for (src, dst) in [("a.b.c.d", "a.b.c"), ("a.b.c", "a.b"), ("a.b", "a")] {
+            g.insert_edge(Edge {
+                source: path(src),
+                follows: path(dst),
+                origin: EdgeOrigin::Resolved {
+                    parent_node: Segment::from_unquoted(src).unwrap(),
+                    target_node: Segment::from_unquoted(dst).unwrap(),
+                },
+            });
+        }
+        assert!(g.lock_routes_to(&path("a.b.c.d"), &path("a"), None, &[]));
+    }
+
+    /// End-to-end: a depth-3 chain detected by [`FollowsGraph::lock_routes_to`]
+    /// drives a [`Change::Remove`] through [`FlakeEdit`].
+    #[test]
+    fn lock_routes_to_drives_change_remove_at_depth_three() {
+        use crate::change::{Change, ChangeId};
+        use crate::edit::FlakeEdit;
+
+        let mut g = FollowsGraph::default();
+        for (src, dst) in [
+            ("omnibus.flops.POP.nixpkgs", "omnibus.flops.nixpkgs"),
+            ("omnibus.flops.nixpkgs", "omnibus.nixpkgs"),
+            ("omnibus.nixpkgs", "nixpkgs"),
+        ] {
+            g.insert_edge(Edge {
+                source: path(src),
+                follows: path(dst),
+                origin: EdgeOrigin::Resolved {
+                    parent_node: Segment::from_unquoted(src).unwrap(),
+                    target_node: Segment::from_unquoted(dst).unwrap(),
+                },
+            });
+        }
+        let candidate = declared_edge("omnibus.flops.POP.nixpkgs", "nixpkgs");
+        g.insert_edge(candidate.clone());
+
+        assert!(
+            g.lock_routes_to(&candidate.source, &candidate.follows, Some(&candidate), &[]),
+            "depth-3 chain should be predicted as covered by upstream propagation"
+        );
+
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    omnibus.url = "github:Lehmanator/nix-configs";
+    omnibus.inputs.nixpkgs.follows = "nixpkgs";
+    omnibus.inputs.flops.inputs.POP.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, ... }: { };
+}
+"#;
+        let mut fe = FlakeEdit::from_text(flake).expect("parses");
+        let change = Change::Remove {
+            ids: vec![ChangeId::new(candidate.source.clone())],
+        };
+        let outcome = fe.apply_change(change).expect("apply succeeds");
+        let new_text = outcome.text.expect("walker rewrote the tree");
+
+        assert!(
+            !new_text.contains("flops"),
+            "depth-3 redundant follows should be removed, got:\n{new_text}"
+        );
+        assert!(
+            new_text.contains("omnibus.inputs.nixpkgs.follows = \"nixpkgs\""),
+            "load-bearing depth-1 follows must remain, got:\n{new_text}"
+        );
+    }
+}

--- a/src/follows/path.rs
+++ b/src/follows/path.rs
@@ -1,0 +1,636 @@
+//! [`Segment`] and [`AttrPath`]: typed attribute paths.
+//!
+//! [`Segment`] is a single attribute name. [`AttrPath`] is a non-empty
+//! sequence of them. Both store values unquoted. The `"..."` quotes Nix
+//! requires for names containing dots or leading digits live on the rendering
+//! boundary ([`fmt::Display`] / [`Segment::render`]).
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use smallvec::{SmallVec, smallvec};
+
+/// Strip a single outer pair of `"..."` from CST source text.
+///
+/// Returns the input unchanged when it is not bracketed by quotes.
+pub fn strip_outer_quotes(s: &str) -> &str {
+    s.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .unwrap_or(s)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Segment(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SegmentError {
+    Empty,
+    ContainsQuote,
+    ContainsControl,
+}
+
+impl fmt::Display for SegmentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SegmentError::Empty => write!(f, "segment must not be empty"),
+            SegmentError::ContainsQuote => {
+                write!(f, "segment must not contain an embedded double quote")
+            }
+            SegmentError::ContainsControl => {
+                write!(f, "segment must not contain control characters")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SegmentError {}
+
+impl Segment {
+    /// Construct from already-unquoted text.
+    ///
+    /// Rejects empty input, embedded `"`, and ASCII control characters.
+    /// Everything else (`.`, `+`, `/`, leading digits, hyphens, single quotes)
+    /// is accepted. [`Self::render`] decides whether to wrap in `"..."`.
+    pub fn from_unquoted(s: impl Into<String>) -> Result<Self, SegmentError> {
+        let s = s.into();
+        if s.is_empty() {
+            return Err(SegmentError::Empty);
+        }
+        if s.contains('"') {
+            return Err(SegmentError::ContainsQuote);
+        }
+        if s.chars().any(|c| c.is_control()) {
+            return Err(SegmentError::ContainsControl);
+        }
+        Ok(Segment(s))
+    }
+
+    /// Parse source-form text. Strips a single surrounding pair of `"..."`,
+    /// otherwise behaves like [`Self::from_unquoted`].
+    pub fn from_source(s: &str) -> Result<Self, SegmentError> {
+        let body = if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+            &s[1..s.len() - 1]
+        } else {
+            s
+        };
+        Segment::from_unquoted(body.to_string())
+    }
+
+    /// Build a [`Segment`] from a CST node's source text.
+    pub fn from_syntax(node: &rnix::SyntaxNode) -> Result<Self, SegmentError> {
+        Segment::from_source(&node.to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume the segment, returning the unquoted text.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    /// Whether this segment requires source-level `"..."` quoting.
+    ///
+    /// Bare Nix identifiers match `[a-zA-Z_][a-zA-Z0-9_'-]*`. Anything else
+    /// (leading digit, embedded `.`, leading `-`) needs quoting.
+    pub fn needs_quoting(&self) -> bool {
+        let mut chars = self.0.chars();
+        let Some(first) = chars.next() else {
+            return true;
+        };
+        if !(first.is_ascii_alphabetic() || first == '_') {
+            return true;
+        }
+        for c in chars {
+            if !(c.is_ascii_alphanumeric() || c == '_' || c == '\'' || c == '-') {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Render to source form, wrapping in `"..."` only when needed.
+    pub fn render(&self) -> String {
+        if self.needs_quoting() {
+            format!("\"{}\"", self.0)
+        } else {
+            self.0.clone()
+        }
+    }
+}
+
+impl fmt::Display for Segment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.render())
+    }
+}
+
+impl FromStr for Segment {
+    type Err = SegmentError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Segment::from_source(s)
+    }
+}
+
+impl Serialize for Segment {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Segment {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Segment::from_unquoted(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AttrPath(SmallVec<[Segment; 2]>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttrPathParseError {
+    Empty,
+    EmptySegment,
+    SegmentInvalid(SegmentError),
+}
+
+impl fmt::Display for AttrPathParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AttrPathParseError::Empty => write!(f, "attribute path must not be empty"),
+            AttrPathParseError::EmptySegment => write!(f, "attribute path has an empty segment"),
+            AttrPathParseError::SegmentInvalid(e) => write!(f, "invalid segment: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AttrPathParseError {}
+
+impl From<SegmentError> for AttrPathParseError {
+    fn from(value: SegmentError) -> Self {
+        AttrPathParseError::SegmentInvalid(value)
+    }
+}
+
+impl AttrPath {
+    pub fn new(first: Segment) -> Self {
+        AttrPath(smallvec![first])
+    }
+
+    /// Parse a dotted path, respecting `"..."` quoting on individual segments.
+    ///
+    /// Examples:
+    /// - `nixpkgs` → 1 segment.
+    /// - `crane.nixpkgs` → 2 segments.
+    /// - `"hls-1.10".nixpkgs` → 2 segments, the first stored unquoted.
+    /// - `a."b.c".d` → 3 segments.
+    pub fn parse(s: &str) -> Result<Self, AttrPathParseError> {
+        if s.is_empty() {
+            return Err(AttrPathParseError::Empty);
+        }
+        let mut segments: SmallVec<[Segment; 2]> = SmallVec::new();
+        let bytes = s.as_bytes();
+        let mut start = 0;
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'"' {
+                // Skip until matching closing quote.
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'"' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1; // skip closing quote
+                }
+            } else if bytes[i] == b'.' {
+                let raw = &s[start..i];
+                if raw.is_empty() {
+                    return Err(AttrPathParseError::EmptySegment);
+                }
+                segments.push(Segment::from_source(raw)?);
+                i += 1;
+                start = i;
+            } else {
+                i += 1;
+            }
+        }
+        let last = &s[start..];
+        if last.is_empty() {
+            return Err(AttrPathParseError::EmptySegment);
+        }
+        segments.push(Segment::from_source(last)?);
+        Ok(AttrPath(segments))
+    }
+
+    pub fn first(&self) -> &Segment {
+        &self.0[0]
+    }
+
+    pub fn last(&self) -> &Segment {
+        self.0.last().expect("AttrPath is non-empty by invariant")
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn segments(&self) -> &[Segment] {
+        &self.0
+    }
+
+    /// All segments except the last, or `None` for a length-1 path.
+    pub fn parent(&self) -> Option<AttrPath> {
+        if self.0.len() <= 1 {
+            return None;
+        }
+        let parent_segments: SmallVec<[Segment; 2]> =
+            self.0[..self.0.len() - 1].iter().cloned().collect();
+        Some(AttrPath(parent_segments))
+    }
+
+    /// The second segment, or `None` for length-1 paths.
+    pub fn child(&self) -> Option<&Segment> {
+        if self.0.len() >= 2 {
+            self.0.get(1)
+        } else {
+            None
+        }
+    }
+
+    pub fn push(&mut self, seg: Segment) {
+        self.0.push(seg);
+    }
+
+    /// Whether `self` is a structural prefix of `other`. A path is its own
+    /// prefix.
+    pub fn is_prefix_of(&self, other: &AttrPath) -> bool {
+        if self.0.len() > other.0.len() {
+            return false;
+        }
+        self.0.iter().zip(other.0.iter()).all(|(a, b)| a == b)
+    }
+
+    /// If `base` is a strict prefix of `self`, returns the suffix. Returns
+    /// `None` otherwise, including when the paths are equal.
+    pub fn relative_to(&self, base: &AttrPath) -> Option<AttrPath> {
+        if !base.is_prefix_of(self) || base.0.len() == self.0.len() {
+            return None;
+        }
+        let suffix: SmallVec<[Segment; 2]> = self.0[base.0.len()..].iter().cloned().collect();
+        Some(AttrPath(suffix))
+    }
+
+    /// Render as the `parent/child/grandchild` form used by lockfile
+    /// `follows = [...]` arrays: `/` separators, each segment unquoted.
+    pub fn to_flake_follows_string(&self) -> String {
+        self.0
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+}
+
+impl fmt::Display for AttrPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        for seg in &self.0 {
+            if !first {
+                f.write_str(".")?;
+            }
+            first = false;
+            f.write_str(&seg.render())?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for AttrPath {
+    type Err = AttrPathParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        AttrPath::parse(s)
+    }
+}
+
+impl From<Segment> for AttrPath {
+    fn from(value: Segment) -> Self {
+        AttrPath::new(value)
+    }
+}
+
+impl Serialize for AttrPath {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for AttrPath {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        AttrPath::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_from_unquoted_rejects_empty() {
+        assert_eq!(Segment::from_unquoted(""), Err(SegmentError::Empty));
+    }
+
+    #[test]
+    fn segment_from_unquoted_rejects_embedded_quote() {
+        assert_eq!(
+            Segment::from_unquoted("a\"b"),
+            Err(SegmentError::ContainsQuote)
+        );
+    }
+
+    #[test]
+    fn segment_from_unquoted_rejects_control() {
+        assert_eq!(
+            Segment::from_unquoted("a\nb"),
+            Err(SegmentError::ContainsControl)
+        );
+    }
+
+    #[test]
+    fn segment_from_unquoted_accepts_dotted() {
+        let s = Segment::from_unquoted("hls-1.10").unwrap();
+        assert_eq!(s.as_str(), "hls-1.10");
+    }
+
+    #[test]
+    fn segment_from_source_strips_quotes() {
+        let s = Segment::from_source("\"hls-1.10\"").unwrap();
+        assert_eq!(s.as_str(), "hls-1.10");
+    }
+
+    #[test]
+    fn segment_from_source_unquoted_passthrough() {
+        let s = Segment::from_source("nixpkgs").unwrap();
+        assert_eq!(s.as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn segment_from_syntax_via_rnix() {
+        // Build a tiny CST and route the first NODE_STRING through
+        // `from_syntax` to verify the round-trip.
+        let src = r#"{ inputs."hls-1.10".url = "x"; }"#;
+        let parsed = rnix::Root::parse(src);
+        let syntax = parsed.syntax();
+        fn find_string(node: rnix::SyntaxNode) -> Option<rnix::SyntaxNode> {
+            if node.kind() == rnix::SyntaxKind::NODE_STRING {
+                return Some(node);
+            }
+            for c in node.children() {
+                if let Some(s) = find_string(c) {
+                    return Some(s);
+                }
+            }
+            None
+        }
+        let string_node = find_string(syntax).expect("has a string node");
+        let seg = Segment::from_syntax(&string_node).unwrap();
+        // The first NODE_STRING in source order is "hls-1.10".
+        assert_eq!(seg.as_str(), "hls-1.10");
+    }
+
+    #[test]
+    fn segment_needs_quoting_boundaries() {
+        for bare in ["nixpkgs", "_x", "foo'bar"] {
+            assert!(
+                !Segment::from_unquoted(bare).unwrap().needs_quoting(),
+                "{bare} should be a bare ident",
+            );
+        }
+        for quoted in ["hls-1.10", "24.11", "-x"] {
+            assert!(
+                Segment::from_unquoted(quoted).unwrap().needs_quoting(),
+                "{quoted} should require quoting",
+            );
+        }
+    }
+
+    #[test]
+    fn segment_render_unquoted() {
+        let s = Segment::from_unquoted("nixpkgs").unwrap();
+        assert_eq!(s.render(), "nixpkgs");
+    }
+
+    #[test]
+    fn segment_render_quoted() {
+        let s = Segment::from_unquoted("hls-1.10").unwrap();
+        assert_eq!(s.render(), "\"hls-1.10\"");
+    }
+
+    #[test]
+    fn segment_display_matches_render() {
+        let s = Segment::from_unquoted("hls-1.10").unwrap();
+        assert_eq!(format!("{s}"), s.render());
+    }
+
+    #[test]
+    fn segment_from_str_uses_from_source() {
+        let s: Segment = "\"hls-1.10\"".parse().unwrap();
+        assert_eq!(s.as_str(), "hls-1.10");
+    }
+
+    #[test]
+    fn segment_serde_roundtrip_bare() {
+        let s = Segment::from_unquoted("nixpkgs").unwrap();
+        let j = serde_json::to_string(&s).unwrap();
+        assert_eq!(j, "\"nixpkgs\"");
+        let back: Segment = serde_json::from_str(&j).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn segment_serde_roundtrip_dotted() {
+        let s = Segment::from_unquoted("hls-1.10").unwrap();
+        let j = serde_json::to_string(&s).unwrap();
+        // Wire form has no embedded backslash-quote.
+        assert_eq!(j, "\"hls-1.10\"");
+        let back: Segment = serde_json::from_str(&j).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn attr_path_parse_single_segment() {
+        let p = AttrPath::parse("nixpkgs").unwrap();
+        assert_eq!(p.len(), 1);
+        assert_eq!(p.first().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_parse_two_segments() {
+        let p = AttrPath::parse("crane.nixpkgs").unwrap();
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.first().as_str(), "crane");
+        assert_eq!(p.last().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_parse_quoted_first() {
+        let p = AttrPath::parse("\"hls-1.10\".nixpkgs").unwrap();
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.first().as_str(), "hls-1.10");
+        assert_eq!(p.last().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_parse_three_segments_middle_quoted() {
+        let p = AttrPath::parse("a.\"b.c\".d").unwrap();
+        assert_eq!(p.len(), 3);
+        assert_eq!(p.segments()[0].as_str(), "a");
+        assert_eq!(p.segments()[1].as_str(), "b.c");
+        assert_eq!(p.segments()[2].as_str(), "d");
+    }
+
+    #[test]
+    fn attr_path_parse_empty_rejected() {
+        assert_eq!(AttrPath::parse(""), Err(AttrPathParseError::Empty));
+    }
+
+    #[test]
+    fn attr_path_parse_double_dot_rejected() {
+        assert_eq!(
+            AttrPath::parse("a..b"),
+            Err(AttrPathParseError::EmptySegment)
+        );
+    }
+
+    #[test]
+    fn attr_path_display_roundtrip() {
+        for s in ["crane.nixpkgs", "\"hls-1.10\".nixpkgs"] {
+            let p = AttrPath::parse(s).unwrap();
+            assert_eq!(format!("{p}"), s);
+        }
+    }
+
+    #[test]
+    fn attr_path_parent_none_for_single() {
+        let p = AttrPath::parse("nixpkgs").unwrap();
+        assert!(p.parent().is_none());
+    }
+
+    #[test]
+    fn attr_path_parent_some_for_two() {
+        let p = AttrPath::parse("crane.nixpkgs").unwrap();
+        let parent = p.parent().unwrap();
+        assert_eq!(parent.len(), 1);
+        assert_eq!(parent.first().as_str(), "crane");
+    }
+
+    #[test]
+    fn attr_path_child_returns_second_segment() {
+        let p = AttrPath::parse("crane.nixpkgs").unwrap();
+        assert_eq!(p.child().unwrap().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_child_none_for_single() {
+        let p = AttrPath::parse("crane").unwrap();
+        assert!(p.child().is_none());
+    }
+
+    #[test]
+    fn attr_path_push_extends() {
+        let mut p = AttrPath::parse("a").unwrap();
+        p.push(Segment::from_unquoted("b").unwrap());
+        assert_eq!(format!("{p}"), "a.b");
+    }
+
+    #[test]
+    fn attr_path_is_prefix_self() {
+        let p = AttrPath::parse("a.b").unwrap();
+        assert!(p.is_prefix_of(&p));
+    }
+
+    #[test]
+    fn attr_path_is_prefix_strict() {
+        let a = AttrPath::parse("a").unwrap();
+        let ab = AttrPath::parse("a.b").unwrap();
+        assert!(a.is_prefix_of(&ab));
+        assert!(!ab.is_prefix_of(&a));
+    }
+
+    #[test]
+    fn attr_path_is_prefix_diverging() {
+        let a = AttrPath::parse("a.x").unwrap();
+        let b = AttrPath::parse("a.y").unwrap();
+        assert!(!a.is_prefix_of(&b));
+    }
+
+    #[test]
+    fn attr_path_relative_to_strict_prefix() {
+        let base = AttrPath::parse("a").unwrap();
+        let path = AttrPath::parse("a.b.c").unwrap();
+        let rel = path.relative_to(&base).unwrap();
+        assert_eq!(format!("{rel}"), "b.c");
+    }
+
+    #[test]
+    fn attr_path_relative_to_equal_returns_none() {
+        let p = AttrPath::parse("a.b").unwrap();
+        assert!(p.relative_to(&p).is_none());
+    }
+
+    #[test]
+    fn attr_path_relative_to_non_prefix_returns_none() {
+        let base = AttrPath::parse("c").unwrap();
+        let path = AttrPath::parse("a.b").unwrap();
+        assert!(path.relative_to(&base).is_none());
+    }
+
+    #[test]
+    fn attr_path_from_segment() {
+        let s = Segment::from_unquoted("nixpkgs").unwrap();
+        let p: AttrPath = s.clone().into();
+        assert_eq!(p.len(), 1);
+        assert_eq!(p.first(), &s);
+    }
+
+    #[test]
+    fn attr_path_from_str_parses() {
+        let p: AttrPath = "crane.nixpkgs".parse().unwrap();
+        assert_eq!(p.len(), 2);
+    }
+
+    #[test]
+    fn attr_path_serde_roundtrip() {
+        let p = AttrPath::parse("\"hls-1.10\".nixpkgs").unwrap();
+        let j = serde_json::to_string(&p).unwrap();
+        // Wire form is the canonical Display output (quoted as needed).
+        assert_eq!(j, "\"\\\"hls-1.10\\\".nixpkgs\"");
+        let back: AttrPath = serde_json::from_str(&j).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn attr_path_to_flake_follows_string_simple() {
+        let p = AttrPath::parse("nixpkgs").unwrap();
+        assert_eq!(p.to_flake_follows_string(), "nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_to_flake_follows_string_two_segments() {
+        let p = AttrPath::parse("crane.nixpkgs").unwrap();
+        assert_eq!(p.to_flake_follows_string(), "crane/nixpkgs");
+    }
+
+    #[test]
+    fn attr_path_to_flake_follows_string_dotted_segment_preserved() {
+        let p = AttrPath::parse("\"hls-1.10\".nixpkgs").unwrap();
+        // Dot inside a segment must NOT become a slash.
+        assert_eq!(p.to_flake_follows_string(), "hls-1.10/nixpkgs");
+    }
+}

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,16 +1,20 @@
 use rnix::TextRange;
-use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
+use crate::follows::{AttrPath, Segment, strip_outer_quotes};
+
+/// A single flake input declaration.
+#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct Input {
-    pub(crate) id: String,
+    pub(crate) id: Segment,
     pub(crate) flake: bool,
+    /// Stored unquoted. Quoting is re-applied at write-back time.
     pub(crate) url: String,
     pub(crate) follows: Vec<Follows>,
     pub range: Range,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
+/// Source byte range, half-open: `[start, end)`.
+#[derive(Debug, Default, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub struct Range {
     pub start: usize,
     pub end: usize,
@@ -24,62 +28,66 @@ impl Range {
         }
     }
 
+    /// True if the range is the default (zero) range, used as a sentinel for
+    /// inputs without a write-back location.
     pub fn is_empty(&self) -> bool {
         self.start == 0 && self.end == 0
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Hash, Eq, Deserialize, Serialize, PartialOrd, Ord)]
+/// A `follows` declaration on an [`Input`].
+#[derive(Debug, Clone, PartialEq, Hash, Eq, PartialOrd, Ord)]
 pub enum Follows {
-    // From , To
-    Indirect(String, String),
-    // From , To
+    /// A nested input redirected to another input via `follows = "..."`.
+    ///
+    /// `path` is the nested-input chain relative to the owning [`Input`] and
+    /// does not include the owner's id segment. `target` is the right-hand
+    /// side of the `follows = "..."`; `None` represents the empty-string
+    /// form `follows = ""`, the in-flake equivalent of the lockfile's
+    /// [`crate::lock::Input::Indirect`]`(None)` (an `inputs.X = []` entry).
+    ///
+    /// - `inputs.crane.inputs.nixpkgs.follows = "nixpkgs"` is stored on
+    ///   `crane` as `Indirect { path: ["nixpkgs"], target: Some(["nixpkgs"]) }`.
+    /// - `inputs.neovim.inputs.nixvim.inputs.flake-parts.follows =
+    ///   "flake-parts"` is stored on `neovim` as `Indirect { path:
+    ///   ["nixvim", "flake-parts"], target: Some(["flake-parts"]) }`.
+    /// - `inputs.nix.inputs.flake-compat.follows = ""` is stored on `nix`
+    ///   as `Indirect { path: ["flake-compat"], target: None }`.
+    Indirect {
+        path: AttrPath,
+        target: Option<AttrPath>,
+    },
+    /// A nested input declared inline with its own URL.
     Direct(String, Input),
 }
 
-impl Default for Input {
-    fn default() -> Self {
+impl Input {
+    pub(crate) fn new(name: Segment) -> Self {
         Self {
-            id: String::new(),
+            id: name,
             flake: true,
             url: String::new(),
-            follows: vec![],
+            follows: Vec::new(),
             range: Range::default(),
         }
     }
-}
 
-impl Input {
-    pub(crate) fn new(name: String) -> Self {
-        Self {
-            id: name,
-            ..Self::default()
-        }
-    }
-
-    /// Create an Input with id, url, and range set from a TextRange.
-    pub(crate) fn with_url(id: String, url: String, text_range: TextRange) -> Self {
+    /// Build an [`Input`] with `id`, `url`, and the range derived from
+    /// `text_range`. Surrounding double-quotes on `url` are stripped.
+    pub(crate) fn with_url(id: Segment, url: String, text_range: TextRange) -> Self {
         Self {
             id,
-            url,
+            flake: true,
+            url: strip_outer_quotes(&url).to_string(),
+            follows: Vec::new(),
             range: Range::from_text_range(text_range),
-            ..Self::default()
         }
     }
 
-    pub fn id(&self) -> &str {
-        self.id.as_ref()
+    pub fn id(&self) -> &Segment {
+        &self.id
     }
-    /// Return the id with surrounding double-quotes stripped.
-    ///
-    /// AST-extracted identifiers preserve Nix quoting (e.g. `"nixpkgs-24.11"`),
-    /// but user-facing output and comparisons need the bare name.
-    pub fn bare_id(&self) -> &str {
-        self.id
-            .strip_prefix('"')
-            .and_then(|s| s.strip_suffix('"'))
-            .unwrap_or(&self.id)
-    }
+
     pub fn url(&self) -> &str {
         self.url.as_ref()
     }
@@ -87,7 +95,19 @@ impl Input {
         self.follows.as_ref()
     }
 
+    /// True if the URL can be rewritten in place. False for synthetic inputs
+    /// without a known source range.
     pub fn has_editable_url(&self) -> bool {
         !self.url.is_empty() && !self.range.is_empty()
+    }
+
+    /// Append an `Indirect` follows entry and re-normalize the follows vec
+    /// (sort + dedup). Walker insertion sites maintain this invariant so
+    /// callers downstream (validate, follows-graph, snapshots) see one
+    /// canonical ordering.
+    pub(crate) fn push_indirect_follows(&mut self, path: AttrPath, target: Option<AttrPath>) {
+        self.follows.push(Follows::Indirect { path, target });
+        self.follows.sort();
+        self.follows.dedup();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,24 @@
+//! Edit Nix flake inputs from Rust.
+//!
+//! [`edit::FlakeEdit`] is the entry point: build one with
+//! [`edit::FlakeEdit::from_text`], queue or apply [`change::Change`]s, and read
+//! back the new source via [`edit::FlakeEdit::source_text`] or
+//! [`edit::ApplyOutcome`].
+//!
+//! Supporting modules:
+//! - [`walk`] traverses the `rnix` CST and applies edits.
+//! - [`input`] models a flake input and its [`input::Follows`] declarations.
+//! - [`lock`] parses `flake.lock` for revs, follows targets, and nested input
+//!   discovery via [`lock::FlakeLock::nested_inputs`].
+//! - [`update`] handles version pins, channel updates, and remote tag lookup
+//!   (paired with [`api`], [`channel`], [`version`]).
+//! - [`config`] loads `flake-edit.toml`.
+//! - [`cache`] persists URI completion state.
+//! - [`validate`] runs pre-edit lint passes. [`error::FlakeEditError`] is the
+//!   crate-wide error.
+//!
+//! Feature flags: `tui` enables [`app`] and [`tui`], `diff` enables [`diff`].
+
 pub mod api;
 #[cfg(feature = "tui")]
 pub mod app;
@@ -10,6 +31,7 @@ pub mod config;
 pub mod diff;
 pub mod edit;
 pub mod error;
+pub mod follows;
 pub mod input;
 pub mod lock;
 pub mod state;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,41 +1,48 @@
 use crate::error::FlakeEditError;
-use serde::{Deserialize, Serialize};
+use crate::follows::{AttrPath, Segment};
+use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-/// A nested input path with optional existing follows target.
+/// A nested input discovered in `flake.lock` with its existing follows
+/// target, if any.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NestedInput {
-    /// The path to the nested input (e.g., "crane.nixpkgs")
-    pub path: String,
-    /// The target this input follows, if any (e.g., "nixpkgs")
-    pub follows: Option<String>,
-    /// The original flake URL for Direct references (e.g., "github:nixos/nixpkgs/nixos-unstable")
+    /// Dotted path to the nested input (e.g. `crane.nixpkgs`).
+    pub path: AttrPath,
+    /// Existing follows target, if the input is redirected.
+    pub follows: Option<AttrPath>,
+    /// Original flake URL for `Direct` references (e.g.
+    /// `github:nixos/nixpkgs/nixos-unstable`). `None` for follows-only
+    /// references.
     pub url: Option<String>,
 }
 
 impl NestedInput {
-    /// Format for display: "path\tfollows_target" or just "path".
-    /// The tab separator allows the UI to parse and style the parts differently.
+    /// Render as `path\tfollows_target` (or just `path` when the input has no
+    /// follows target). The tab separator lets the UI style each side
+    /// independently.
     pub fn to_display_string(&self) -> String {
         match &self.follows {
             Some(target) => format!("{}\t{}", self.path, target),
-            None => self.path.clone(),
+            None => self.path.to_string(),
         }
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+/// Parsed `flake.lock`. Loaded with [`Self::from_default_path`],
+/// [`Self::from_file`], or [`Self::read_from_str`].
+#[derive(Debug, Deserialize)]
 pub struct FlakeLock {
     nodes: HashMap<String, Node>,
     root: String,
-    version: u8,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Node {
+/// A single entry in the lockfile's `nodes` map.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Node {
     inputs: Option<HashMap<String, Input>>,
     locked: Option<Locked>,
     original: Option<Original>,
@@ -50,34 +57,98 @@ impl Node {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(untagged)]
+/// Reference from a node's `inputs` map.
+///
+/// Lockfile shape:
+/// - `"name"` is a direct reference to another node, parsed as
+///   [`Self::Direct`].
+/// - `["a", "b", ...]` is a follows path with a target, parsed as
+///   `Indirect(Some(path))`.
+/// - `[]` is a follows declaration with no target (Nix emits this when an
+///   upstream chain has overridden the input to nothing, e.g. a lockfile
+///   whose source `flake.nix` carries
+///   `nix.inputs.flake-compat.follows = "";`), parsed as `Indirect(None)`.
+#[derive(Debug, Clone)]
 pub enum Input {
     Direct(String),
-    Indirect(Vec<String>),
+    Indirect(Option<AttrPath>),
 }
 
 impl Input {
-    /// Get the target node name for this input.
-    /// For Direct inputs, returns the node name directly.
-    /// For Indirect inputs (follows paths), returns the final target in the path.
+    /// Target node name. For [`Self::Direct`], the wrapped name. For
+    /// `Indirect(Some(path))`, the last segment of the follows path. For
+    /// `Indirect(None)` (empty `[]` in the lockfile), an empty string.
+    /// Resolution paths in [`FlakeLock`] are built from validated
+    /// [`AttrPath`] segments and can never contain `""`, so a lookup on
+    /// this id falls through to a [`FlakeEditError::LockError`].
     fn id(&self) -> String {
         match self {
             Input::Direct(id) => id.to_string(),
-            Input::Indirect(path) => path.last().cloned().unwrap_or_default(),
+            Input::Indirect(Some(path)) => path.last().as_str().to_string(),
+            Input::Indirect(None) => String::new(),
         }
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Locked {
-    owner: Option<String>,
-    repo: Option<String>,
+impl<'de> Deserialize<'de> for Input {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{Error, SeqAccess, Visitor};
+        use std::fmt;
+
+        struct InputVisitor;
+
+        impl<'de> Visitor<'de> for InputVisitor {
+            type Value = Input;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str(
+                    "a node name string, an empty array, or an array of \
+                     non-empty segment names",
+                )
+            }
+
+            fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(Input::Direct(v.to_string()))
+            }
+
+            fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
+                Ok(Input::Direct(v))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                // Empty `[]` is a real lockfile shape: `inputs.X = []`
+                // marks an input whose follows chain has been overridden
+                // away. Surface it as `Indirect(None)` instead of an
+                // error.
+                let Some(first) = seq.next_element::<String>()? else {
+                    return Ok(Input::Indirect(None));
+                };
+                let first_seg = Segment::from_unquoted(first).map_err(A::Error::custom)?;
+                let mut path = AttrPath::new(first_seg);
+                while let Some(raw) = seq.next_element::<String>()? {
+                    let seg = Segment::from_unquoted(raw).map_err(A::Error::custom)?;
+                    path.push(seg);
+                }
+                Ok(Input::Indirect(Some(path)))
+            }
+        }
+
+        deserializer.deserialize_any(InputVisitor)
+    }
+}
+
+/// Locked metadata for a node. Only [`Self::rev`] is consumed by the rest
+/// of the crate; other coordinates from the JSON (`owner`, `repo`, `type`,
+/// `ref`, `narHash`, ...) are ignored on parse.
+#[derive(Debug, Deserialize, Clone)]
+pub(crate) struct Locked {
     rev: Option<String>,
-    #[serde(rename = "type")]
-    node_type: String,
-    #[serde(rename = "ref")]
-    ref_field: Option<String>,
 }
 
 impl Locked {
@@ -88,8 +159,9 @@ impl Locked {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Original {
+/// Original (pre-lock) reference for a node, as written in the source flake.
+#[derive(Debug, Deserialize)]
+pub(crate) struct Original {
     owner: Option<String>,
     repo: Option<String>,
     #[serde(rename = "type")]
@@ -100,8 +172,10 @@ pub struct Original {
 }
 
 impl Original {
-    /// Reconstruct a flake URL from the original reference.
-    pub fn to_flake_url(&self) -> Option<String> {
+    /// Reconstruct a flake URL from the original reference. Returns `None`
+    /// when the type is forge-shaped (`github`, `gitlab`, `sourcehut`) but
+    /// `owner` or `repo` is missing.
+    fn to_flake_url(&self) -> Option<String> {
         match self.node_type.as_str() {
             "github" | "gitlab" | "sourcehut" => {
                 let owner = self.owner.as_deref()?;
@@ -121,54 +195,31 @@ impl Original {
 impl FlakeLock {
     const LOCK: &'static str = "flake.lock";
 
+    /// Load `flake.lock` from the current directory.
     pub fn from_default_path() -> Result<Self, FlakeEditError> {
         let path = PathBuf::from(Self::LOCK);
         Self::from_file(path)
     }
 
+    /// Load and parse a lockfile from `path`.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, FlakeEditError> {
         let mut file = File::open(path)?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
         Self::read_from_str(&contents)
     }
+
+    /// Parse lockfile JSON from `str`.
     pub fn read_from_str(str: &str) -> Result<Self, FlakeEditError> {
         Ok(serde_json::from_str(str)?)
     }
+
+    /// Name of the root node.
     pub fn root(&self) -> &str {
         &self.root
     }
-    /// Split an input path into segments, respecting quoted names.
-    /// E.g. `"hls-1.10".nixpkgs` -> `["hls-1.10", "nixpkgs"]`
-    /// E.g. `browseros.nixpkgs` -> `["browseros", "nixpkgs"]`
-    fn split_input_path(path: &str) -> Vec<&str> {
-        let mut segments = Vec::new();
-        let mut rest = path;
-        while !rest.is_empty() {
-            if rest.starts_with('"') {
-                // Quoted segment: find closing quote
-                if let Some(end) = rest[1..].find('"') {
-                    segments.push(&rest[1..end + 1]);
-                    rest = &rest[end + 2..];
-                    // Skip the dot separator if present
-                    rest = rest.strip_prefix('.').unwrap_or(rest);
-                } else {
-                    // Malformed: no closing quote, treat rest as one segment
-                    segments.push(rest.trim_matches('"'));
-                    break;
-                }
-            } else if let Some(dot) = rest.find('.') {
-                segments.push(&rest[..dot]);
-                rest = &rest[dot + 1..];
-            } else {
-                segments.push(rest);
-                break;
-            }
-        }
-        segments
-    }
 
-    /// Resolve an input path to a node name by walking the lock tree.
+    /// Resolve a dotted input path to a node name by walking the lock tree.
     fn resolve_input_path(&self, segments: &[&str]) -> Result<String, FlakeEditError> {
         let mut current_node = self
             .nodes
@@ -197,7 +248,6 @@ impl FlakeLock {
             let node_name = resolved.id();
 
             if i < segments.len() - 1 {
-                // Intermediate segment: move to the next node
                 current_node = self.nodes.get(&node_name).ok_or_else(|| {
                     FlakeEditError::LockError(format!(
                         "Could not find node '{}' for input '{}'.",
@@ -206,7 +256,6 @@ impl FlakeLock {
                     ))
                 })?;
             } else {
-                // Final segment: return the node name
                 return Ok(node_name);
             }
         }
@@ -214,87 +263,139 @@ impl FlakeLock {
         Err(FlakeEditError::LockError("Empty input path.".into()))
     }
 
-    /// Query the lock file for a specific rev.
+    /// Resolve `id` (a dotted attribute path) to its locked revision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlakeEditError::LockError`] if `id` is malformed or does not
+    /// resolve to a node with a `rev` field.
     pub fn rev_for(&self, id: &str) -> Result<String, FlakeEditError> {
-        let segments = Self::split_input_path(id);
-        let node_name = self.resolve_input_path(&segments)?;
+        let path = AttrPath::parse(id)
+            .map_err(|e| FlakeEditError::LockError(format!("Invalid input path '{id}': {e}")))?;
+        let owned: Vec<&str> = path.segments().iter().map(|s| s.as_str()).collect();
+        let node_name = self.resolve_input_path(&owned)?;
         let node = self.nodes.get(&node_name).ok_or_else(|| {
             FlakeEditError::LockError(format!("Could not find node '{node_name}'."))
         })?;
         node.rev()
     }
 
-    /// Get all nested input paths for shell completions.
-    /// Returns paths like "naersk.nixpkgs", "naersk.flake-utils", etc.
+    /// Rendered nested input paths (e.g. `naersk.nixpkgs`,
+    /// `naersk.flake-utils`) suitable for shell completion.
     pub fn nested_input_paths(&self) -> Vec<String> {
         self.nested_inputs()
             .into_iter()
-            .map(|input| input.path)
+            .map(|input| input.path.to_string())
             .collect()
     }
 
-    /// Get all nested inputs with their existing follows targets.
+    /// All nested inputs reachable from the root, with their existing
+    /// follows targets.
+    ///
+    /// Walks `flake.lock` recursively from the root, emitting one entry per
+    /// `inputs.X` on any descendant node and building the path
+    /// segment-by-segment. Capped at [`NESTED_INPUTS_MAX_DEPTH`]. Cycles in
+    /// the node graph are broken by a visited set keyed on node name.
+    ///
+    /// Output is sorted by path for stable emission order.
     pub fn nested_inputs(&self) -> Vec<NestedInput> {
         let mut inputs = Vec::new();
-
-        // Get the root node
         let Some(root_node) = self.nodes.get(&self.root) else {
             return inputs;
         };
-
-        // Get top-level inputs from root
         let Some(root_inputs) = &root_node.inputs else {
             return inputs;
         };
 
-        // For each top-level input, find its nested inputs
         for (top_level_name, top_level_ref) in root_inputs {
-            // Resolve the node name (could be different from input name)
             let node_name = match top_level_ref {
                 Input::Direct(name) => name.clone(),
-                Input::Indirect(_) => {
-                    // For indirect inputs (follows), skip - they don't have their own inputs
-                    continue;
-                }
+                // Indirect top-level inputs have no sub-inputs to descend
+                // into. Their follows edges still appear via the recursive
+                // walker on the `Direct` siblings that own them.
+                Input::Indirect(_) => continue,
             };
-
-            // Get the node for this input
-            if let Some(node) = self.nodes.get(&node_name) {
-                // Get nested inputs of this node
-                if let Some(nested_inputs) = &node.inputs {
-                    for (nested_name, nested_ref) in nested_inputs {
-                        let quoted_parent = if top_level_name.contains('.') {
-                            format!("\"{}\"", top_level_name)
-                        } else {
-                            top_level_name.clone()
-                        };
-                        let quoted_nested = if nested_name.contains('.') {
-                            format!("\"{}\"", nested_name)
-                        } else {
-                            nested_name.clone()
-                        };
-                        let path = format!("{}.{}", quoted_parent, quoted_nested);
-                        let (follows, url) = match nested_ref {
-                            Input::Indirect(targets) => (Some(targets.join(".")), None),
-                            Input::Direct(node_name) => {
-                                let url = self
-                                    .nodes
-                                    .get(node_name.as_str())
-                                    .and_then(|n| n.original.as_ref())
-                                    .and_then(|o| o.to_flake_url());
-                                (None, url)
-                            }
-                        };
-                        inputs.push(NestedInput { path, follows, url });
-                    }
-                }
-            }
+            let Ok(parent_seg) = Segment::from_unquoted(top_level_name.clone()) else {
+                continue;
+            };
+            let path = AttrPath::new(parent_seg);
+            let mut visited: HashMap<String, ()> = HashMap::new();
+            visited.insert(node_name.clone(), ());
+            self.collect_nested_inputs_recursive(&node_name, &path, 1, &mut visited, &mut inputs);
         }
 
         inputs.sort_by(|a, b| a.path.cmp(&b.path));
         inputs
     }
+
+    /// Descend through `node_name`, emitting one [`NestedInput`] per declared
+    /// sub-input up to [`NESTED_INPUTS_MAX_DEPTH`].
+    fn collect_nested_inputs_recursive(
+        &self,
+        node_name: &str,
+        parent_path: &AttrPath,
+        depth: usize,
+        visited: &mut HashMap<String, ()>,
+        out: &mut Vec<NestedInput>,
+    ) {
+        if depth >= NESTED_INPUTS_MAX_DEPTH {
+            return;
+        }
+        let Some(node) = self.nodes.get(node_name) else {
+            return;
+        };
+        let Some(node_inputs) = &node.inputs else {
+            return;
+        };
+
+        // Iterate sub-inputs in lex order so emission is deterministic.
+        let mut keys: Vec<&String> = node_inputs.keys().collect();
+        keys.sort();
+        for nested_name in keys {
+            let nested_ref = node_inputs.get(nested_name).unwrap();
+            let Ok(nested_seg) = Segment::from_unquoted(nested_name.clone()) else {
+                continue;
+            };
+            let mut path = parent_path.clone();
+            path.push(nested_seg);
+
+            let (follows, url, descend_into) = match nested_ref {
+                Input::Indirect(Some(target)) => (Some(target.clone()), None, None),
+                // Empty `[]` declarations have no follows target. Emit
+                // the input with `follows: None` so the path is still
+                // visible to the UI.
+                Input::Indirect(None) => (None, None, None),
+                Input::Direct(child_node_name) => {
+                    let url = self
+                        .nodes
+                        .get(child_node_name.as_str())
+                        .and_then(|n| n.original.as_ref())
+                        .and_then(|o| o.to_flake_url());
+                    (None, url, Some(child_node_name.clone()))
+                }
+            };
+
+            out.push(NestedInput {
+                path: path.clone(),
+                follows,
+                url,
+            });
+
+            if let Some(child) = descend_into {
+                if visited.contains_key(&child) {
+                    continue;
+                }
+                visited.insert(child.clone(), ());
+                self.collect_nested_inputs_recursive(&child, &path, depth + 1, visited, out);
+                visited.remove(&child);
+            }
+        }
+    }
 }
+
+/// Maximum recursion depth for [`FlakeLock::nested_inputs`]. Backstops
+/// pathological cycles in malformed lockfiles.
+pub const NESTED_INPUTS_MAX_DEPTH: usize = 64;
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,12 +556,17 @@ mod tests {
         let minimal_lock = minimal_lock();
         FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
     }
+    /// The lockfile's top-level `"version"` field is not validated. A
+    /// wildly unsupported version (e.g. `99`) must still parse cleanly
+    /// so this crate can read whatever shape Nix produces.
     #[test]
-    fn parse_minimal_version() {
-        let minimal_lock = minimal_lock();
-        let parsed_lock =
-            FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
-        assert_eq!(7, parsed_lock.version);
+    fn parse_ignores_unknown_version() {
+        let lock = r#"{
+  "nodes": { "root": { "inputs": {} } },
+  "root": "root",
+  "version": 99
+}"#;
+        FlakeLock::read_from_str(lock).expect("unknown version must still parse");
     }
     #[test]
     fn parse_minimal_root() {
@@ -506,14 +612,23 @@ mod tests {
 
     #[test]
     fn input_indirect_id() {
-        // Follows path like ["nixpkgs"] should return "nixpkgs"
-        let input = Input::Indirect(vec!["nixpkgs".to_string()]);
+        let input = Input::Indirect(Some(AttrPath::new(
+            Segment::from_unquoted("nixpkgs").unwrap(),
+        )));
         assert_eq!("nixpkgs", input.id());
+    }
+
+    /// `Indirect(None)` (empty `[]` in the lockfile) reports an empty
+    /// `id()`, and a resolution lookup that hits `""` produces a
+    /// [`FlakeEditError::LockError`] rather than a panic.
+    #[test]
+    fn input_indirect_none_id_is_empty() {
+        let input = Input::Indirect(None);
+        assert_eq!("", input.id());
     }
 
     #[test]
     fn rev_for_sub_input_path_missing_parent_returns_error() {
-        // Sub-input paths where the parent doesn't exist should error.
         let minimal_lock = minimal_lock();
         let parsed_lock =
             FlakeLock::read_from_str(minimal_lock).expect("Should be parsed correctly.");
@@ -522,7 +637,6 @@ mod tests {
 
     #[test]
     fn rev_for_sub_input_path_resolves() {
-        // Sub-input paths like "treefmt-nix.nixpkgs" should traverse the lock tree.
         let lock = minimal_independent_lock_no_overrides();
         let parsed = FlakeLock::read_from_str(lock).expect("Should be parsed correctly.");
         assert_eq!(
@@ -535,7 +649,6 @@ mod tests {
 
     #[test]
     fn rev_for_sub_input_follows_resolves() {
-        // Sub-input that follows the root input should resolve to the same rev.
         let lock = minimal_independent_lock_nixpkgs_overridden();
         let parsed = FlakeLock::read_from_str(lock).expect("Should be parsed correctly.");
         assert_eq!(
@@ -561,7 +674,6 @@ mod tests {
 
     #[test]
     fn rev_for_node_without_locked_returns_error() {
-        // A node that exists but has no "locked" field should error, not panic.
         let lock = r#"{
   "nodes": {
     "root": {
@@ -580,7 +692,6 @@ mod tests {
 
     #[test]
     fn rev_for_node_without_rev_returns_error() {
-        // A locked node without a "rev" field should error, not panic.
         let lock = r#"{
   "nodes": {
     "root": {
@@ -600,7 +711,6 @@ mod tests {
 
     #[test]
     fn nested_input_path_quotes_dots() {
-        // Input names with dots should be quoted in the path
         let lock = r#"{
   "nodes": {
     "hls-1.10": {
@@ -627,12 +737,89 @@ mod tests {
         let parsed = FlakeLock::read_from_str(lock).unwrap();
         let nested = parsed.nested_inputs();
         assert_eq!(nested.len(), 1);
-        assert_eq!(nested[0].path, "\"hls-1.10\".nixpkgs");
+        assert_eq!(nested[0].path.to_string(), "\"hls-1.10\".nixpkgs");
+    }
+
+    #[test]
+    fn nested_inputs_recurses_to_grandchild() {
+        // The walker descends through `Direct` children, so a depth-2
+        // nested input (root → neovim → nixvim → flake-parts) must be
+        // emitted with a 3-segment path. This exercises the recursive
+        // path-stack code in `collect_nested_inputs_recursive`.
+        let lock = r#"{
+  "nodes": {
+    "flake-parts": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "a", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "flake-parts_2": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "b", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "neovim": {
+      "inputs": { "nixvim": "nixvim" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "c", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nixvim": {
+      "inputs": { "flake-parts": "flake-parts_2" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "d", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "flake-parts": "flake-parts", "neovim": "neovim" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let parsed = FlakeLock::read_from_str(lock).unwrap();
+        let nested = parsed.nested_inputs();
+        let paths: Vec<String> = nested.iter().map(|n| n.path.to_string()).collect();
+        assert!(
+            paths.contains(&"neovim.nixvim".to_string()),
+            "depth-1 path missing, got: {paths:?}"
+        );
+        assert!(
+            paths.contains(&"neovim.nixvim.flake-parts".to_string()),
+            "depth-2 path missing, got: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn nested_inputs_terminates_on_cyclic_lockfile() {
+        // A pathological lock graph where node A's input recurses back
+        // into A itself must not loop forever. The visited-set in
+        // `collect_nested_inputs_recursive` short-circuits the cycle.
+        let lock = r#"{
+  "nodes": {
+    "a": {
+      "inputs": { "b": "b" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "a", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "b": {
+      "inputs": { "a": "a" },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "b", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": { "inputs": { "a": "a" } }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let parsed = FlakeLock::read_from_str(lock).unwrap();
+        let nested = parsed.nested_inputs();
+        assert!(!nested.is_empty());
+        assert!(
+            nested
+                .iter()
+                .all(|n| n.path.len() <= NESTED_INPUTS_MAX_DEPTH)
+        );
     }
 
     #[test]
     fn rev_for_quoted_sub_input_path() {
-        // Quoted input names with dots like "hls-1.10".nixpkgs should resolve
         let lock = r#"{
   "nodes": {
     "hls-1.10": {
@@ -664,24 +851,190 @@ mod tests {
         );
     }
 
-    #[test]
-    fn split_input_path_simple() {
-        assert_eq!(FlakeLock::split_input_path("nixpkgs"), vec!["nixpkgs"]);
+    /// Walk every `inputs` map and collect each `Indirect` follows target as
+    /// a vector of segment strings. Used by the fixture parse tests below.
+    fn collect_indirect_targets(lock: &FlakeLock) -> Vec<(String, String, Vec<String>)> {
+        let mut out: Vec<(String, String, Vec<String>)> = Vec::new();
+        for (node_name, node) in &lock.nodes {
+            let Some(inputs) = node.inputs.as_ref() else {
+                continue;
+            };
+            for (input_name, input_ref) in inputs {
+                if let Input::Indirect(Some(path)) = input_ref {
+                    let segs: Vec<String> = path
+                        .segments()
+                        .iter()
+                        .map(|s| s.as_str().to_string())
+                        .collect();
+                    out.push((node_name.clone(), input_name.clone(), segs));
+                }
+            }
+        }
+        out.sort();
+        out
     }
 
+    /// `depth_upstream_redundant_depth3.flake.lock` has three `Indirect`
+    /// entries forming the upstream-propagation chain: `omnibus.nixpkgs`
+    /// follows `["nixpkgs"]`, the depth-2 follows `["omnibus", "nixpkgs"]`,
+    /// and the depth-3 follows `["omnibus", "flops", "nixpkgs"]`.
     #[test]
-    fn split_input_path_dotted() {
+    fn fixture_depth_upstream_redundant_depth3_parses_indirects() {
+        let lock_text =
+            std::fs::read_to_string("tests/fixtures/depth_upstream_redundant_depth3.flake.lock")
+                .expect("fixture present");
+        let lock = FlakeLock::read_from_str(&lock_text).expect("fixture parses");
+        let mut segs_only: Vec<Vec<String>> = collect_indirect_targets(&lock)
+            .into_iter()
+            .map(|(_, _, segs)| segs)
+            .collect();
+        segs_only.sort();
         assert_eq!(
-            FlakeLock::split_input_path("treefmt-nix.nixpkgs"),
-            vec!["treefmt-nix", "nixpkgs"]
+            segs_only,
+            vec![
+                vec!["nixpkgs".to_string()],
+                vec![
+                    "omnibus".to_string(),
+                    "flops".to_string(),
+                    "nixpkgs".to_string()
+                ],
+                vec!["omnibus".to_string(), "nixpkgs".to_string()],
+            ],
+            "Indirect entries must be decoded with their full structural depth",
         );
     }
 
+    /// `depth_upstream_partial.flake.lock` covers a deeper mix of Indirect
+    /// shapes; verify each one is decoded into a non-empty `AttrPath` whose
+    /// segments are valid Nix names (no embedded quotes / control chars).
     #[test]
-    fn split_input_path_quoted() {
+    fn fixture_depth_upstream_partial_parses_indirects() {
+        let lock_text = std::fs::read_to_string("tests/fixtures/depth_upstream_partial.flake.lock")
+            .expect("fixture present");
+        let lock = FlakeLock::read_from_str(&lock_text).expect("fixture parses");
+        let entries = collect_indirect_targets(&lock);
+        assert!(
+            entries.len() >= 3,
+            "fixture has at least three Indirect arrays, got {}",
+            entries.len()
+        );
+        for (node, input, segs) in &entries {
+            assert!(
+                !segs.is_empty(),
+                "{node}.{input}: Indirect path must be non-empty",
+            );
+            for seg in segs {
+                assert!(
+                    !seg.is_empty() && !seg.contains('"'),
+                    "{node}.{input}: segment `{seg}` must be a valid Nix name",
+                );
+            }
+        }
+    }
+
+    /// `dot_ancestor_cycle.flake.lock` exercises the dotted-segment case:
+    /// the lockfile node `hls-1.10` is reachable through the typed
+    /// `AttrPath`, even though a literal dot in the segment forces source-
+    /// form quoting at the `flake.nix` boundary.
+    #[test]
+    fn fixture_dot_ancestor_cycle_parses_indirects_with_dotted_node() {
+        let lock_text = std::fs::read_to_string("tests/fixtures/dot_ancestor_cycle.flake.lock")
+            .expect("fixture present");
+        let lock = FlakeLock::read_from_str(&lock_text).expect("fixture parses");
+        // Direct walk: the dotted node `hls-1.10` exists and its
+        // `Indirect` `["helper"]` entry is decoded as a one-segment path.
+        let hls = lock.nodes.get("hls-1.10").expect("hls-1.10 node");
+        let inputs = hls.inputs.as_ref().expect("hls-1.10 has inputs");
+        match inputs.get("helper").expect("helper input present") {
+            Input::Indirect(Some(path)) => {
+                let segs: Vec<&str> = path.segments().iter().map(|s| s.as_str()).collect();
+                assert_eq!(segs, vec!["helper"]);
+            }
+            Input::Indirect(None) => panic!("expected Indirect(Some), got Indirect(None)"),
+            Input::Direct(name) => panic!("expected Indirect, got Direct({name})"),
+        }
+    }
+
+    /// Empty `[]` follows arrays mark an input whose follows chain has
+    /// been overridden away (e.g. a lockfile entry `inputs.flake-compat
+    /// = []`). The deserializer must accept them and store them as
+    /// `Indirect(None)`.
+    #[test]
+    fn indirect_empty_array_is_accepted_as_none() {
+        let lock = r#"{
+  "nodes": {
+    "child": {
+      "inputs": { "disabled": [] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "x", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": { "inputs": { "child": "child" } }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let parsed = FlakeLock::read_from_str(lock).expect("empty Indirect must parse");
+        let child = parsed.nodes.get("child").expect("child node");
+        let inputs = child.inputs.as_ref().expect("child has inputs");
+        match inputs.get("disabled").expect("disabled input present") {
+            Input::Indirect(None) => {}
+            other => panic!("expected Indirect(None), got {other:?}"),
+        }
+    }
+
+    /// A top-level input (`nix`) whose nested inputs map mixes
+    /// [`Input::Direct`] references, non-empty
+    /// [`Input::Indirect`] arrays (`["nixpkgs"]`), and empty `[]`
+    /// declarations must parse cleanly. [`FlakeLock::nested_inputs`]
+    /// emits one entry per declaration; entries built from `[]` carry
+    /// `follows: None`.
+    #[test]
+    fn nested_inputs_handles_mixed_direct_indirect_and_empty() {
+        let lock = r#"{
+  "nodes": {
+    "flake-parts": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "fp", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [],
+        "flake-parts": "flake-parts",
+        "nixpkgs": ["nixpkgs"]
+      },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "n", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "np", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": { "inputs": { "nix": "nix", "nixpkgs": "nixpkgs" } }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let parsed = FlakeLock::read_from_str(lock).expect("mixed-shape lock parses");
+        let nested = parsed.nested_inputs();
+        let by_path: std::collections::HashMap<String, &NestedInput> =
+            nested.iter().map(|n| (n.path.to_string(), n)).collect();
+
+        let disabled = by_path
+            .get("nix.flake-compat")
+            .expect("empty Indirect emitted as nested input");
+        assert!(
+            disabled.follows.is_none(),
+            "empty `[]` must surface as follows: None, got {:?}",
+            disabled.follows
+        );
+
+        let resolved = by_path
+            .get("nix.nixpkgs")
+            .expect("non-empty Indirect emitted as nested input");
         assert_eq!(
-            FlakeLock::split_input_path("\"hls-1.10\".nixpkgs"),
-            vec!["hls-1.10", "nixpkgs"]
+            resolved.follows.as_ref().map(|p| p.to_string()),
+            Some("nixpkgs".to_string()),
+            "non-empty Indirect must surface its follows target",
         );
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -18,7 +18,7 @@ use super::completions::uri_completion_items;
 use super::components::confirm::ConfirmAction;
 use super::components::input::{Input, InputAction, InputResult, InputState};
 use super::components::list::{ListAction, ListResult, ListState};
-use super::workflow::{AddPhase, ConfirmResultAction, FollowPhase, WorkflowData};
+use super::workflow::{AddStep, ConfirmResultAction, FollowStep, WorkflowData};
 
 // Re-export workflow types that are part of the public API
 pub use super::workflow::{AppResult, MultiSelectResultData, SingleSelectResult, UpdateResult};
@@ -108,7 +108,7 @@ impl App {
                 label: None,
             }),
             data: WorkflowData::Add {
-                phase: AddPhase::Uri,
+                step: AddStep::Uri,
                 uri: None,
                 id: None,
             },
@@ -278,7 +278,7 @@ impl App {
                 false,
             )),
             data: WorkflowData::Follow {
-                phase: FollowPhase::SelectInput,
+                step: FollowStep::SelectInput,
                 selected_input: None,
                 selected_target: None,
                 nested_inputs,
@@ -308,7 +308,7 @@ impl App {
                 false,
             )),
             data: WorkflowData::Follow {
-                phase: FollowPhase::SelectTarget,
+                step: FollowStep::SelectTarget,
                 selected_input: Some(input),
                 selected_target: None,
                 nested_inputs: Vec::<NestedInput>::new(),
@@ -474,13 +474,13 @@ impl App {
                     return Change::None;
                 }
                 match &self.data {
-                    WorkflowData::Add { phase, uri, .. } => match phase {
-                        AddPhase::Uri => Change::Add {
+                    WorkflowData::Add { step, uri, .. } => match step {
+                        AddStep::Uri => Change::Add {
                             id: None,
                             uri: Some(current_text.to_string()),
                             flake: true,
                         },
-                        AddPhase::Id => Change::Add {
+                        AddStep::Id => Change::Add {
                             id: Some(current_text.to_string()),
                             uri: uri.clone(),
                             flake: true,
@@ -506,28 +506,38 @@ impl App {
                 if !selected_items.is_empty() {
                     return match &self.data {
                         WorkflowData::Remove { .. } => Change::Remove {
-                            ids: selected_items.into_iter().map(|s| s.into()).collect(),
+                            ids: selected_items
+                                .into_iter()
+                                .filter_map(|s| crate::change::ChangeId::parse(&s).ok())
+                                .collect(),
                         },
                         WorkflowData::Follow {
-                            phase,
+                            step,
                             selected_input,
                             ..
                         } => {
-                            // During SelectInput phase, we can't preview yet
-                            // During SelectTarget phase, use selected_input + current selection
-                            if *phase == FollowPhase::SelectTarget {
+                            // During SelectInput step, we can't preview yet
+                            // During SelectTarget step, use selected_input + current selection
+                            if *step == FollowStep::SelectTarget {
                                 if let Some(input) = selected_input {
-                                    let target =
+                                    let target_str: String =
                                         selected_items.into_iter().next().unwrap_or_default();
-                                    Change::Follows {
-                                        input: input.clone().into(),
-                                        target,
+                                    let parsed = crate::change::ChangeId::parse(input)
+                                        .ok()
+                                        .zip(crate::follows::AttrPath::parse(&target_str).ok());
+                                    if let Some((change_id, target_path)) = parsed {
+                                        Change::Follows {
+                                            input: change_id,
+                                            target: target_path,
+                                        }
+                                    } else {
+                                        Change::None
                                     }
                                 } else {
                                     Change::None
                                 }
                             } else {
-                                // SelectInput phase - no preview possible
+                                // SelectInput step - no preview possible
                                 Change::None
                             }
                         }
@@ -579,10 +589,10 @@ impl App {
                         InputResult::Submit(text) => self.handle_input_submit(text),
                         InputResult::Cancel => {
                             // In Add workflow, Escape from ID input goes back to URI input
-                            if let WorkflowData::Add { phase, uri, .. } = &mut self.data
-                                && *phase == AddPhase::Id
+                            if let WorkflowData::Add { step, uri, .. } = &mut self.data
+                                && *step == AddStep::Id
                             {
-                                *phase = AddPhase::Uri;
+                                *step = AddStep::Uri;
                                 self.screen = Screen::Input(InputScreen {
                                     state: InputState::with_completions(
                                         uri.as_deref(),
@@ -630,14 +640,14 @@ impl App {
                 ListResult::Cancel => {
                     // For Follow workflow, Escape from SelectTarget goes back to SelectInput
                     if let WorkflowData::Follow {
-                        phase,
+                        step,
                         nested_inputs,
                         ..
                     } = &mut self.data
-                        && *phase == FollowPhase::SelectTarget
+                        && *step == FollowStep::SelectTarget
                         && !nested_inputs.is_empty()
                     {
-                        *phase = FollowPhase::SelectInput;
+                        *step = FollowStep::SelectInput;
                         let display_items: Vec<String> = nested_inputs
                             .iter()
                             .map(|i| i.to_display_string())
@@ -691,11 +701,11 @@ impl App {
 
     fn handle_input_submit(&mut self, text: String) -> UpdateResult {
         match &mut self.data {
-            WorkflowData::Add { phase, uri, id } => match phase {
-                AddPhase::Uri => {
+            WorkflowData::Add { step, uri, id } => match step {
+                AddStep::Uri => {
                     let (inferred_id, normalized_uri) = Self::parse_uri_and_infer_id(&text);
                     *uri = Some(normalized_uri);
-                    *phase = AddPhase::Id;
+                    *step = AddStep::Id;
                     self.screen = Screen::Input(InputScreen {
                         state: InputState::new(inferred_id.as_deref()),
                         prompt: format!("for {}", text),
@@ -703,7 +713,7 @@ impl App {
                     });
                     UpdateResult::Continue
                 }
-                AddPhase::Id => {
+                AddStep::Id => {
                     *id = Some(text);
                     self.transition_to_confirm()
                 }
@@ -758,22 +768,22 @@ impl App {
                 UpdateResult::Done
             }
             WorkflowData::Follow {
-                phase,
+                step,
                 selected_input,
                 selected_target,
                 nested_inputs,
                 top_level_inputs,
             } => {
-                match phase {
-                    FollowPhase::SelectInput => {
+                match step {
+                    FollowStep::SelectInput => {
                         // Use index to look up the path from nested_inputs
                         let index = indices.first().copied().unwrap_or(0);
                         let path = nested_inputs
                             .get(index)
-                            .map(|i| i.path.clone())
+                            .map(|i| i.path.to_string())
                             .unwrap_or_default();
                         *selected_input = Some(path.clone());
-                        *phase = FollowPhase::SelectTarget;
+                        *step = FollowStep::SelectTarget;
                         self.screen = Screen::List(ListScreen::single(
                             top_level_inputs.clone(),
                             format!("Select target for {path}"),
@@ -781,7 +791,7 @@ impl App {
                         ));
                         UpdateResult::Continue
                     }
-                    FollowPhase::SelectTarget => {
+                    FollowStep::SelectTarget => {
                         let item = items.into_iter().next().unwrap_or_default();
                         *selected_target = Some(item);
                         self.transition_to_confirm()
@@ -805,8 +815,8 @@ impl App {
 
     fn go_back(&mut self) {
         match &mut self.data {
-            WorkflowData::Add { phase, id, uri } => {
-                *phase = AddPhase::Id;
+            WorkflowData::Add { step, id, uri } => {
+                *step = AddStep::Id;
                 self.screen = Screen::Input(InputScreen {
                     state: InputState::new(id.as_deref()),
                     prompt: format!("for {}", uri.as_deref().unwrap_or("")),
@@ -835,21 +845,21 @@ impl App {
                 ));
             }
             WorkflowData::Follow {
-                phase,
+                step,
                 nested_inputs,
                 top_level_inputs,
                 ..
             } => {
                 // go_back is called from confirm screen, so we need to go back to
-                // the target selection list (SelectTarget phase)
-                if *phase == FollowPhase::SelectTarget {
+                // the target selection list (SelectTarget step)
+                if *step == FollowStep::SelectTarget {
                     self.screen = Screen::List(ListScreen::single(
                         top_level_inputs.clone(),
                         "Select target to follow",
                         self.show_diff,
                     ));
                 } else if !nested_inputs.is_empty() {
-                    // SelectInput phase - go back to input selection
+                    // SelectInput step - go back to input selection
                     let display_items: Vec<String> = nested_inputs
                         .iter()
                         .map(|i| i.to_display_string())

--- a/src/tui/components/list/view.rs
+++ b/src/tui/components/list/view.rs
@@ -218,12 +218,13 @@ mod tests {
 
     #[test]
     fn test_nested_input_display_roundtrip() {
+        use crate::follows::AttrPath;
         use crate::lock::NestedInput;
 
-        // With follows target
+        // With follows target.
         let input = NestedInput {
-            path: "crane.nixpkgs".into(),
-            follows: Some("nixpkgs".into()),
+            path: AttrPath::parse("crane.nixpkgs").unwrap(),
+            follows: Some(AttrPath::parse("nixpkgs").unwrap()),
             url: None,
         };
         let display = input.to_display_string();
@@ -231,9 +232,9 @@ mod tests {
         assert_eq!(path, "crane.nixpkgs");
         assert_eq!(follows, Some("nixpkgs"));
 
-        // Without follows target
+        // Without follows target.
         let input = NestedInput {
-            path: "crane.nixpkgs".into(),
+            path: AttrPath::parse("crane.nixpkgs").unwrap(),
             follows: None,
             url: None,
         };

--- a/src/tui/workflow.rs
+++ b/src/tui/workflow.rs
@@ -37,16 +37,16 @@ pub enum ConfirmResultAction {
     Exit,
 }
 
-/// Phase within the Add workflow
+/// Step within the Add workflow.
 #[derive(Debug, Clone, PartialEq)]
-pub enum AddPhase {
+pub enum AddStep {
     Uri,
     Id,
 }
 
-/// Phase within the Follow workflow
+/// Step within the Follow workflow.
 #[derive(Debug, Clone, PartialEq)]
-pub enum FollowPhase {
+pub enum FollowStep {
     /// Select the nested input path (e.g., "crane.nixpkgs")
     SelectInput,
     /// Select the target to follow (e.g., "nixpkgs")
@@ -81,7 +81,7 @@ pub enum AppResult {
 #[derive(Debug, Clone)]
 pub enum WorkflowData {
     Add {
-        phase: AddPhase,
+        step: AddStep,
         uri: Option<String>,
         id: Option<String>,
     },
@@ -105,7 +105,7 @@ pub enum WorkflowData {
         action: Option<ConfirmResultAction>,
     },
     Follow {
-        phase: FollowPhase,
+        step: FollowStep,
         /// The selected nested input path (e.g., "crane.nixpkgs")
         selected_input: Option<String>,
         /// The selected target to follow (e.g., "nixpkgs")
@@ -142,7 +142,10 @@ impl WorkflowData {
                     Change::None
                 } else {
                     Change::Remove {
-                        ids: selected_inputs.iter().map(|s| s.clone().into()).collect(),
+                        ids: selected_inputs
+                            .iter()
+                            .filter_map(|s| crate::change::ChangeId::parse(s).ok())
+                            .collect(),
                     }
                 }
             }
@@ -156,9 +159,16 @@ impl WorkflowData {
                 ..
             } => {
                 if let (Some(input), Some(target)) = (selected_input, selected_target) {
-                    Change::Follows {
-                        input: input.clone().into(),
-                        target: target.clone(),
+                    let parsed = crate::change::ChangeId::parse(input)
+                        .ok()
+                        .zip(crate::follows::AttrPath::parse(target).ok());
+                    if let Some((change_id, target_path)) = parsed {
+                        Change::Follows {
+                            input: change_id,
+                            target: target_path,
+                        }
+                    } else {
+                        Change::None
                     }
                 } else {
                     Change::None
@@ -199,8 +209,7 @@ pub fn compute_diff(flake_text: &str, change: &Change) -> String {
     };
 
     let new_text = match edit.apply_change(change.clone()) {
-        Ok(Some(text)) => text,
-        Ok(None) => flake_text.to_string(),
+        Ok(outcome) => outcome.text.unwrap_or_else(|| flake_text.to_string()),
         Err(e) => return format!("Error: {e}"),
     };
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,11 +8,12 @@ use crate::input::Input;
 use crate::uri::is_git_url;
 use crate::version::parse_ref;
 
+/// Rewrites flake.nix URIs for `update`, `pin`, and `unpin`.
 #[derive(Default, Debug)]
 pub struct Updater {
     text: Rope,
     inputs: Vec<UpdateInput>,
-    // Keeps track of offset for changing multiple inputs on a single pass.
+    /// Cumulative byte delta from edits applied earlier in the current pass.
     offset: i32,
 }
 
@@ -158,13 +159,17 @@ impl Updater {
                 change.clone()
             };
 
-            // set_ref() preserves storage location (path vs query param)
+            // `set_ref` preserves whether the ref lives in the URL path or a
+            // query parameter.
             let mut parsed = parsed.clone();
             let _ = parsed.set_ref(Some(final_change.clone()));
             let updated_uri = parsed.to_string();
 
-            if !Self::print_update_status(&input.input.id, &parsed_ref.previous_ref, &final_change)
-            {
+            if !Self::print_update_status(
+                input.input.id.as_str(),
+                &parsed_ref.previous_ref,
+                &final_change,
+            ) {
                 return;
             }
 
@@ -173,6 +178,8 @@ impl Updater {
             tracing::error!("Could not find latest version for Input: {:?}", input);
         }
     }
+    /// Build an [`Updater`] from `text` and the inputs in `map`. Inputs
+    /// without an editable URL are skipped.
     pub fn new(text: Rope, map: InputMap) -> Self {
         let mut inputs = vec![];
         for (_id, input) in map {
@@ -192,9 +199,15 @@ impl Updater {
             .strip_prefix('"')
             .and_then(|s| s.strip_suffix('"'))
             .unwrap_or(id);
-        self.inputs.iter().position(|n| n.input.bare_id() == bare)
+        self.inputs
+            .iter()
+            .position(|n| n.input.id().as_str() == bare)
     }
-    /// Pin an input based on it's id to a specific rev.
+    /// Pin the input named `id` to `rev`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the requested `id` if no such input exists.
     pub fn pin_input_to_ref(&mut self, id: &str, rev: &str) -> Result<(), String> {
         self.sort();
         let idx = self.get_index(id).ok_or_else(|| id.to_string())?;
@@ -203,7 +216,12 @@ impl Updater {
         self.change_input_to_rev(&input, rev);
         Ok(())
     }
-    /// Remove any ?ref= or ?rev= parameters from a specific input.
+
+    /// Remove any `?ref=` or `?rev=` pin from `id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the requested `id` if no such input exists.
     pub fn unpin_input(&mut self, id: &str) -> Result<(), String> {
         self.sort();
         let idx = self.get_index(id).ok_or_else(|| id.to_string())?;
@@ -212,14 +230,17 @@ impl Updater {
         self.remove_ref_and_rev(&input);
         Ok(())
     }
-    /// Update all inputs to a specific semver release,
-    /// if a specific input is given, just update the single input.
+
+    /// Update inputs to the latest matching release.
+    ///
+    /// When `id` is `Some`, only that input is updated. Otherwise every
+    /// input with an editable URL is processed.
     pub fn update_all_inputs_to_latest_semver(&mut self, id: Option<String>, init: bool) {
         self.sort();
         let inputs = self.inputs.clone();
         for input in inputs.iter() {
             if let Some(ref input_id) = id {
-                if input.input.id == *input_id {
+                if input.input.id.as_str() == input_id.as_str() {
                     self.query_and_update_all_inputs(input, init);
                 }
             } else {
@@ -227,6 +248,8 @@ impl Updater {
             }
         }
     }
+
+    /// Current source after all queued edits.
     pub fn get_changes(&self) -> String {
         self.text.to_string()
     }
@@ -240,12 +263,13 @@ impl Updater {
             .to_string()
     }
 
-    /// Change a specific input to a specific rev.
+    /// Rewrite `input`'s URL to pin it to `rev`.
     pub fn change_input_to_rev(&mut self, input: &UpdateInput, rev: &str) {
         let uri = self.get_input_text(input);
         match uri.parse::<FlakeRef>() {
             Ok(mut parsed) => {
-                // set_rev() preserves storage location (path vs query param)
+                // `set_rev` preserves whether the rev lives in the URL path
+                // or a query parameter.
                 let _ = parsed.set_rev(Some(rev.into()));
                 self.update_input(input.clone(), &parsed.to_string());
             }
@@ -261,7 +285,8 @@ impl Updater {
                 if parsed.ref_source_location() == RefLocation::None {
                     return;
                 }
-                // set_ref/set_rev handle both path-based and query param storage
+                // `set_ref`/`set_rev` handle both path-based and
+                // query-parameter storage.
                 let _ = parsed.set_ref(None);
                 let _ = parsed.set_rev(None);
                 self.update_input(input.clone(), &parsed.to_string());
@@ -271,7 +296,8 @@ impl Updater {
             }
         }
     }
-    /// Query a forge api for the latest release and update, if necessary.
+    /// Query the forge API for `input`'s latest release and rewrite the URL
+    /// when newer.
     pub fn query_and_update_all_inputs(&mut self, input: &UpdateInput, init: bool) {
         let uri = self.get_input_text(input);
 
@@ -314,7 +340,8 @@ impl Updater {
         }
     }
 
-    /// Update an input using channel-based versioning (nixpkgs, home-manager, nix-darwin).
+    /// Update `input` using channel-based versioning (nixpkgs, home-manager,
+    /// nix-darwin).
     fn update_channel_input(&mut self, input: &UpdateInput, parsed: &FlakeRef) {
         let owner = parsed.r#type.get_owner().unwrap();
         let repo = parsed.r#type.get_repo().unwrap();
@@ -323,7 +350,10 @@ impl Updater {
         let current_ref = parsed.get_ref_or_rev().unwrap_or_default();
 
         if current_ref.is_empty() {
-            tracing::debug!("Skipping unpinned channel input: {}", input.input.id);
+            tracing::debug!(
+                "Skipping unpinned channel input: {}",
+                input.input.id.as_str()
+            );
             return;
         }
 
@@ -345,12 +375,12 @@ impl Updater {
         let _ = parsed.set_ref(Some(final_ref.clone()));
         let updated_uri = parsed.to_string();
 
-        if Self::print_update_status(&input.input.id, &current_ref, &final_ref) {
+        if Self::print_update_status(input.input.id.as_str(), &current_ref, &final_ref) {
             self.update_input(input.clone(), &updated_uri);
         }
     }
 
-    /// Update an input using semver tag-based versioning (standard behavior).
+    /// Update `input` to the latest semver tag from its forge.
     fn update_semver_input(&mut self, input: &UpdateInput, init: bool) {
         let target = match self.parse_update_target(input, init) {
             Some(target) => target,
@@ -365,7 +395,7 @@ impl Updater {
         self.apply_update(input, &target, tags, init);
     }
 
-    // Sort the entries, so that we can adjust multiple values together
+    // Sort by source range so multi-edit passes stay aligned with `offset`.
     fn sort(&mut self) {
         self.inputs.sort();
     }
@@ -388,7 +418,7 @@ impl Updater {
     }
 }
 
-// Wrapper around  individual inputs
+/// Wrapper that lets [`Updater`] sort inputs by source position.
 #[derive(Debug, Clone)]
 pub struct UpdateInput {
     input: Input,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -1,309 +1,139 @@
-//! Validation for Nix expressions.
+//! Validation for Nix flake expressions.
+//!
+//! - [`error`]: [`ValidationError`], [`Severity`], [`Location`].
+//! - `syntax` (private): rnix parse errors and duplicate-attribute detection.
+//! - `follows` (crate-private): cycle, stale, target, contradiction, and depth
+//!   lints.
+//!
+//! [`validate`] runs the syntax-level lints. [`validate_full`] adds the
+//! follows-graph lints that need a parsed [`InputMap`] and an optional
+//! [`FlakeLock`].
 
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
-use std::fmt;
+pub mod error;
+pub(crate) mod follows;
+mod syntax;
 
-use rnix::{Root, SyntaxKind, SyntaxNode, TextRange};
+pub use error::{DuplicateAttr, Location, Severity, ValidationError, ValidationResult};
 
-/// Location information for error reporting (1-indexed).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Location {
-    pub line: usize,
-    pub column: usize,
-}
+use crate::edit::InputMap;
+use crate::follows::DEFAULT_MAX_DEPTH;
+use crate::lock::FlakeLock;
 
-impl fmt::Display for Location {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "line {}, column {}", self.line, self.column)
-    }
-}
-
-/// Information about a duplicate attribute.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DuplicateAttr {
-    /// The attribute path, e.g., "a.b.c" or "inputs.nixpkgs.url".
-    pub path: String,
-    /// Location of the first occurrence.
-    pub first: Location,
-    /// Location of the duplicate occurrence.
-    pub duplicate: Location,
-}
-
-impl fmt::Display for DuplicateAttr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "duplicate attribute '{}' at {} (first defined at {})",
-            self.path, self.duplicate, self.first
-        )
-    }
-}
-
-/// Validation errors that can occur when parsing Nix expressions.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ValidationError {
-    /// Syntax error from rnix parser.
-    ParseError { message: String, location: Location },
-    /// Duplicate attribute in an attribute set.
-    DuplicateAttribute(DuplicateAttr),
-}
-
-impl fmt::Display for ValidationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ValidationError::ParseError { message, location } => {
-                write!(f, "parse error at {}: {}", location, message)
-            }
-            ValidationError::DuplicateAttribute(dup) => write!(f, "{}", dup),
-        }
-    }
-}
-
-/// Result of validation containing any errors found.
-#[derive(Debug, Default)]
-pub struct ValidationResult {
-    pub errors: Vec<ValidationError>,
-}
-
-impl ValidationResult {
-    pub fn is_ok(&self) -> bool {
-        self.errors.is_empty()
-    }
-
-    pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
-    }
-}
-
-/// Validator for Nix expressions.
-pub struct Validator {
-    source: String,
-    /// Byte offsets where each line starts (for computing line/column).
-    line_starts: Vec<usize>,
-}
-
-/// Extract the full attribute path as a string, e.g., "a.b.c".
-fn extract_attrpath(attrpath: &SyntaxNode) -> String {
-    attrpath
-        .children()
-        .map(|child| {
-            let s = child.to_string();
-            // Unquote string attribute names: `"a"` -> `a`
-            if child.kind() == SyntaxKind::NODE_STRING {
-                s.trim_matches('"').to_string()
-            } else {
-                s
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(".")
-}
-
-/// Check whether a `NODE_ATTRPATH_VALUE` node has a `NODE_ATTR_SET` as its value.
-fn value_is_attrset(node: &SyntaxNode) -> bool {
-    node.children()
-        .any(|c| c.kind() == SyntaxKind::NODE_ATTR_SET)
-}
-
-impl Validator {
-    /// Create a new validator for the given source.
-    pub fn new(source: &str) -> Self {
-        let line_starts = Self::compute_line_starts(source);
-        Self {
-            source: source.to_string(),
-            line_starts,
-        }
-    }
-
-    /// Compute byte offsets for the start of each line.
-    fn compute_line_starts(source: &str) -> Vec<usize> {
-        let mut starts = vec![0];
-        for (i, c) in source.char_indices() {
-            if c == '\n' {
-                starts.push(i + 1);
-            }
-        }
-        starts
-    }
-
-    /// Convert a TextRange to a Location (using the start position).
-    fn range_to_location(&self, range: TextRange) -> Location {
-        self.offset_to_location(range.start().into())
-    }
-
-    /// Convert a byte offset to line and column (1-indexed).
-    fn offset_to_location(&self, offset: usize) -> Location {
-        let line = self
-            .line_starts
-            .iter()
-            .rposition(|&start| start <= offset)
-            .unwrap_or(0);
-        let column = offset - self.line_starts[line];
-        Location {
-            line: line + 1,
-            column: column + 1,
-        }
-    }
-
-    /// Validate the source and return any errors found.
-    pub fn validate(&self) -> ValidationResult {
-        let root = Root::parse(&self.source);
-        let mut errors = Vec::new();
-
-        // Collect rnix parse errors
-        for error in root.errors() {
-            let location = self.parse_error_location(error);
-            errors.push(ValidationError::ParseError {
-                message: error.to_string(),
-                location,
-            });
-        }
-
-        // Check for duplicate attributes
-        let syntax = root.syntax();
-        self.check_node(&syntax, &mut errors);
-
-        ValidationResult { errors }
-    }
-
-    /// Extract location from an rnix ParseError.
-    fn parse_error_location(&self, error: &rnix::ParseError) -> Location {
-        use rnix::ParseError::*;
-        match error {
-            Unexpected(r)
-            | UnexpectedExtra(r)
-            | UnexpectedWanted(_, r, _)
-            | UnexpectedDoubleBind(r)
-            | DuplicatedArgs(r, _) => self.range_to_location(*r),
-            UnexpectedEOF | UnexpectedEOFWanted(_) | RecursionLimitExceeded | _ => Location {
-                line: self.line_starts.len(),
-                column: 1,
-            },
-        }
-    }
-
-    /// Recursively check a node and its descendants for duplicate attributes.
-    fn check_node(&self, node: &SyntaxNode, errors: &mut Vec<ValidationError>) {
-        if node.kind() == SyntaxKind::NODE_ATTR_SET {
-            self.check_attr_set(node, errors);
-        }
-
-        for child in node.children() {
-            self.check_node(&child, errors);
-        }
-    }
-
-    /// Check an attribute set for duplicate attributes.
-    ///
-    /// Nix allows duplicate attribute names when both values are attribute sets
-    /// (they get merged). For example:
-    /// ```nix
-    /// {
-    ///   inputs = { nixpkgs.url = "..."; };
-    ///   inputs = { flake-utils.url = "..."; };
-    /// }
-    /// ```
-    /// is equivalent to a single `inputs` with both entries. We allow this but
-    /// still check the merged contents for true conflicts.
-    fn check_attr_set(&self, attr_set: &SyntaxNode, errors: &mut Vec<ValidationError>) {
-        // Track first occurrence: path -> (location, is_attrset, node)
-        let mut seen: HashMap<String, (Location, bool, SyntaxNode)> = HashMap::new();
-        // Track all attrset-valued nodes for a given path so we can cross-check
-        let mut merged_attrsets: HashMap<String, Vec<SyntaxNode>> = HashMap::new();
-
-        for child in attr_set.children() {
-            if child.kind() == SyntaxKind::NODE_ATTRPATH_VALUE
-                && let Some(attrpath) = child
-                    .children()
-                    .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
-            {
-                let path = extract_attrpath(&attrpath);
-                let location = self.range_to_location(attrpath.text_range());
-                let is_attrset = value_is_attrset(&child);
-
-                match seen.entry(path.clone()) {
-                    Entry::Occupied(entry) => {
-                        let (ref first_loc, first_is_attrset, _) = *entry.get();
-                        if first_is_attrset && is_attrset {
-                            merged_attrsets.entry(path).or_default().push(child.clone());
-                        } else {
-                            errors.push(ValidationError::DuplicateAttribute(DuplicateAttr {
-                                path: entry.key().clone(),
-                                first: first_loc.clone(),
-                                duplicate: location,
-                            }));
-                        }
-                    }
-                    Entry::Vacant(entry) => {
-                        if is_attrset {
-                            merged_attrsets.entry(path).or_default().push(child.clone());
-                        }
-                        entry.insert((location, is_attrset, child.clone()));
-                    }
-                }
-            }
-        }
-
-        // Cross-check merged attrsets for duplicate attrs across blocks.
-        for nodes in merged_attrsets.values() {
-            if nodes.len() < 2 {
-                continue;
-            }
-            // Collect all attrs across all blocks and check for duplicates.
-            let mut cross_seen: HashMap<String, Location> = HashMap::new();
-            for node in nodes {
-                // Find the NODE_ATTR_SET child to iterate its attrs.
-                for attrset_child in node.children() {
-                    if attrset_child.kind() != SyntaxKind::NODE_ATTR_SET {
-                        continue;
-                    }
-                    for inner in attrset_child.children() {
-                        if inner.kind() == SyntaxKind::NODE_ATTRPATH_VALUE
-                            && let Some(inner_path_node) = inner
-                                .children()
-                                .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
-                        {
-                            let inner_path = extract_attrpath(&inner_path_node);
-                            let inner_loc = self.range_to_location(inner_path_node.text_range());
-
-                            match cross_seen.entry(inner_path) {
-                                Entry::Occupied(e) => {
-                                    errors.push(ValidationError::DuplicateAttribute(
-                                        DuplicateAttr {
-                                            path: e.key().clone(),
-                                            first: e.get().clone(),
-                                            duplicate: inner_loc,
-                                        },
-                                    ));
-                                }
-                                Entry::Vacant(e) => {
-                                    e.insert(inner_loc);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// Convenience function to validate source and return errors.
+/// Run the syntax-level lints over `source`: parse errors, duplicate
+/// attributes, and the always-on declared-cycle check.
 pub fn validate(source: &str) -> ValidationResult {
-    Validator::new(source).validate()
+    let mut errors: Vec<ValidationError> = Vec::new();
+    syntax::collect(source, &mut errors);
+    if errors.is_empty() {
+        let mut walker = crate::walk::Walker::new(source);
+        if walker.walk(&crate::change::Change::None).is_ok() {
+            let line_map = syntax::LineMap::new(source);
+            let graph = crate::follows::FollowsGraph::from_declared(&walker.inputs);
+            let offset_to_location = |offset: usize| line_map.offset_to_location(offset);
+            errors.extend(follows::lint_follows_cycle(&graph, &offset_to_location));
+        }
+    }
+    ValidationResult {
+        errors,
+        warnings: Vec::new(),
+    }
+}
+
+/// Run syntax checks plus every follows-graph lint.
+///
+/// The follows-graph is built once from `inputs` and the optional `lock`,
+/// then handed to each lint. One graph build per call is cheap enough that
+/// callers do not need to share a pre-built graph.
+pub fn validate_full(
+    source: &str,
+    inputs: &InputMap,
+    lock: Option<&FlakeLock>,
+) -> ValidationResult {
+    validate_full_inner(source, inputs, lock, true)
+}
+
+/// Like [`validate_full`] but skips the lock-drift lints (`lint_follows_stale`
+/// and `lint_follows_stale_lock`) that compare declared edges in `flake.nix`
+/// against `flake.lock`.
+///
+/// For speculative validation during a multi-step apply. The lockfile cannot
+/// reflect mid-batch text edits, so a freshly-added follows always looks
+/// stale relative to the on-disk lock. Running lock-drift lints there would
+/// flag every in-progress edit as drift.
+pub fn validate_speculative(
+    source: &str,
+    inputs: &InputMap,
+    lock: Option<&FlakeLock>,
+) -> ValidationResult {
+    validate_full_inner(source, inputs, lock, false)
+}
+
+fn validate_full_inner(
+    source: &str,
+    inputs: &InputMap,
+    lock: Option<&FlakeLock>,
+    lock_drift_lints: bool,
+) -> ValidationResult {
+    let mut errors: Vec<ValidationError> = Vec::new();
+    let mut warnings: Vec<ValidationError> = Vec::new();
+
+    syntax::collect(source, &mut errors);
+
+    let line_map = syntax::LineMap::new(source);
+    let offset_to_location = |offset: usize| line_map.offset_to_location(offset);
+
+    let graph = follows::build_graph(inputs, lock, DEFAULT_MAX_DEPTH);
+
+    let mut candidates: Vec<ValidationError> = Vec::new();
+    candidates.extend(follows::lint_follows_cycle(&graph, &offset_to_location));
+    if let Some(lock) = lock
+        && lock_drift_lints
+    {
+        candidates.extend(follows::lint_follows_stale(&graph, &offset_to_location));
+        candidates.extend(follows::lint_follows_stale_lock(
+            &graph,
+            lock,
+            &offset_to_location,
+        ));
+    }
+    let top_level = follows::top_level_names(inputs);
+    candidates.extend(follows::lint_follows_target_not_toplevel(
+        &graph,
+        &top_level,
+        &offset_to_location,
+    ));
+    candidates.extend(follows::lint_follows_contradiction(
+        &graph,
+        &offset_to_location,
+    ));
+    candidates.extend(follows::lint_follows_depth_exceeded(
+        &graph,
+        DEFAULT_MAX_DEPTH,
+        &offset_to_location,
+    ));
+
+    for err in candidates {
+        match err.severity() {
+            Severity::Warning => warnings.push(err),
+            Severity::Error => errors.push(err),
+        }
+    }
+
+    ValidationResult { errors, warnings }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::edit::InputMap;
+    use crate::follows::{AttrPath, Segment};
+    use crate::input::{Follows, Input, Range};
+    use crate::validate::error::DuplicateAttr;
 
     fn expect_duplicate(err: &ValidationError) -> &DuplicateAttr {
         match err {
             ValidationError::DuplicateAttribute(dup) => dup,
-            ValidationError::ParseError { .. } => {
-                panic!("expected DuplicateAttribute, got ParseError")
-            }
+            other => panic!("expected DuplicateAttribute, got {other:?}"),
         }
     }
 
@@ -521,6 +351,26 @@ mod tests {
     }
 
     #[test]
+    fn follows_cycle_self_edge_lints() {
+        let source = r#"{
+  inputs.foo = {
+    url = "github:owner/foo";
+    inputs.foo.follows = "foo/foo";
+  };
+  outputs = { ... }: { };
+}"#;
+        let result = validate(source);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::FollowsCycle { .. })),
+            "expected FollowsCycle, got: {:?}",
+            result.errors,
+        );
+    }
+
+    #[test]
     fn three_mergeable_attrsets() {
         let source = r#"{
   inputs = { a.url = "a"; };
@@ -532,6 +382,82 @@ mod tests {
             result.is_ok(),
             "expected no errors, got: {:?}",
             result.errors
+        );
+    }
+
+    fn seg(s: &str) -> Segment {
+        Segment::from_unquoted(s).unwrap()
+    }
+
+    fn path(s: &str) -> AttrPath {
+        AttrPath::parse(s).unwrap()
+    }
+
+    fn declared_input(id: &str, follows: &[(&str, &str)]) -> Input {
+        let mut input = Input::new(seg(id));
+        for (parent, target) in follows {
+            input.follows.push(Follows::Indirect {
+                path: AttrPath::new(seg(parent)),
+                target: Some(path(target)),
+            });
+        }
+        input.range = Range { start: 1, end: 2 };
+        input
+    }
+
+    fn make_inputs(items: Vec<Input>) -> InputMap {
+        let mut map = InputMap::new();
+        for input in items {
+            map.insert(input.id().as_str().to_string(), input);
+        }
+        map
+    }
+
+    #[test]
+    fn validate_full_emits_target_not_toplevel_by_default() {
+        let inputs = make_inputs(vec![declared_input("a", &[("b", "missing")])]);
+        let result = validate_full("{}", &inputs, None);
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::FollowsTargetNotToplevel { .. })),
+            "expected target-not-toplevel error, got: {:?}",
+            result.errors,
+        );
+    }
+
+    #[test]
+    fn validate_full_separates_warnings_from_errors() {
+        // Stale follows is a warning, target-not-toplevel is an error, and
+        // both can fire on the same input.
+        let inputs = make_inputs(vec![declared_input("a", &[("b", "missing")])]);
+        let lock_text = r#"{
+  "nodes": {
+    "a": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": { "inputs": { "a": "a" } }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = FlakeLock::read_from_str(lock_text).unwrap();
+        let result = validate_full("{}", &inputs, Some(&lock));
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::FollowsTargetNotToplevel { .. })),
+        );
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|e| matches!(e, ValidationError::FollowsStale { .. })),
+            "expected at least one stale warning, got warnings: {:?}",
+            result.warnings,
         );
     }
 }

--- a/src/validate/error.rs
+++ b/src/validate/error.rs
@@ -1,0 +1,303 @@
+//! [`ValidationError`], [`Severity`], and [`Location`].
+//!
+//! [`Severity`] separates fatal errors from non-fatal warnings.
+
+use std::fmt;
+
+/// 1-indexed line/column for error reporting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Location {
+    pub line: usize,
+    pub column: usize,
+}
+
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "line {}, column {}", self.line, self.column)
+    }
+}
+
+/// A duplicate attribute and where its two definitions sit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DuplicateAttr {
+    /// Attribute path, e.g. `a.b.c` or `inputs.nixpkgs.url`.
+    pub path: String,
+    /// Location of the first occurrence.
+    pub first: Location,
+    /// Location of the duplicate occurrence.
+    pub duplicate: Location,
+}
+
+impl fmt::Display for DuplicateAttr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "duplicate attribute '{}' at {} (first defined at {})",
+            self.path, self.duplicate, self.first
+        )
+    }
+}
+
+/// Severity classification for [`ValidationError`].
+///
+/// Errors abort the edit; warnings do not. Both flavours land in
+/// [`ValidationResult::errors`] and [`ValidationResult::warnings`]
+/// respectively, populated by [`super::validate_full`] and
+/// [`super::validate_speculative`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Warning,
+    Error,
+}
+
+/// Errors raised while parsing or analysing a flake.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationError {
+    /// rnix could not parse the source.
+    ParseError { message: String, location: Location },
+    /// Duplicate attribute in an attribute set.
+    DuplicateAttribute(DuplicateAttr),
+    /// A declared `inputs.X.inputs.Y.follows` chain forms a cycle.
+    FollowsCycle {
+        cycle: crate::follows::Cycle,
+        location: Location,
+    },
+    /// A follows declaration in `flake.nix` points at a nested input that no
+    /// longer exists in `flake.lock`. Warning: the auto-follow pass should
+    /// drop the declaration on the next run.
+    FollowsStale {
+        /// Declared edge whose source has dropped out of `flake.lock`'s
+        /// nested-input universe.
+        edge: crate::follows::Edge,
+        location: Location,
+    },
+    /// A follows target points at something that is not a top-level input,
+    /// e.g. `inputs.foo.inputs.bar.follows = "does-not-exist"`.
+    FollowsTargetNotToplevel {
+        edge: crate::follows::Edge,
+        location: Location,
+    },
+    /// Two follows declarations share a source path but disagree on the
+    /// target.
+    FollowsContradiction {
+        edges: Vec<crate::follows::Edge>,
+        location: Location,
+    },
+    /// A declared follows whose target diverges from the lockfile's
+    /// resolution of the same source path. Warning: the user edited
+    /// `flake.nix` but never ran `nix flake lock`.
+    FollowsStaleLock {
+        /// Source path of the declared follows, e.g. `crane.nixpkgs`.
+        source: crate::follows::AttrPath,
+        /// Target the declaration in `flake.nix` asks for.
+        declared_target: crate::follows::AttrPath,
+        /// Target the lockfile resolves the same source to. `None` if the
+        /// lockfile has the path but no follows attached.
+        lock_target: Option<crate::follows::AttrPath>,
+        location: Location,
+    },
+    /// A follows path is deeper than the configured graph traversal bound.
+    FollowsDepthExceeded {
+        edge: crate::follows::Edge,
+        depth: usize,
+        max_depth: usize,
+        location: Location,
+    },
+}
+
+impl ValidationError {
+    /// Severity for this variant.
+    pub fn severity(&self) -> Severity {
+        match self {
+            ValidationError::FollowsStale { .. } | ValidationError::FollowsStaleLock { .. } => {
+                Severity::Warning
+            }
+            _ => Severity::Error,
+        }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ValidationError::ParseError { message, location } => {
+                write!(f, "parse error at {}: {}", location, message)
+            }
+            ValidationError::DuplicateAttribute(dup) => write!(f, "{}", dup),
+            ValidationError::FollowsCycle { cycle, location } => {
+                let chain = cycle
+                    .edges
+                    .iter()
+                    .map(|e| format!("{} -> {}", e.source, e.follows))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "follows cycle at {}: {}", location, chain)
+            }
+            ValidationError::FollowsStale { edge, location } => {
+                write!(
+                    f,
+                    "stale follows at {}: {} -> {} (source no longer present in flake.lock)",
+                    location, edge.source, edge.follows
+                )
+            }
+            ValidationError::FollowsTargetNotToplevel { edge, location } => {
+                write!(
+                    f,
+                    "follows target not a top-level input at {}: {} -> {}",
+                    location, edge.source, edge.follows
+                )
+            }
+            ValidationError::FollowsContradiction { edges, location } => {
+                let pairs = edges
+                    .iter()
+                    .map(|e| format!("{} -> {}", e.source, e.follows))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                write!(f, "contradicting follows at {}: {}", location, pairs)
+            }
+            ValidationError::FollowsStaleLock {
+                source,
+                declared_target,
+                lock_target,
+                location,
+            } => {
+                let lock = match lock_target {
+                    Some(t) => t.to_string(),
+                    None => "<none>".to_string(),
+                };
+                write!(
+                    f,
+                    "stale-lock follows at {}: {} -> {} (flake.lock resolves to {}; run `nix flake lock`)",
+                    location, source, declared_target, lock,
+                )
+            }
+            ValidationError::FollowsDepthExceeded {
+                edge,
+                depth,
+                max_depth,
+                location,
+            } => {
+                write!(
+                    f,
+                    "follows depth exceeded at {}: {} -> {} reached depth {} (max {})",
+                    location, edge.source, edge.follows, depth, max_depth
+                )
+            }
+        }
+    }
+}
+
+/// Errors and warnings collected during a single validation pass.
+#[derive(Debug, Default)]
+pub struct ValidationResult {
+    pub errors: Vec<ValidationError>,
+    pub warnings: Vec<ValidationError>,
+}
+
+impl ValidationResult {
+    pub fn is_ok(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
+    }
+
+    pub fn has_warnings(&self) -> bool {
+        !self.warnings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::follows::{AttrPath, Cycle, Edge, EdgeOrigin};
+    use crate::input::Range;
+
+    fn declared_edge(source: &str, follows: &str) -> Edge {
+        Edge {
+            source: AttrPath::parse(source).unwrap(),
+            follows: AttrPath::parse(follows).unwrap(),
+            origin: EdgeOrigin::Declared {
+                range: Range { start: 0, end: 0 },
+            },
+        }
+    }
+
+    fn loc() -> Location {
+        Location { line: 1, column: 1 }
+    }
+
+    #[test]
+    fn severity_classification() {
+        let cases: Vec<(ValidationError, Severity)> = vec![
+            (
+                ValidationError::ParseError {
+                    message: "x".into(),
+                    location: loc(),
+                },
+                Severity::Error,
+            ),
+            (
+                ValidationError::DuplicateAttribute(DuplicateAttr {
+                    path: "a".into(),
+                    first: loc(),
+                    duplicate: loc(),
+                }),
+                Severity::Error,
+            ),
+            (
+                ValidationError::FollowsCycle {
+                    cycle: Cycle {
+                        edges: vec![declared_edge("a", "a")],
+                    },
+                    location: loc(),
+                },
+                Severity::Error,
+            ),
+            (
+                ValidationError::FollowsStale {
+                    edge: declared_edge("a.b", "c"),
+                    location: loc(),
+                },
+                Severity::Warning,
+            ),
+            (
+                ValidationError::FollowsTargetNotToplevel {
+                    edge: declared_edge("a.b", "missing"),
+                    location: loc(),
+                },
+                Severity::Error,
+            ),
+            (
+                ValidationError::FollowsContradiction {
+                    edges: vec![declared_edge("a.b", "x"), declared_edge("a.b", "y")],
+                    location: loc(),
+                },
+                Severity::Error,
+            ),
+            (
+                ValidationError::FollowsStaleLock {
+                    source: AttrPath::parse("a.b").unwrap(),
+                    declared_target: AttrPath::parse("x").unwrap(),
+                    lock_target: Some(AttrPath::parse("y").unwrap()),
+                    location: loc(),
+                },
+                Severity::Warning,
+            ),
+            (
+                ValidationError::FollowsDepthExceeded {
+                    edge: declared_edge("a.b", "x"),
+                    depth: 5,
+                    max_depth: 4,
+                    location: loc(),
+                },
+                Severity::Error,
+            ),
+        ];
+        for (err, want) in cases {
+            assert_eq!(err.severity(), want, "unexpected severity for {err:?}");
+        }
+    }
+}

--- a/src/validate/follows.rs
+++ b/src/validate/follows.rs
@@ -1,0 +1,433 @@
+//! Follows-graph lints.
+//!
+//! Each lint is a pure function over a [`FollowsGraph`] (or an [`InputMap`])
+//! that returns [`ValidationError`]s. Lints take the graph by reference,
+//! never mutate it, and never read from disk. [`super::validate_full`]
+//! supplies the [`Location`]s.
+
+use std::collections::{HashMap, HashSet};
+
+use super::error::{Location, ValidationError};
+use crate::edit::InputMap;
+use crate::follows::{AttrPath, Edge, EdgeOrigin, FollowsGraph};
+use crate::lock::FlakeLock;
+
+/// Translate `edge`'s declared range into a 1-indexed [`Location`] via
+/// `offset_to_location`. Resolved (lockfile-only) edges fall back to
+/// `(line=1, column=1)` since they have no source-text range.
+fn edge_location<F: Fn(usize) -> Location>(edge: &Edge, offset_to_location: &F) -> Location {
+    match &edge.origin {
+        EdgeOrigin::Declared { range } => offset_to_location(range.start),
+        EdgeOrigin::Resolved { .. } => Location { line: 1, column: 1 },
+    }
+}
+
+/// Lint cycles among declared and merged edges. Wraps each
+/// [`crate::follows::Cycle`] from the graph into a
+/// [`ValidationError::FollowsCycle`].
+pub(crate) fn lint_follows_cycle<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    graph
+        .cycles()
+        .into_iter()
+        .map(|cycle| {
+            let location = cycle
+                .edges
+                .first()
+                .map(|edge| edge_location(edge, offset_to_location))
+                .unwrap_or(Location { line: 1, column: 1 });
+            ValidationError::FollowsCycle { cycle, location }
+        })
+        .collect()
+}
+
+/// Lint declared follows whose source path has dropped out of the
+/// lockfile's nested-input universe. Always [`super::Severity::Warning`].
+///
+/// `graph` must be a merged graph (declared plus resolved edges over the
+/// lockfile's nested-input universe). The lint defers to
+/// [`FollowsGraph::stale_edges`] to compare declared sources against the
+/// resolved set.
+pub(crate) fn lint_follows_stale<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    graph
+        .stale_edges()
+        .into_iter()
+        .map(|edge| ValidationError::FollowsStale {
+            edge: edge.clone(),
+            location: edge_location(edge, offset_to_location),
+        })
+        .collect()
+}
+
+/// Lint declared follows whose lockfile resolution disagrees with what
+/// `flake.nix` asks for. Wraps each [`crate::follows::StaleLockDeclaration`]
+/// into a [`ValidationError::FollowsStaleLock`].
+///
+/// Always [`super::Severity::Warning`]. The remediation is `nix flake lock`.
+pub(crate) fn lint_follows_stale_lock<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    lock: &FlakeLock,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    graph
+        .stale_lock_declarations(lock)
+        .into_iter()
+        .map(|item| ValidationError::FollowsStaleLock {
+            source: item.declared.source.clone(),
+            declared_target: item.declared.follows.clone(),
+            lock_target: item.lock_target,
+            location: edge_location(item.declared, offset_to_location),
+        })
+        .collect()
+}
+
+/// Lint declared follows targets that fail to resolve to a top-level input.
+///
+/// `top_level` is the set of top-level input names from `flake.nix`, as
+/// produced by [`top_level_names`]. Only declared edges are inspected.
+/// Resolved edges reference real lockfile nodes by construction.
+pub(crate) fn lint_follows_target_not_toplevel<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    top_level: &HashSet<String>,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    let mut out = Vec::new();
+    for edge in graph.declared_edges() {
+        let target_root = edge.follows.first().as_str();
+        if !top_level.contains(target_root) {
+            out.push(ValidationError::FollowsTargetNotToplevel {
+                edge: edge.clone(),
+                location: edge_location(edge, offset_to_location),
+            });
+        }
+    }
+    out
+}
+
+/// Lint declared follows that share a source path but disagree on the
+/// target. Emits one [`ValidationError::FollowsContradiction`] per source
+/// path with more than one distinct target among declared edges.
+pub(crate) fn lint_follows_contradiction<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    let mut by_source: HashMap<AttrPath, Vec<&Edge>> = HashMap::new();
+    for edge in graph.declared_edges() {
+        by_source.entry(edge.source.clone()).or_default().push(edge);
+    }
+    let mut sources: Vec<&AttrPath> = by_source.keys().collect();
+    sources.sort();
+    let mut out = Vec::new();
+    for source in sources {
+        let edges = &by_source[source];
+        let mut targets: Vec<&AttrPath> = edges.iter().map(|e| &e.follows).collect();
+        targets.sort();
+        targets.dedup();
+        if targets.len() <= 1 {
+            continue;
+        }
+        let cloned: Vec<Edge> = edges.iter().map(|&e| e.clone()).collect();
+        let location = cloned
+            .first()
+            .map(|e| edge_location(e, offset_to_location))
+            .unwrap_or(Location { line: 1, column: 1 });
+        out.push(ValidationError::FollowsContradiction {
+            edges: cloned,
+            location,
+        });
+    }
+    out
+}
+
+/// Lint declared follows whose source path is longer than `max_depth`
+/// segments. Exceeding the bound means the path is deeper than the resolver
+/// is willing to chase.
+pub(crate) fn lint_follows_depth_exceeded<F: Fn(usize) -> Location>(
+    graph: &FollowsGraph,
+    max_depth: usize,
+    offset_to_location: &F,
+) -> Vec<ValidationError> {
+    let mut out = Vec::new();
+    for edge in graph.declared_edges() {
+        let depth = edge.source.len();
+        if depth > max_depth {
+            out.push(ValidationError::FollowsDepthExceeded {
+                edge: edge.clone(),
+                depth,
+                max_depth,
+                location: edge_location(edge, offset_to_location),
+            });
+        }
+    }
+    out
+}
+
+/// Top-level input names from an [`InputMap`], shaped for
+/// [`lint_follows_target_not_toplevel`].
+pub(crate) fn top_level_names(inputs: &InputMap) -> HashSet<String> {
+    inputs.keys().cloned().collect()
+}
+
+/// Build the follows graph from declared `flake.nix` edges, plus resolved
+/// edges from `lock` when supplied. With `lock = None` only declared edges
+/// are present and [`FollowsGraph::stale_edges`] reports nothing.
+pub(crate) fn build_graph(
+    inputs: &InputMap,
+    lock: Option<&FlakeLock>,
+    max_depth: usize,
+) -> FollowsGraph {
+    let graph = match lock {
+        Some(lock) => FollowsGraph::from_flake(inputs, lock),
+        None => FollowsGraph::from_declared(inputs),
+    };
+    graph.with_max_depth(max_depth)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::edit::InputMap;
+    use crate::follows::{AttrPath, Segment};
+    use crate::input::{Follows, Input, Range};
+
+    fn seg(s: &str) -> Segment {
+        Segment::from_unquoted(s).unwrap()
+    }
+
+    fn path(s: &str) -> AttrPath {
+        AttrPath::parse(s).unwrap()
+    }
+
+    fn loc_id() -> impl Fn(usize) -> Location {
+        |_| Location { line: 1, column: 1 }
+    }
+
+    fn declared_input(id: &str, follows: &[(&str, &str)]) -> Input {
+        let mut input = Input::new(seg(id));
+        for (parent, target) in follows {
+            input.follows.push(Follows::Indirect {
+                path: AttrPath::new(seg(parent)),
+                target: Some(path(target)),
+            });
+        }
+        input.range = Range { start: 1, end: 2 };
+        input
+    }
+
+    fn make_inputs(items: Vec<Input>) -> InputMap {
+        let mut map = InputMap::new();
+        for input in items {
+            map.insert(input.id().as_str().to_string(), input);
+        }
+        map
+    }
+
+    #[test]
+    fn cycle_lint_lifts_self_loop() {
+        let inputs = make_inputs(vec![declared_input("foo", &[("foo", "foo.foo")])]);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let errs = lint_follows_cycle(&graph, &loc_id());
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(errs[0], ValidationError::FollowsCycle { .. }));
+    }
+
+    #[test]
+    fn stale_lint_returns_empty_without_lock() {
+        // Without a lock the resolved universe is empty, so every declared
+        // source registers as stale. The lock-aware lint only runs when the
+        // caller supplies a lock. The surrounding integration filters
+        // accordingly.
+        let inputs = make_inputs(vec![declared_input(
+            "home-manager",
+            &[("nixpkgs", "nixpkgs")],
+        )]);
+        let graph = build_graph(&inputs, None, 64);
+        let stale = lint_follows_stale(&graph, &loc_id());
+        assert_eq!(stale.len(), 1);
+    }
+
+    #[test]
+    fn stale_lint_with_lock_only_fires_for_missing_source() {
+        let inputs = make_inputs(vec![declared_input(
+            "home-manager",
+            &[("nixpkgs", "nixpkgs")],
+        )]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "home-manager": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ddd", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = crate::lock::FlakeLock::read_from_str(lock_text).unwrap();
+        let graph = build_graph(&inputs, Some(&lock), 64);
+        let stale = lint_follows_stale(&graph, &loc_id());
+        assert_eq!(stale.len(), 1);
+        assert!(matches!(stale[0], ValidationError::FollowsStale { .. }));
+        assert_eq!(stale[0].severity(), super::super::Severity::Warning);
+    }
+
+    #[test]
+    fn lints_emit_stale_lock_when_targets_diverge() {
+        let inputs = make_inputs(vec![
+            declared_input("crane", &[("nixpkgs", "nixpkgs")]),
+            declared_input("nixpkgs", &[]),
+        ]);
+        let lock_text = r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "abc", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "nixpkgs_2": {
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "def", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "crane": {
+      "inputs": { "nixpkgs": ["nixpkgs_2"] },
+      "locked": { "lastModified": 1, "narHash": "", "owner": "o", "repo": "r", "rev": "ggg", "type": "github" },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "crane": "crane" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#;
+        let lock = crate::lock::FlakeLock::read_from_str(lock_text).unwrap();
+        let graph = build_graph(&inputs, Some(&lock), 64);
+        let errs = lint_follows_stale_lock(&graph, &lock, &loc_id());
+        assert_eq!(errs.len(), 1);
+        match &errs[0] {
+            ValidationError::FollowsStaleLock {
+                source,
+                declared_target,
+                lock_target,
+                location,
+            } => {
+                assert_eq!(source.to_string(), "crane.nixpkgs");
+                assert_eq!(declared_target.to_string(), "nixpkgs");
+                assert_eq!(
+                    lock_target.as_ref().map(|p| p.to_string()),
+                    Some("nixpkgs_2".to_string())
+                );
+                assert_eq!(*location, Location { line: 1, column: 1 });
+            }
+            other => panic!("expected FollowsStaleLock, got {other:?}"),
+        }
+        assert_eq!(errs[0].severity(), super::super::Severity::Warning);
+    }
+
+    #[test]
+    fn target_not_toplevel_flags_unknown_target() {
+        let inputs = make_inputs(vec![
+            declared_input("home-manager", &[("nixpkgs", "does-not-exist")]),
+            declared_input("nixpkgs", &[]),
+        ]);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let top_level = top_level_names(&inputs);
+        let errs = lint_follows_target_not_toplevel(&graph, &top_level, &loc_id());
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(
+            errs[0],
+            ValidationError::FollowsTargetNotToplevel { .. }
+        ));
+    }
+
+    #[test]
+    fn target_not_toplevel_passes_for_known_target() {
+        let inputs = make_inputs(vec![
+            declared_input("home-manager", &[("nixpkgs", "nixpkgs")]),
+            declared_input("nixpkgs", &[]),
+        ]);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let top_level = top_level_names(&inputs);
+        let errs = lint_follows_target_not_toplevel(&graph, &top_level, &loc_id());
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn contradiction_flags_two_distinct_targets_for_same_source() {
+        // Mergeable `inputs = { ... }` attrsets land here alongside the
+        // duplicate-attribute lint. This lint surfaces the graph-level
+        // semantics.
+        let synthetic = synthetic_graph_with_contradiction();
+        let errs = lint_follows_contradiction(&synthetic, &loc_id());
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(
+            errs[0],
+            ValidationError::FollowsContradiction { .. }
+        ));
+    }
+
+    /// Build a [`FollowsGraph`] with two declared edges that share a source
+    /// but disagree on the target, by feeding [`FollowsGraph::from_declared`]
+    /// an [`InputMap`] with two `Follows` entries on the same input.
+    fn synthetic_graph_with_contradiction() -> FollowsGraph {
+        let mut inputs = InputMap::new();
+        let mut a = Input::new(seg("a"));
+        a.follows.push(Follows::Indirect {
+            path: AttrPath::new(seg("x")),
+            target: Some(path("y")),
+        });
+        a.follows.push(Follows::Indirect {
+            path: AttrPath::new(seg("x")),
+            target: Some(path("z")),
+        });
+        a.range = Range { start: 1, end: 2 };
+        inputs.insert("a".to_string(), a);
+        FollowsGraph::from_declared(&inputs)
+    }
+
+    #[test]
+    fn contradiction_passes_for_consistent_target() {
+        let inputs = make_inputs(vec![declared_input("a", &[("x", "y")])]);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let errs = lint_follows_contradiction(&graph, &loc_id());
+        assert!(errs.is_empty());
+    }
+
+    #[test]
+    fn depth_exceeded_flags_long_source_path() {
+        // Source path `a.b.c` (depth 3) tripped against max_depth = 1.
+        let mut inputs = InputMap::new();
+        let mut a = Input::new(seg("a"));
+        a.follows.push(Follows::Indirect {
+            path: AttrPath::parse("b.c").unwrap(),
+            target: Some(path("d")),
+        });
+        a.range = Range { start: 1, end: 2 };
+        inputs.insert("a".to_string(), a);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let errs = lint_follows_depth_exceeded(&graph, 1, &loc_id());
+        assert_eq!(errs.len(), 1);
+        assert!(matches!(
+            errs[0],
+            ValidationError::FollowsDepthExceeded { .. }
+        ));
+    }
+
+    #[test]
+    fn depth_exceeded_passes_when_within_bound() {
+        let inputs = make_inputs(vec![declared_input("a", &[("b", "c")])]);
+        let graph = FollowsGraph::from_declared(&inputs);
+        let errs = lint_follows_depth_exceeded(&graph, 4, &loc_id());
+        assert!(errs.is_empty());
+    }
+}

--- a/src/validate/syntax.rs
+++ b/src/validate/syntax.rs
@@ -1,0 +1,199 @@
+//! Syntax-level lints: rnix parse errors and duplicate-attribute detection.
+//!
+//! Entry point is [`collect`]. [`LineMap`] resolves CST byte offsets into
+//! [`Location`]s.
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+
+use rnix::{Root, SyntaxKind, SyntaxNode, TextRange};
+
+use super::error::{DuplicateAttr, Location, ValidationError};
+
+/// Lookup table that maps CST byte offsets to 1-indexed [`Location`]s.
+pub(super) struct LineMap {
+    line_starts: Vec<usize>,
+}
+
+impl LineMap {
+    pub(super) fn new(source: &str) -> Self {
+        let mut starts = vec![0];
+        for (i, c) in source.char_indices() {
+            if c == '\n' {
+                starts.push(i + 1);
+            }
+        }
+        Self {
+            line_starts: starts,
+        }
+    }
+
+    pub(super) fn offset_to_location(&self, offset: usize) -> Location {
+        let line = self
+            .line_starts
+            .iter()
+            .rposition(|&start| start <= offset)
+            .unwrap_or(0);
+        let column = offset - self.line_starts[line];
+        Location {
+            line: line + 1,
+            column: column + 1,
+        }
+    }
+
+    pub(super) fn range_to_location(&self, range: TextRange) -> Location {
+        self.offset_to_location(range.start().into())
+    }
+
+    pub(super) fn fallback_eof(&self) -> Location {
+        Location {
+            line: self.line_starts.len(),
+            column: 1,
+        }
+    }
+}
+
+/// Parse `source` with rnix and append parse errors and duplicate-attribute
+/// findings to `errors`.
+pub(super) fn collect(source: &str, errors: &mut Vec<ValidationError>) {
+    let line_map = LineMap::new(source);
+    let root = Root::parse(source);
+
+    for error in root.errors() {
+        let location = parse_error_location(error, &line_map);
+        errors.push(ValidationError::ParseError {
+            message: error.to_string(),
+            location,
+        });
+    }
+
+    let syntax = root.syntax();
+    check_node(&syntax, &line_map, errors);
+}
+
+fn parse_error_location(error: &rnix::ParseError, line_map: &LineMap) -> Location {
+    use rnix::ParseError::*;
+    match error {
+        Unexpected(r)
+        | UnexpectedExtra(r)
+        | UnexpectedWanted(_, r, _)
+        | UnexpectedDoubleBind(r)
+        | DuplicatedArgs(r, _) => line_map.range_to_location(*r),
+        UnexpectedEOF | UnexpectedEOFWanted(_) | RecursionLimitExceeded | _ => {
+            line_map.fallback_eof()
+        }
+    }
+}
+
+/// Render an attribute path node as a dotted string, e.g. `a.b.c`.
+fn extract_attrpath(attrpath: &SyntaxNode) -> String {
+    attrpath
+        .children()
+        .map(|child| match crate::follows::Segment::from_syntax(&child) {
+            Ok(seg) => seg.into_string(),
+            Err(_) => child.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn value_is_attrset(node: &SyntaxNode) -> bool {
+    node.children()
+        .any(|c| c.kind() == SyntaxKind::NODE_ATTR_SET)
+}
+
+fn check_node(node: &SyntaxNode, line_map: &LineMap, errors: &mut Vec<ValidationError>) {
+    if node.kind() == SyntaxKind::NODE_ATTR_SET {
+        check_attr_set(node, line_map, errors);
+    }
+    for child in node.children() {
+        check_node(&child, line_map, errors);
+    }
+}
+
+/// Check an attribute set for duplicate attributes.
+///
+/// Nix merges duplicate attribute names whose values are both attribute
+/// sets, e.g.
+/// ```nix
+/// {
+///   inputs = { nixpkgs.url = "..."; };
+///   inputs = { flake-utils.url = "..."; };
+/// }
+/// ```
+/// is equivalent to a single `inputs` carrying both entries. The merge is
+/// allowed. The merged contents are still checked for true conflicts.
+fn check_attr_set(attr_set: &SyntaxNode, line_map: &LineMap, errors: &mut Vec<ValidationError>) {
+    let mut seen: HashMap<String, (Location, bool, SyntaxNode)> = HashMap::new();
+    let mut merged_attrsets: HashMap<String, Vec<SyntaxNode>> = HashMap::new();
+
+    for child in attr_set.children() {
+        if child.kind() == SyntaxKind::NODE_ATTRPATH_VALUE
+            && let Some(attrpath) = child
+                .children()
+                .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
+        {
+            let path = extract_attrpath(&attrpath);
+            let location = line_map.range_to_location(attrpath.text_range());
+            let is_attrset = value_is_attrset(&child);
+
+            match seen.entry(path.clone()) {
+                Entry::Occupied(entry) => {
+                    let (ref first_loc, first_is_attrset, _) = *entry.get();
+                    if first_is_attrset && is_attrset {
+                        merged_attrsets.entry(path).or_default().push(child.clone());
+                    } else {
+                        errors.push(ValidationError::DuplicateAttribute(DuplicateAttr {
+                            path: entry.key().clone(),
+                            first: first_loc.clone(),
+                            duplicate: location,
+                        }));
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    if is_attrset {
+                        merged_attrsets.entry(path).or_default().push(child.clone());
+                    }
+                    entry.insert((location, is_attrset, child.clone()));
+                }
+            }
+        }
+    }
+
+    for nodes in merged_attrsets.values() {
+        if nodes.len() < 2 {
+            continue;
+        }
+        let mut cross_seen: HashMap<String, Location> = HashMap::new();
+        for node in nodes {
+            for attrset_child in node.children() {
+                if attrset_child.kind() != SyntaxKind::NODE_ATTR_SET {
+                    continue;
+                }
+                for inner in attrset_child.children() {
+                    if inner.kind() == SyntaxKind::NODE_ATTRPATH_VALUE
+                        && let Some(inner_path_node) = inner
+                            .children()
+                            .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
+                    {
+                        let inner_path = extract_attrpath(&inner_path_node);
+                        let inner_loc = line_map.range_to_location(inner_path_node.text_range());
+
+                        match cross_seen.entry(inner_path) {
+                            Entry::Occupied(e) => {
+                                errors.push(ValidationError::DuplicateAttribute(DuplicateAttr {
+                                    path: e.key().clone(),
+                                    first: e.get().clone(),
+                                    duplicate: inner_loc,
+                                }));
+                            }
+                            Entry::Vacant(e) => {
+                                e.insert(inner_loc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -1,4 +1,4 @@
-//! AST walking and manipulation for flake.nix files.
+//! CST walking and mutation for `flake.nix` files.
 
 mod context;
 mod error;
@@ -12,6 +12,7 @@ use rnix::{Root, SyntaxKind, SyntaxNode};
 
 use crate::change::Change;
 use crate::edit::{OutputChange, Outputs};
+use crate::follows::{AttrPath, Segment, strip_outer_quotes};
 use crate::input::Input;
 
 pub use context::Context;
@@ -19,10 +20,45 @@ pub use error::WalkerError;
 
 use inputs::walk_inputs;
 use node::{
-    adjacent_whitespace_index, get_sibling_whitespace, insertion_index_after,
-    make_nested_follows_attr, make_quoted_string, make_toplevel_flake_false_attr,
-    make_toplevel_nested_follows_attr, make_toplevel_url_attr, parse_node, substitute_child,
+    FollowsKind, adjacent_whitespace_index, get_sibling_whitespace, insertion_index_after,
+    make_quoted_string, make_toplevel_flake_false_attr, make_toplevel_url_attr, parse_node,
+    substitute_child,
 };
+
+/// Expected idents for a top-level flat follows attrpath of any depth:
+/// `inputs.<S0>.inputs.<S1>...inputs.<SN>.follows`.
+fn expected_toplevel_flat_idents(path: &AttrPath) -> Vec<&str> {
+    let mut out: Vec<&str> = Vec::with_capacity(path.len() * 2 + 2);
+    for seg in path.segments() {
+        out.push("inputs");
+        out.push(seg.as_str());
+    }
+    out.push("follows");
+    out
+}
+
+/// Expected idents for a block-style follows attrpath inside a parent input's
+/// `{ ... }` block: `inputs.<R0>.inputs.<R1>...inputs.<RN>.follows`.
+fn expected_block_follows_idents(rest: &[Segment]) -> Vec<&str> {
+    let mut out: Vec<&str> = Vec::with_capacity(rest.len() * 2 + 1);
+    for seg in rest.iter() {
+        out.push("inputs");
+        out.push(seg.as_str());
+    }
+    out.push("follows");
+    out
+}
+
+/// Whether a CST attrpath (idents may carry surrounding `"..."`) matches `expected`
+/// pairwise after unquoting.
+fn idents_match(have: &[String], expected: &[&str]) -> bool {
+    if have.len() != expected.len() {
+        return false;
+    }
+    have.iter()
+        .zip(expected.iter())
+        .all(|(h, e)| strip_outer_quotes(h) == *e)
+}
 
 #[derive(Debug, Clone)]
 pub struct Walker {
@@ -41,11 +77,11 @@ impl<'a> Walker {
         }
     }
 
-    /// Traverse the toplevel `flake.nix` file.
-    /// It should consist of three attribute keys:
-    /// - description
-    /// - inputs
-    /// - outputs
+    /// Apply `change` to the parsed `flake.nix`, returning the rebuilt root if
+    /// the tree was modified.
+    ///
+    /// Expects the parsed root to be an attrset with `description`, `inputs`, and
+    /// `outputs` keys.
     pub fn walk(&mut self, change: &Change) -> Result<Option<SyntaxNode>, WalkerError> {
         let cst = self.root.clone();
         if cst.kind() != SyntaxKind::NODE_ROOT {
@@ -54,12 +90,12 @@ impl<'a> Walker {
         self.walk_toplevel(cst, None, change)
     }
 
-    /// Only walk the outputs attribute
+    /// List the `outputs` arguments without touching `inputs`.
     pub(crate) fn list_outputs(&mut self) -> Result<Outputs, WalkerError> {
         outputs::list_outputs(&self.root)
     }
 
-    /// Only change the outputs attribute
+    /// Apply an [`OutputChange`] to the `outputs` attribute alone.
     pub(crate) fn change_outputs(
         &mut self,
         change: OutputChange,
@@ -67,7 +103,7 @@ impl<'a> Walker {
         outputs::change_outputs(&self.root, change)
     }
 
-    /// Traverse the toplevel `flake.nix` file.
+    /// Walk the top-level attrset, dispatching on `description`/`inputs`/`outputs`.
     fn walk_toplevel(
         &mut self,
         node: SyntaxNode,
@@ -117,20 +153,22 @@ impl<'a> Walker {
             }
         }
 
-        // Handle follows for toplevel flat-style inputs (inputs.X.url = "...")
-        if let Change::Follows { input, target } = change
-            && let Some(nested_id) = input.follows()
-        {
-            let parent_id = input.input();
-            if self.inputs.contains_key(parent_id) {
-                return self.handle_follows_flat_toplevel(&attr_set, parent_id, nested_id, target);
+        // Follows on toplevel flat-style inputs (`inputs.X.url = "..."`).
+        if let Change::Follows { input, target } = change {
+            let path = input.path();
+            if path.len() >= 2 {
+                let parent_id = input.input();
+                if self.inputs.contains_key(parent_id.as_str()) {
+                    let target_str = target.to_string();
+                    return self.handle_follows_flat_toplevel(&attr_set, path, &target_str);
+                }
             }
         }
 
         Ok(None)
     }
 
-    /// Handle adding follows to a toplevel flat-style input.
+    /// Add a follows attribute next to a toplevel flat-style input.
     ///
     /// Converts `inputs.crane.url = "github:...";` into:
     /// ```nix
@@ -140,10 +178,13 @@ impl<'a> Walker {
     fn handle_follows_flat_toplevel(
         &self,
         attr_set: &SyntaxNode,
-        parent_id: &str,
-        nested_id: &str,
+        path: &AttrPath,
         target: &str,
     ) -> Result<Option<SyntaxNode>, WalkerError> {
+        let parent_id = path.first();
+        // Toplevel-flat shape: `inputs.S0.inputs.S1...inputs.SN.follows`
+        // (2 * len + 1 idents).
+        let expected_flat = expected_toplevel_flat_idents(path);
         let mut last_parent_attr: Option<SyntaxNode> = None;
         let mut block_parent: Option<(SyntaxNode, SyntaxNode)> = None;
 
@@ -162,7 +203,7 @@ impl<'a> Walker {
             // Detect `inputs.{parent_id} = { ... }` block style
             if idents.len() == 2
                 && idents[0] == "inputs"
-                && idents[1] == parent_id
+                && strip_outer_quotes(&idents[1]) == parent_id.as_str()
                 && let Some(block_attr_set) = toplevel
                     .children()
                     .find(|c| c.kind() == SyntaxKind::NODE_ATTR_SET)
@@ -170,18 +211,12 @@ impl<'a> Walker {
                 block_parent = Some((toplevel.clone(), block_attr_set));
             }
 
-            // Check for existing follows: inputs.{parent_id}.inputs.{nested_id}.follows
-            if idents.len() == 5
-                && idents[0] == "inputs"
-                && idents[1] == parent_id
-                && idents[2] == "inputs"
-                && idents[3] == nested_id
-                && idents[4] == "follows"
-            {
+            // Check for existing follows: inputs.S0.inputs.S1...inputs.SN.follows
+            if idents_match(&idents, &expected_flat) {
                 let value_node = attrpath.next_sibling();
                 let current_target = value_node
                     .as_ref()
-                    .map(|v| v.to_string().trim_matches('"').to_string())
+                    .map(|v| strip_outer_quotes(&v.to_string()).to_string())
                     .unwrap_or_default();
 
                 if current_target == target {
@@ -200,24 +235,28 @@ impl<'a> Walker {
             }
 
             // Track last inputs.{parent_id}.* attribute
-            if idents.len() >= 2 && idents[0] == "inputs" && idents[1] == parent_id {
+            if idents.len() >= 2
+                && idents[0] == "inputs"
+                && strip_outer_quotes(&idents[1]) == parent_id.as_str()
+            {
                 last_parent_attr = Some(toplevel.clone());
             }
         }
 
         if let Some((toplevel, block_attr_set)) = block_parent {
+            let rest: Vec<Segment> = path.segments()[1..].to_vec();
             return self.handle_follows_block_toplevel(
                 attr_set,
                 &toplevel,
                 &block_attr_set,
-                nested_id,
+                &rest,
                 target,
             );
         }
 
         // No existing follows, insert after the last parent attribute
         if let Some(ref_child) = last_parent_attr {
-            let follows_node = make_toplevel_nested_follows_attr(parent_id, nested_id, target);
+            let follows_node = FollowsKind::TopLevelNested { path, target }.emit();
             let insert_index = insertion_index_after(&ref_child);
 
             let mut green = attr_set
@@ -246,9 +285,10 @@ impl<'a> Walker {
         attr_set: &SyntaxNode,
         toplevel: &SyntaxNode,
         block_attr_set: &SyntaxNode,
-        nested_id: &str,
+        rest: &[Segment],
         target: &str,
     ) -> Result<Option<SyntaxNode>, WalkerError> {
+        let expected_block = expected_block_follows_idents(rest);
         for attr in block_attr_set.children() {
             if attr.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
                 continue;
@@ -261,15 +301,11 @@ impl<'a> Walker {
             };
             let idents: Vec<String> = attrpath.children().map(|c| c.to_string()).collect();
 
-            if idents.len() == 3
-                && idents[0] == "inputs"
-                && idents[1] == nested_id
-                && idents[2] == "follows"
-            {
+            if idents_match(&idents, &expected_block) {
                 let value_node = attrpath.next_sibling();
                 let current_target = value_node
                     .as_ref()
-                    .map(|v| v.to_string().trim_matches('"').to_string())
+                    .map(|v| strip_outer_quotes(&v.to_string()).to_string())
                     .unwrap_or_default();
 
                 if current_target == target {
@@ -290,7 +326,7 @@ impl<'a> Walker {
             }
         }
 
-        let follows_node = make_nested_follows_attr(nested_id, target);
+        let follows_node = FollowsKind::BlockNested { rest, target }.emit();
         let children: Vec<_> = block_attr_set.children().collect();
         if let Some(last_child) = children.last() {
             let insert_index = last_child.index() + 1;
@@ -314,10 +350,10 @@ impl<'a> Walker {
         Ok(None)
     }
 
-    /// Handle `inputs = { ... }` attribute.
+    /// Apply `change` to the `inputs = { ... }` attribute.
     ///
-    /// `toplevel.replace_with()` propagates through NODE_ATTR_SET up to
-    /// NODE_ROOT, preserving any leading comments/trivia.
+    /// `toplevel.replace_with()` propagates through `NODE_ATTR_SET` up to `NODE_ROOT`,
+    /// preserving leading comments and trivia.
     fn handle_inputs_attr(
         &mut self,
         toplevel: &SyntaxNode,
@@ -335,11 +371,10 @@ impl<'a> Walker {
         Some(parse_node(&green.to_string()))
     }
 
-    /// Handle flat-style `inputs.foo.url = "..."` attributes.
+    /// Apply `change` to flat-style `inputs.foo.url = "..."` attributes.
     ///
-    /// For removals, builds the modified attr_set green and uses
-    /// `replace_with()` to propagate to NODE_ROOT.
-    /// For replacements, `toplevel.replace_with()` propagates naturally.
+    /// Removals rebuild the parent attrset green and `replace_with()` propagates to
+    /// `NODE_ROOT`. Replacements rely on `toplevel.replace_with()` to propagate.
     fn handle_inputs_flat(
         &mut self,
         attr_set: &SyntaxNode,
@@ -350,7 +385,7 @@ impl<'a> Walker {
     ) -> Option<SyntaxNode> {
         let replacement = walk_inputs(&mut self.inputs, child.clone(), ctx, change)?;
 
-        // If replacement is empty, remove the entire toplevel node and
+        // Empty replacement means we remove the entire toplevel node and
         // propagate through attr_set to NODE_ROOT.
         if replacement.to_string().is_empty() {
             let element: rnix::SyntaxElement = toplevel.clone().into();
@@ -369,10 +404,10 @@ impl<'a> Walker {
         Some(parse_node(&green.to_string()))
     }
 
-    /// Handle adding inputs when we've reached `outputs` but have no inputs yet.
+    /// Add a new input just before `outputs` when no `inputs` block exists yet.
     ///
-    /// Builds the modified attr_set green and uses `replace_with()` to
-    /// propagate to NODE_ROOT, preserving leading comments.
+    /// Rebuilds the parent attrset green. `replace_with()` propagates to `NODE_ROOT`
+    /// while preserving leading comments.
     fn handle_add_at_outputs(
         &mut self,
         attr_set: &SyntaxNode,
@@ -396,9 +431,9 @@ impl<'a> Walker {
             return None;
         }
 
-        // Find normalized whitespace (single newline + indent) by walking back
-        // from `outputs` through tokens. This handles comments between the last
-        // input and outputs correctly.
+        // Walk back from `outputs` through tokens to find a whitespace run, then
+        // normalize it to a single newline + indent. Walking through tokens (not
+        // siblings) lets us skip past comments between the last input and `outputs`.
         let ws_node = {
             let mut ws: Option<SyntaxNode> = None;
             let mut cursor = toplevel.prev_sibling_or_token();
@@ -429,7 +464,7 @@ impl<'a> Walker {
             green = green.insert_child(insert_pos, ws.green().into());
         }
 
-        // Add flake=false if needed
+        // Append `inputs.<id>.flake = false;` when the new input opts out of flake mode.
         if !flake {
             let no_flake = make_toplevel_flake_false_attr(id);
             green = green.insert_child(toplevel.index() + 1, no_flake.green().into());

--- a/src/walk/context.rs
+++ b/src/walk/context.rs
@@ -1,27 +1,25 @@
-/// A helper for the [`Walker`], in order to hold context while traversing the tree.
+use crate::follows::Segment;
+
+/// Path of enclosing input identifiers tracked by [`super::Walker`] during CST traversal.
 #[derive(Debug, Clone)]
 pub struct Context {
-    level: Vec<String>,
+    level: Vec<Segment>,
 }
 
 impl Context {
-    /// Returns the first (top) level of context, if any.
-    pub fn first(&self) -> Option<&str> {
-        self.level.first().map(|s| s.as_str())
+    /// Top-level enclosing segment, if any.
+    pub fn first(&self) -> Option<&Segment> {
+        self.level.first()
     }
 
-    /// Returns true if the first level matches the given string.
-    pub fn first_matches(&self, s: &str) -> bool {
+    /// Whether the top-level segment equals `s`.
+    pub fn first_matches(&self, s: &Segment) -> bool {
         self.first() == Some(s)
-    }
-
-    pub fn level(&self) -> &[String] {
-        &self.level
     }
 }
 
-impl From<String> for Context {
-    fn from(s: String) -> Self {
+impl From<Segment> for Context {
+    fn from(s: Segment) -> Self {
         Self { level: vec![s] }
     }
 }

--- a/src/walk/inputs.rs
+++ b/src/walk/inputs.rs
@@ -3,17 +3,72 @@ use std::collections::HashMap;
 use rnix::{SyntaxKind, SyntaxNode};
 
 use crate::change::Change;
+use crate::follows::{AttrPath, Segment, strip_outer_quotes};
 use crate::input::Input;
 
 use super::context::Context;
 use super::node::{
-    adjacent_whitespace_index, empty_node, get_sibling_whitespace, insertion_index_after,
-    make_attrset_url_attr, make_attrset_url_flake_false_attr, make_flake_false_attr,
-    make_follows_attr, make_nested_follows_attr, make_quoted_string, make_toplevel_follows_attr,
-    make_url_attr, parse_node, should_remove_input, should_remove_nested_input, substitute_child,
+    FollowsKind, adjacent_whitespace_index, empty_node, get_sibling_whitespace,
+    insertion_index_after, is_attrset_content_empty, make_attrset_url_attr,
+    make_attrset_url_flake_false_attr, make_flake_false_attr, make_quoted_string, make_url_attr,
+    parse_node, should_remove_input, should_remove_nested_input, substitute_child,
 };
 
-/// Remove a child node along with its adjacent whitespace.
+/// Sentinel segment used when CST text cannot form a valid [`Segment`].
+const INVALID_SEGMENT_SENTINEL: &str = "__invalid__";
+
+/// Read a CST node as an unquoted [`Segment`].
+///
+/// Falls back to [`INVALID_SEGMENT_SENTINEL`] when the node text would be
+/// rejected by [`Segment::from_unquoted`], so the walker keeps making forward
+/// progress against malformed input instead of panicking. Emits a
+/// `tracing::warn!` so the fall-through is observable.
+fn segment_from_syntax(node: &SyntaxNode) -> Segment {
+    Segment::from_syntax(node).unwrap_or_else(|err| {
+        let raw = node.to_string();
+        tracing::warn!(
+            "walk/inputs: invalid attribute segment {raw:?} ({err}); using sentinel \
+             {INVALID_SEGMENT_SENTINEL:?}"
+        );
+        Segment::from_unquoted(INVALID_SEGMENT_SENTINEL)
+            .expect("sentinel segment is non-empty and quote-free")
+    })
+}
+
+/// Parse the right-hand side of a `follows = "..."` binding into a typed
+/// target.
+///
+/// Empty input produces `None`, the in-flake analog of the lockfile's
+/// `Input::Indirect(None)` (`inputs.X = []`). Non-empty input is split
+/// on `/`, the only separator Nix recognises in a follows target. A `.`
+/// inside a segment is part of the identifier (`"hls-1.10/nixpkgs"` is
+/// two segments, not three). Each segment passes through
+/// [`Segment::from_unquoted`]; if the body is malformed the result
+/// falls back to a single-segment path built from `fallback_seg` so
+/// the walker never loses an entry.
+fn parse_follows_target(text: &str, fallback_seg: &Segment) -> Option<AttrPath> {
+    if text.is_empty() {
+        return None;
+    }
+    let body = strip_outer_quotes(text);
+    if body.is_empty() {
+        return None;
+    }
+    let mut segs = body
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .filter_map(|s| Segment::from_unquoted(s.to_string()).ok());
+    let Some(first) = segs.next() else {
+        return Some(AttrPath::new(fallback_seg.clone()));
+    };
+    let mut path = AttrPath::new(first);
+    for seg in segs {
+        path.push(seg);
+    }
+    Some(path)
+}
+
+/// Remove `node` from `parent` along with any adjacent whitespace token.
 fn remove_child_with_whitespace(
     parent: &SyntaxNode,
     node: &SyntaxNode,
@@ -27,32 +82,39 @@ fn remove_child_with_whitespace(
     parse_node(&green.to_string())
 }
 
-/// Insert a new Input node at the correct position or update it with new information.
-pub fn insert_with_ctx(
+/// Insert or update `inputs[id]` from a parsed `Input`.
+///
+/// When `ctx` carries an enclosing input, the `input` is interpreted as a follows
+/// edge attached to that owner instead of a top-level entry. Only depth-1 follows
+/// shapes (`<owner>.<id>.follows = ...`) hit this path. Deeper shapes are parsed up
+/// front in [`handle_attrpath_follows`] and bypass this helper.
+pub(crate) fn insert_with_ctx(
     inputs: &mut HashMap<String, Input>,
-    id: String,
+    id: Segment,
     input: Input,
     ctx: &Option<Context>,
 ) {
     if let Some(ctx) = ctx {
         if let Some(follows) = ctx.first() {
-            if let Some(node) = inputs.get_mut(follows) {
-                node.follows
-                    .push(crate::input::Follows::Indirect(id, input.url));
-                node.follows.sort();
-                node.follows.dedup();
+            // The follows target arrives as the `input.url` token.
+            let target = parse_follows_target(&input.url, &id);
+            let key = follows.as_str().to_string();
+            let nested_path = AttrPath::new(id.clone());
+            if let Some(node) = inputs.get_mut(&key) {
+                node.push_indirect_follows(nested_path, target);
             } else {
-                // In case the Input is not fully constructed
-                let mut stub = Input::new(follows.to_string());
-                stub.follows
-                    .push(crate::input::Follows::Indirect(id, input.url));
-                inputs.insert(follows.to_string(), stub);
+                let mut stub = Input::new(follows.clone());
+                stub.follows.push(crate::input::Follows::Indirect {
+                    path: nested_path,
+                    target,
+                });
+                inputs.insert(key, stub);
             }
         }
     } else {
-        // Update the input, in case there was already a stub present.
-        if let Some(node) = inputs.get_mut(&id) {
-            if !input.url.to_string().is_empty() {
+        let key = id.as_str().to_string();
+        if let Some(node) = inputs.get_mut(&key) {
+            if !input.url.is_empty() {
                 node.url = input.url;
                 node.range = input.range;
             }
@@ -60,19 +122,19 @@ pub fn insert_with_ctx(
                 node.flake = input.flake;
             }
         } else {
-            inputs.insert(id, input);
+            inputs.insert(key, input);
         }
     }
 }
 
-/// Walk the inputs section of a flake.nix file.
+/// Walk the `inputs` section of a `flake.nix`, applying `change` and recording
+/// every traversed input into `inputs`.
 pub fn walk_inputs(
     inputs: &mut HashMap<String, Input>,
     node: SyntaxNode,
     ctx: &Option<Context>,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    // Handle special node types at the top level
     match node.kind() {
         SyntaxKind::NODE_ATTRPATH => {
             if let Some(result) = handle_attrpath_follows(inputs, &node, change) {
@@ -83,78 +145,72 @@ pub fn walk_inputs(
         _ => {}
     }
 
-    // Handle Change::Follows for flat-style inputs (inputs inside an attr set)
-    // This adds follows to the inputs attr set when there's no nested block
+    // Add follows on flat-style inputs declared inside an `inputs = { ... }`
+    // attr set, when the parent input has no nested `{ ... }` block.
     if let Change::Follows { input, target } = change
         && node.kind() == SyntaxKind::NODE_ATTR_SET
         && ctx.is_none()
     {
+        let full_path = input.path();
         let parent_id = input.input();
-        let nested_id = input.follows();
+        let parent_id_str = parent_id.as_str();
+        let target_str = target.to_string();
 
-        if let Some(nested_id) = nested_id {
-            // Check if the parent input exists in this attr set (flat style)
-            let parent_exists = inputs.contains_key(parent_id);
+        if full_path.len() >= 2 {
+            let parent_exists = inputs.contains_key(parent_id_str);
 
-            // Check if this input uses nested-style (has an attr set block)
-            // If it does, we should NOT add flat-style follows here - the nested
-            // handler in handle_input_attr_set will add the follows inside the block
             let has_nested_block = node.children().any(|child| {
-                // Look for `parent_id = { ... }` pattern
                 if child.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
                     return false;
                 }
                 child
                     .first_child()
                     .and_then(|attrpath| attrpath.first_child())
-                    .map(|first_ident| first_ident.to_string() == parent_id)
+                    .map(|first_ident| {
+                        strip_outer_quotes(&first_ident.to_string()) == parent_id_str
+                    })
                     .unwrap_or(false)
                     && child
                         .children()
                         .any(|c| c.kind() == SyntaxKind::NODE_ATTR_SET)
             });
 
-            // Only use flat-style if the input exists AND doesn't have a nested block
             if parent_exists && !has_nested_block {
-                // Check if follows for this nested_id already exists (flat style)
                 if let Some(result) =
-                    find_existing_flat_follows(&node, parent_id, nested_id, target)
+                    find_existing_flat_follows(&node, full_path.segments(), &target_str)
                 {
                     return result;
                 }
 
-                // Add a flat-style follows attribute to this attr set
-                let follows_node = parse_node(&format!(
-                    "{}.inputs.{}.follows = \"{}\";",
-                    parent_id, nested_id, target
-                ));
+                let follows_node = FollowsKind::InputsBlockNested {
+                    path: full_path,
+                    target: &target_str,
+                }
+                .emit();
 
-                // Find the last attribute belonging to this input's parent
-                // This groups follows with their parent input instead of appending at the end
+                // Bail out (None) when the parent isn't declared in this
+                // block - `Walker::handle_follows_flat_toplevel` owns the
+                // split-declaration placement instead.
                 let children: Vec<_> = node.children().collect();
                 let insert_after = children.iter().rev().find(|child| {
-                    // Check if this child's attrpath starts with parent_id
                     child
                         .first_child()
                         .and_then(|attrpath| attrpath.first_child())
-                        .map(|first_ident| first_ident.to_string() == parent_id)
+                        .map(|first_ident| {
+                            strip_outer_quotes(&first_ident.to_string()) == parent_id_str
+                        })
                         .unwrap_or(false)
                 });
 
-                // Use the found position, or fall back to end of inputs
-                let reference_child = insert_after.or(children.last());
-                if let Some(ref_child) = reference_child {
+                if let Some(ref_child) = insert_after {
                     let insert_index = insertion_index_after(ref_child);
 
                     let mut green = node
                         .green()
                         .insert_child(insert_index, follows_node.green().into());
 
-                    // Copy whitespace from before the reference child, but normalize it
-                    // to a single newline + indentation (strip extra blank lines)
                     if let Some(whitespace) = get_sibling_whitespace(ref_child) {
                         let ws_str = whitespace.to_string();
-                        // Keep only the last newline and subsequent indentation
                         let normalized = if let Some(last_nl) = ws_str.rfind('\n') {
                             &ws_str[last_nl..]
                         } else {
@@ -169,8 +225,7 @@ pub fn walk_inputs(
             }
         }
 
-        if nested_id.is_none() {
-            // Only use flat-style if the input does not have a nested block.
+        if full_path.len() == 1 {
             let has_nested_block = node.children().any(|child| {
                 if child.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
                     return false;
@@ -178,7 +233,9 @@ pub fn walk_inputs(
                 child
                     .first_child()
                     .and_then(|attrpath| attrpath.first_child())
-                    .map(|first_ident| first_ident.to_string() == parent_id)
+                    .map(|first_ident| {
+                        strip_outer_quotes(&first_ident.to_string()) == parent_id_str
+                    })
                     .unwrap_or(false)
                     && child
                         .children()
@@ -186,20 +243,24 @@ pub fn walk_inputs(
             });
 
             if !has_nested_block {
-                let follows_node = make_toplevel_follows_attr(parent_id, target);
+                let follows_node = FollowsKind::TopLevelFlat {
+                    id: parent_id,
+                    target: &target_str,
+                }
+                .emit();
 
-                // Find the last attribute belonging to this input's parent
                 let children: Vec<_> = node.children().collect();
                 let insert_after = children.iter().rev().find(|child| {
                     child
                         .first_child()
                         .and_then(|attrpath| attrpath.first_child())
-                        .map(|first_ident| first_ident.to_string() == parent_id)
+                        .map(|first_ident| {
+                            strip_outer_quotes(&first_ident.to_string()) == parent_id_str
+                        })
                         .unwrap_or(false)
                 });
 
-                let reference_child = insert_after.or(children.last());
-                if let Some(ref_child) = reference_child {
+                if let Some(ref_child) = insert_after {
                     let insert_index = insertion_index_after(ref_child);
                     let mut green = node
                         .green()
@@ -240,9 +301,9 @@ pub fn walk_inputs(
         }
     }
 
-    // Handle Add into an empty `inputs = { }` attr set.
-    // Derive indentation from the whitespace preceding the parent `inputs`
-    // attrpath-value node, then indent contents one level deeper.
+    // Add an entry into an empty `inputs = { }` attr set.
+    // Indentation comes from the whitespace preceding the `inputs`
+    // attrpath-value node. Contents indent one level deeper.
     if node.kind() == SyntaxKind::NODE_ATTR_SET
         && ctx.is_none()
         && let Change::Add {
@@ -254,8 +315,6 @@ pub fn walk_inputs(
             .children()
             .any(|c| c.kind() == SyntaxKind::NODE_ATTRPATH_VALUE)
     {
-        // Derive indentation: look at the whitespace before the parent
-        // `inputs = { }` node to get the base indent, then add one level.
         let base_indent = node
             .parent()
             .and_then(|p| p.prev_sibling_or_token())
@@ -273,8 +332,8 @@ pub fn walk_inputs(
 
         let uri_node = make_url_attr(id, uri);
 
-        // Remove any existing whitespace between braces in the empty set,
-        // then rebuild from a clean string representation.
+        // Drop any whitespace already sitting between the braces, then
+        // rebuild the contents from scratch.
         let ws_index = node
             .children_with_tokens()
             .find(|t| t.kind() == SyntaxKind::TOKEN_WHITESPACE)
@@ -286,7 +345,6 @@ pub fn walk_inputs(
             node.green().into_owned()
         };
 
-        // Find closing brace position after potential whitespace removal
         let brace_index = green
             .children()
             .position(|c| c.as_token().map(|t| t.text() == "}").unwrap_or(false))
@@ -307,7 +365,6 @@ pub fn walk_inputs(
             offset += 1;
         }
 
-        // Add closing indent before the brace
         green = green.insert_child(
             brace_index + offset,
             parse_node(&closing_indent).green().into(),
@@ -319,8 +376,8 @@ pub fn walk_inputs(
     None
 }
 
-/// Handle flat-style URL attribute: `inputs.foo.url = "..."`
-/// Returns Some(node) if a modification was made.
+/// Handle a flat-style URL attribute (`inputs.foo.url = "..."`), returning the
+/// replacement node when `change` modifies it.
 fn handle_flat_url(
     inputs: &mut HashMap<String, Input>,
     input_id: &SyntaxNode,
@@ -328,11 +385,12 @@ fn handle_flat_url(
     ctx: &Option<Context>,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    let id_str = input_id.to_string();
-    let input = Input::with_url(id_str.clone(), url.to_string(), url.text_range());
-    insert_with_ctx(inputs, id_str.clone(), input, ctx);
+    let id_seg = segment_from_syntax(input_id);
+    let id_str = id_seg.as_str().to_string();
+    let input = Input::with_url(id_seg.clone(), url.to_string(), url.text_range());
+    insert_with_ctx(inputs, id_seg.clone(), input, ctx);
 
-    if should_remove_input(change, ctx, &id_str) {
+    if should_remove_input(change, ctx, &id_seg) {
         return Some(empty_node());
     }
 
@@ -349,25 +407,25 @@ fn handle_flat_url(
     None
 }
 
-/// Handle flat-style flake attribute: `inputs.foo.flake = false`
-/// Returns Some(node) if a modification was made.
+/// Handle a flat-style flake attribute (`inputs.foo.flake = false`), returning
+/// the replacement node when `change` removes the input.
 fn handle_flat_flake(
     input_id: &SyntaxNode,
     _is_flake: &SyntaxNode,
     ctx: &Option<Context>,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    let id_str = input_id.to_string();
+    let id_seg = segment_from_syntax(input_id);
 
-    if should_remove_input(change, ctx, &id_str) {
+    if should_remove_input(change, ctx, &id_seg) {
         return Some(empty_node());
     }
 
     None
 }
 
-/// Handle nested input attributes like `inputs.foo = { url = "..."; ... }`
-/// Returns Some(node) if a modification was made.
+/// Handle a nested input declaration (`inputs.foo = { url = "..."; ... }`),
+/// returning the replacement node when `change` modifies it.
 fn handle_nested_input(
     inputs: &mut HashMap<String, Input>,
     input_id: &SyntaxNode,
@@ -375,21 +433,21 @@ fn handle_nested_input(
     ctx: &Option<Context>,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    let id_str = input_id.to_string();
+    let id_seg = segment_from_syntax(input_id);
 
     for attr in nested_attr.children() {
         for binding in attr.children() {
             if binding.to_string() == "url" {
                 let url = binding.next_sibling().unwrap();
-                let input = Input::with_url(id_str.clone(), url.to_string(), url.text_range());
-                insert_with_ctx(inputs, id_str.clone(), input, ctx);
+                let input = Input::with_url(id_seg.clone(), url.to_string(), url.text_range());
+                insert_with_ctx(inputs, id_seg.clone(), input, ctx);
             }
-            if should_remove_input(change, ctx, &id_str) {
+            if should_remove_input(change, ctx, &id_seg) {
                 return Some(empty_node());
             }
         }
 
-        let context = id_str.clone().into();
+        let context: Context = id_seg.clone().into();
         if walk_input(inputs, &attr, &Some(context), change).is_some() {
             let replacement = remove_child_with_whitespace(nested_attr, &attr, attr.index());
             return Some(replacement);
@@ -399,9 +457,8 @@ fn handle_nested_input(
     None
 }
 
-/// Handle a NODE_IDENT child node during input walking.
-/// Processes flat-style input declarations like `inputs.nixpkgs.url = "..."`
-/// Returns Some(node) if a modification was made, None otherwise.
+/// Handle a `NODE_IDENT` child during input walking, covering flat-style
+/// declarations like `inputs.nixpkgs.url = "..."`.
 fn handle_child_ident(
     inputs: &mut HashMap<String, Input>,
     child: &rnix::SyntaxElement,
@@ -411,7 +468,8 @@ fn handle_child_ident(
     let child_node = child.as_node()?;
     let parent_sibling = child_node.parent().and_then(|p| p.next_sibling());
 
-    // Handle "inputs" identifier with next sibling
+    // `inputs` ident with a sibling (e.g. `inputs.foo.url = ...` or
+    // `inputs.foo = { ... }`).
     if child.to_string() == "inputs"
         && let Some(next_sibling) = child_node.next_sibling()
     {
@@ -446,10 +504,9 @@ fn handle_child_ident(
         }
     }
 
-    // Handle flat tree attributes like "inputs.X.Y"
     if child.to_string().starts_with("inputs") {
         let id = child_node.next_sibling()?;
-        let context = id.to_string().into();
+        let context: Context = segment_from_syntax(&id).into();
         if walk_inputs(inputs, child_node.clone(), &Some(context), change).is_some() {
             tracing::warn!(
                 "Flat tree attribute replacement not yet implemented for: {}",
@@ -461,9 +518,8 @@ fn handle_child_ident(
     None
 }
 
-/// Detect whether inputs predominantly use attrset style (`foo = { url = "..."; };`)
-/// or flat style (`foo.url = "...";`).
-/// Returns true if attrset style is more common among input declarations.
+/// Whether `parent`'s input declarations predominantly use attrset style
+/// (`foo = { url = "..."; };`) over flat style (`foo.url = "...";`).
 fn uses_attrset_style(parent: &SyntaxNode) -> bool {
     let mut attrset_count = 0usize;
     let mut flat_url_count = 0usize;
@@ -500,8 +556,8 @@ fn uses_attrset_style(parent: &SyntaxNode) -> bool {
     attrset_count > flat_url_count
 }
 
-/// Extract the indentation string from a whitespace node.
-/// Given whitespace like `\n    `, returns `    ` (everything after the last newline).
+/// Indent slice of a whitespace token: everything after the last `\n`.
+/// For `"\n    "` returns `"    "`.
 fn extract_indent(ws_str: &str) -> &str {
     if let Some(last_nl) = ws_str.rfind('\n') {
         &ws_str[last_nl + 1..]
@@ -510,8 +566,7 @@ fn extract_indent(ws_str: &str) -> &str {
     }
 }
 
-/// Handle a NODE_ATTRPATH_VALUE child node during input walking.
-/// Returns Some(node) if a modification was made, None otherwise.
+/// Handle a `NODE_ATTRPATH_VALUE` child during input walking.
 fn handle_child_attrpath_value(
     inputs: &mut HashMap<String, Input>,
     parent: &SyntaxNode,
@@ -521,25 +576,24 @@ fn handle_child_attrpath_value(
 ) -> Option<SyntaxNode> {
     let child_node = child.as_node().unwrap();
 
-    // Build context if not present
+    // Build a single-segment context from the attrpath when missing.
     let ctx = if ctx.is_none() {
         let maybe_input_id = child_node.children().find_map(|c| {
             c.children()
                 .find(|child| child.to_string() == "inputs")
                 .and_then(|input_child| input_child.prev_sibling())
         });
-        maybe_input_id.map(|id| id.to_string().into())
+        maybe_input_id.map(|id| segment_from_syntax(&id).into())
     } else {
         ctx.clone()
     };
 
-    // Try to walk the input and apply changes
     if let Some(replacement) = walk_input(inputs, child_node, &ctx, change) {
         let mut green = parent
             .green()
             .replace_child(child.index(), replacement.green().into());
 
-        // Remove adjacent whitespace if the replacement is empty
+        // Strip adjacent whitespace when the child was removed outright.
         if replacement.text().is_empty()
             && let Some(ws_index) = adjacent_whitespace_index(child)
         {
@@ -548,7 +602,7 @@ fn handle_child_attrpath_value(
         return Some(parse_node(&green.to_string()));
     }
 
-    // Handle Add change when no context exists
+    // Add a new entry into a non-empty `inputs = { ... }` block.
     if ctx.is_none()
         && let Change::Add {
             id: Some(id),
@@ -556,7 +610,6 @@ fn handle_child_attrpath_value(
             flake,
         } = change
     {
-        // Find the last NODE_ATTRPATH_VALUE child to append after it
         let last_attr = parent
             .children()
             .filter(|c| c.kind() == SyntaxKind::NODE_ATTRPATH_VALUE)
@@ -571,8 +624,8 @@ fn handle_child_attrpath_value(
 
         let use_attrset = uses_attrset_style(parent);
 
-        // Use whitespace from before the last input, but normalize to a single
-        // newline + indentation.  Copying the raw inter-entry whitespace would
+        // Reuse the whitespace before the last input but normalize to a single
+        // newline + indent. Copying the raw inter-entry whitespace would
         // duplicate blank lines when the closing brace already has one.
         let ws_reference = last_attr.as_ref().unwrap_or(child_node);
         if let Some(whitespace) = get_sibling_whitespace(ws_reference) {
@@ -633,50 +686,108 @@ fn handle_child_attrpath_value(
     None
 }
 
-/// Handle NODE_ATTRPATH nodes that represent "follows" attributes.
-/// Example: `inputs.nixpkgs.follows = "nixpkgs"`
+/// Handle a `NODE_ATTRPATH` whose last segment is `follows`, at any depth.
+///
+/// The owning input is the first non-`inputs` segment of the attrpath. The
+/// remaining non-`inputs` segments (excluding the trailing `follows`) form
+/// the nested-input path recorded on the owner as
+/// [`crate::input::Follows::Indirect`].
 fn handle_attrpath_follows(
     inputs: &mut HashMap<String, Input>,
     node: &SyntaxNode,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    let maybe_follows_id = node
-        .children()
-        .find(|child| child.to_string() == "follows")
-        .and_then(|input_child| input_child.prev_sibling());
+    let children: Vec<SyntaxNode> = node.children().collect();
+    let last = children.last()?;
+    if last.to_string() != "follows" {
+        return None;
+    }
 
-    let follows_id = maybe_follows_id.as_ref()?;
+    // First non-`inputs` segment owns the follows. Remaining non-`inputs`
+    // segments form the nested path beneath it.
+    let path_segments: Vec<(SyntaxNode, Segment)> = children[..children.len() - 1]
+        .iter()
+        .filter(|c| c.to_string() != "inputs")
+        .map(|c| (c.clone(), segment_from_syntax(c)))
+        .collect();
 
-    let maybe_input_id = node
-        .children()
-        .find(|child| child.to_string() == "inputs")
-        .and_then(|input_child| input_child.next_sibling());
+    let owner_node = path_segments.first()?.0.clone();
+    let owner_seg = path_segments.first()?.1.clone();
+    let rest: Vec<Segment> = path_segments[1..].iter().map(|(_, s)| s.clone()).collect();
 
-    let ctx = maybe_input_id.clone().map(|id| id.to_string().into());
+    let url_node = node.next_sibling()?;
 
-    let url_node = node.next_sibling().unwrap();
-    let input = Input::with_url(
-        follows_id.to_string(),
+    if rest.is_empty() {
+        // Toplevel direct follows: `inputs.<owner>.follows = "T"`. Store the
+        // target text as a synthetic url on the owning input so depth-1
+        // ctx-driven flows keep working, and honor a `Change::Remove`
+        // matching this owner.
+        let input = Input::with_url(
+            owner_seg.clone(),
+            url_node.to_string(),
+            url_node.text_range(),
+        );
+        insert_with_ctx(inputs, owner_seg.clone(), input, &None);
+        if change.is_remove()
+            && let Some(id) = change.id()
+            && id.matches_with_follows(&owner_seg, Some(&owner_seg))
+        {
+            return Some(empty_node());
+        }
+        return None;
+    }
+
+    let follows_seg = rest.last().cloned().expect("rest is non-empty");
+    let leaf_input = Input::with_url(
+        follows_seg.clone(),
         url_node.to_string(),
         url_node.text_range(),
     );
-    insert_with_ctx(inputs, follows_id.to_string(), input, &ctx);
 
-    // Remove a toplevel follows node
-    if let Some(input_id) = maybe_input_id
-        && change.is_remove()
+    // Build the [`crate::input::Follows::Indirect`] directly so we can carry
+    // the full multi-segment chain. `insert_with_ctx`'s single-segment path
+    // would truncate intermediate segments here.
+    let target = parse_follows_target(&leaf_input.url, &follows_seg);
+    let mut path_iter = rest.iter().cloned();
+    let mut nested_path = AttrPath::new(path_iter.next().expect("rest non-empty"));
+    for seg in path_iter {
+        nested_path.push(seg);
+    }
+
+    let key = owner_seg.as_str().to_string();
+    let entry = inputs
+        .entry(key)
+        .or_insert_with(|| Input::new(owner_seg.clone()));
+    entry.push_indirect_follows(nested_path, target);
+
+    // Remove the follows node when the change targets it. Depth-1 uses the
+    // existing two-segment matcher; depth-N walks the full
+    // [`crate::change::ChangeId`] path because
+    // [`crate::change::ChangeId::input`] / [`crate::change::ChangeId::follows`]
+    // only expose the first two segments.
+    if change.is_remove()
         && let Some(id) = change.id()
     {
-        let maybe_follows = maybe_follows_id.map(|id| id.to_string());
-        if id.matches_with_follows(&input_id.to_string(), maybe_follows) {
-            return Some(empty_node());
+        if rest.len() == 1 {
+            let owner_match_seg = segment_from_syntax(&owner_node);
+            if id.matches_with_follows(&owner_match_seg, Some(&follows_seg)) {
+                return Some(empty_node());
+            }
+        } else if rest.len() >= 2 {
+            let id_segs = id.path().segments();
+            if id_segs.len() == rest.len() + 1
+                && id_segs[0] == owner_seg
+                && id_segs[1..].iter().zip(rest.iter()).all(|(a, b)| a == b)
+            {
+                return Some(empty_node());
+            }
         }
     }
 
     None
 }
 
-/// Handle "url" attribute within an input's ATTRPATH.
+/// Handle a `url = ...` binding inside an input's attrset.
 fn handle_url_attr(
     inputs: &mut HashMap<String, Input>,
     node: &SyntaxNode,
@@ -686,14 +797,24 @@ fn handle_url_attr(
     change: &Change,
 ) -> Option<SyntaxNode> {
     if let Some(prev_id) = attr.prev_sibling() {
+        // `inputs.X.url = "..."` inside another input's attrset is a
+        // transitive URL override, not a follows. With ctx set,
+        // `insert_with_ctx` would read the URL string as a follows target.
+        if ctx.is_some() {
+            return None;
+        }
+        let prev_seg = segment_from_syntax(&prev_id);
+        let prev_str = prev_seg.as_str().to_string();
         if let Change::Remove { ids } = change
-            && ids.iter().any(|id| id.to_string() == prev_id.to_string())
+            && ids
+                .iter()
+                .any(|id| id.input().as_str() == prev_str && id.follows().is_none())
         {
             return Some(empty_node());
         }
         if let Change::Change { id, uri, .. } = change
             && let Some(id) = id
-            && *id == prev_id.to_string()
+            && *id == prev_str
             && let Some(uri) = uri
             && let Some(url_node) = child.next_sibling()
         {
@@ -701,16 +822,13 @@ fn handle_url_attr(
             return Some(substitute_child(node, url_node.index(), &new_url));
         }
         if let Some(sibling) = child.next_sibling() {
-            let input = Input::with_url(
-                prev_id.to_string(),
-                sibling.to_string(),
-                sibling.text_range(),
-            );
-            insert_with_ctx(inputs, prev_id.to_string(), input, ctx);
+            let input =
+                Input::with_url(prev_seg.clone(), sibling.to_string(), sibling.text_range());
+            insert_with_ctx(inputs, prev_seg, input, ctx);
         }
     }
 
-    // Handle nested follows within url attribute
+    // Nested follows that live as siblings of the `url` attribute.
     if let Some(parent) = child.parent()
         && let Some(sibling) = parent.next_sibling()
         && let Some(nested_child) = sibling.first_child()
@@ -727,24 +845,25 @@ fn handle_url_attr(
             };
 
             if let Some(follows_ident) = first_ident.next_sibling() {
-                // Flat attrpath style: `nixpkgs.follows = "nixpkgs"`
+                // Flat attrpath style: `nixpkgs.follows = "nixpkgs"`.
                 if follows_ident.to_string() == "follows" {
-                    let id = &first_ident;
+                    let id_seg = segment_from_syntax(&first_ident);
                     let Some(follows) = attrpath.next_sibling() else {
                         continue;
                     };
                     let input =
-                        Input::with_url(id.to_string(), follows.to_string(), follows.text_range());
-                    insert_with_ctx(inputs, id.to_string(), input, ctx);
-                    if should_remove_nested_input(change, ctx, &follows.to_string()) {
+                        Input::with_url(id_seg.clone(), follows.to_string(), follows.text_range());
+                    insert_with_ctx(inputs, id_seg, input, ctx);
+                    let follows_target_seg = segment_from_syntax(&follows);
+                    if should_remove_nested_input(change, ctx, &follows_target_seg) {
                         return Some(empty_node());
                     }
                 }
             } else if let Some(value_node) = attrpath.next_sibling()
                 && SyntaxKind::NODE_ATTR_SET == value_node.kind()
             {
-                // Deeply nested attrset style: `nixpkgs = { follows = "nixpkgs"; }`
-                let id = &first_ident;
+                // Nested attrset style: `nixpkgs = { follows = "nixpkgs"; }`.
+                let id_seg = segment_from_syntax(&first_ident);
                 for inner_attr in value_node.children() {
                     let Some(inner_path) = inner_attr.first_child() else {
                         continue;
@@ -757,12 +876,13 @@ fn handle_url_attr(
                             continue;
                         };
                         let input = Input::with_url(
-                            id.to_string(),
+                            id_seg.clone(),
                             follows.to_string(),
                             follows.text_range(),
                         );
-                        insert_with_ctx(inputs, id.to_string(), input, ctx);
-                        if should_remove_nested_input(change, ctx, &follows.to_string()) {
+                        insert_with_ctx(inputs, id_seg.clone(), input, ctx);
+                        let follows_target_seg = segment_from_syntax(&follows);
+                        if should_remove_nested_input(change, ctx, &follows_target_seg) {
                             return Some(empty_node());
                         }
                     }
@@ -773,7 +893,7 @@ fn handle_url_attr(
     None
 }
 
-/// Handle "flake" attribute within an input's ATTRPATH.
+/// Handle a `flake = ...` binding inside an input's attrset.
 fn handle_flake_attr(
     inputs: &mut HashMap<String, Input>,
     attr: &SyntaxNode,
@@ -783,39 +903,129 @@ fn handle_flake_attr(
     if let Some(input_id) = attr.prev_sibling()
         && let Some(is_flake) = attr.parent().unwrap().next_sibling()
     {
-        let mut input = Input::new(input_id.to_string());
+        let id_seg = segment_from_syntax(&input_id);
+        let mut input = Input::new(id_seg.clone());
         input.flake = is_flake.to_string().parse().unwrap();
         let text_range = input_id.text_range();
         input.range = crate::input::Range::from_text_range(text_range);
-        insert_with_ctx(inputs, input_id.to_string(), input, ctx);
-        if should_remove_nested_input(change, ctx, &input_id.to_string()) {
+        insert_with_ctx(inputs, id_seg.clone(), input, ctx);
+        if should_remove_nested_input(change, ctx, &id_seg) {
             return Some(empty_node());
         }
     }
     None
 }
 
-/// Handle "follows" attribute within an input's ATTRPATH.
+/// Handle a `follows = ...` binding inside an input's attrset, at any
+/// nesting depth.
+///
+/// Strips the literal `inputs` keywords from the parent attrpath. The
+/// surviving idents are the source chain. The owning input comes from `ctx`
+/// when present, or from `chain[0]` otherwise.
 fn handle_follows_attr(
     inputs: &mut HashMap<String, Input>,
     attr: &SyntaxNode,
     ctx: &Option<Context>,
     change: &Change,
 ) -> Option<SyntaxNode> {
-    let id = attr.prev_sibling().unwrap();
-    let follows = attr.parent().unwrap().next_sibling().unwrap();
-    let input = Input::with_url(id.to_string(), follows.to_string(), follows.text_range());
-    insert_with_ctx(inputs, id.to_string(), input.clone(), ctx);
-    if should_remove_input(change, ctx, input.id())
-        || should_remove_nested_input(change, ctx, input.id())
-    {
-        return Some(empty_node());
+    let attrpath = attr.parent().unwrap();
+    let follows_value = attrpath.next_sibling().unwrap();
+
+    let chain: Vec<SyntaxNode> = attrpath
+        .children()
+        .filter(|c| c.to_string() != "inputs" && c.to_string() != "follows")
+        .collect();
+
+    if chain.is_empty() {
+        return None;
     }
+
+    // Discriminator: the raw attrpath's first ident is `inputs` for the
+    // inside-an-input-block shape (chain is the nested path under the
+    // ctx-supplied owner), and the owner ident otherwise (chain[0] is the
+    // owner and must be stripped to produce the nested path).
+    let attrpath_starts_with_inputs = attrpath
+        .children()
+        .next()
+        .map(|c| c.to_string() == "inputs")
+        .unwrap_or(false);
+    let chain_first = segment_from_syntax(&chain[0]);
+    let (owner_seg, nested_segs): (Segment, Vec<Segment>) =
+        match ctx.as_ref().and_then(|c| c.first().cloned()) {
+            Some(ctx_owner) if attrpath_starts_with_inputs => {
+                (ctx_owner, chain.iter().map(segment_from_syntax).collect())
+            }
+            Some(ctx_owner) if ctx_owner == chain_first => (
+                ctx_owner,
+                chain[1..].iter().map(segment_from_syntax).collect(),
+            ),
+            Some(ctx_owner) => (ctx_owner, chain.iter().map(segment_from_syntax).collect()),
+            None => (
+                chain_first,
+                chain[1..].iter().map(segment_from_syntax).collect(),
+            ),
+        };
+
+    if nested_segs.len() <= 1 {
+        // Depth-1 stores a single-segment leaf and runs the remove-flow.
+        // The depth-N branch below builds a typed multi-segment path.
+        let leaf_seg = nested_segs
+            .first()
+            .cloned()
+            .unwrap_or_else(|| owner_seg.clone());
+        let input = Input::with_url(
+            leaf_seg.clone(),
+            follows_value.to_string(),
+            follows_value.text_range(),
+        );
+        insert_with_ctx(inputs, leaf_seg.clone(), input.clone(), ctx);
+        if should_remove_input(change, ctx, input.id())
+            || should_remove_nested_input(change, ctx, input.id())
+        {
+            return Some(empty_node());
+        }
+        return None;
+    }
+
+    let mut path_iter = nested_segs.iter().cloned();
+    let mut nested_path = AttrPath::new(path_iter.next().expect("len ≥ 2 above"));
+    for seg in path_iter {
+        nested_path.push(seg);
+    }
+    let url_text = follows_value.to_string();
+    let unquoted = strip_outer_quotes(&url_text);
+    let leaf_seg = nested_path.last().clone();
+    let target = parse_follows_target(unquoted, &leaf_seg);
+
+    let key = owner_seg.as_str().to_string();
+    let entry = inputs
+        .entry(key)
+        .or_insert_with(|| Input::new(owner_seg.clone()));
+    entry.push_indirect_follows(nested_path, target);
+
+    // Depth-N removal: same shape as the depth-N branch in
+    // [`handle_attrpath_follows`]. The chain's owner comes from `ctx` when
+    // present.
+    if change.is_remove()
+        && let Some(id) = change.id()
+    {
+        let id_segs = id.path().segments();
+        if id_segs.len() == nested_segs.len() + 1
+            && id_segs[0] == owner_seg
+            && id_segs[1..]
+                .iter()
+                .zip(nested_segs.iter())
+                .all(|(a, b)| a == b)
+        {
+            return Some(empty_node());
+        }
+    }
+
     None
 }
 
-/// Handle NODE_ATTRPATH within an input node.
-/// Dispatches to url, flake, and follows handlers.
+/// Dispatch a `NODE_ATTRPATH` inside an input attrset to the `url`, `flake`,
+/// or `follows` handler based on the leaf attribute name.
 fn handle_input_attrpath(
     inputs: &mut HashMap<String, Input>,
     node: &SyntaxNode,
@@ -847,20 +1057,27 @@ fn handle_input_attrpath(
     None
 }
 
-/// Check if a nested follows attribute already exists in an attr set.
-/// For example, inside `devenv = { ... inputs.nixpkgs.follows = "nixpkgs"; ... }`,
-/// check if `inputs.{nested_id}.follows` is already present.
+/// Result of a follows-attr lookup: the `NODE_ATTRPATH_VALUE` child carrying
+/// the match, its value node (if any), and whether the existing target already
+/// equals the desired one.
+struct ExistingFollows {
+    attr: SyntaxNode,
+    value: Option<SyntaxNode>,
+    same_target: bool,
+}
+
+/// Locate a follows attr inside `container` whose attrpath idents (with outer
+/// `"..."` stripped) match `expected` pairwise.
 ///
-/// Returns:
-/// - `Some(Some(node))` if follows exists (same target = unchanged node, different = retargeted)
-/// - `None` if no matching follows found
-fn find_existing_nested_follows(
-    node: &SyntaxNode,
-    attr_set: &SyntaxNode,
-    nested_id: &str,
+/// `expected` covers the entire attrpath, e.g. `["inputs", "nixpkgs", "follows"]`
+/// or `["crane", "inputs", "nixpkgs", "follows"]`. The caller decides how to
+/// splice the replacement back into the surrounding tree.
+fn find_existing_follows(
+    container: &SyntaxNode,
+    expected: &[&str],
     target: &str,
-) -> Option<Option<SyntaxNode>> {
-    for attr in attr_set.children() {
+) -> Option<ExistingFollows> {
+    for attr in container.children() {
         if attr.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
             continue;
         }
@@ -871,85 +1088,100 @@ fn find_existing_nested_follows(
             continue;
         };
         let idents: Vec<String> = attrpath.children().map(|c| c.to_string()).collect();
-
-        // Match `inputs.{nested_id}.follows`
-        if idents.len() == 3
-            && idents[0] == "inputs"
-            && idents[1] == nested_id
-            && idents[2] == "follows"
-        {
-            let value_node = attrpath.next_sibling();
-            let current_target = value_node
-                .as_ref()
-                .map(|v| v.to_string().trim_matches('"').to_string())
-                .unwrap_or_default();
-
-            if current_target == target {
-                return Some(Some(node.clone()));
-            }
-            if let Some(value) = value_node {
-                let new_value = make_quoted_string(target);
-                let new_attr = substitute_child(&attr, value.index(), &new_value);
-                let new_child = substitute_child(attr_set, attr.index(), &new_attr);
-                return Some(Some(substitute_child(node, attr_set.index(), &new_child)));
-            }
+        if idents.len() != expected.len() {
+            continue;
         }
+        if !idents
+            .iter()
+            .zip(expected.iter())
+            .all(|(have, want)| strip_outer_quotes(have) == *want)
+        {
+            continue;
+        }
+        let value = attrpath.next_sibling();
+        let current_target = value
+            .as_ref()
+            .map(|v| strip_outer_quotes(&v.to_string()).to_string())
+            .unwrap_or_default();
+        return Some(ExistingFollows {
+            attr,
+            value,
+            same_target: current_target == target,
+        });
     }
     None
 }
 
-/// Check if a flat-style follows attribute already exists.
-/// For example, `devenv.inputs.nixpkgs.follows = "nixpkgs"` in the top-level attr set.
+/// Expected attrpath idents for a follows lookup inside a parent input's
+/// `{ ... }` block: `inputs.<R0>.inputs.<R1>...inputs.<RN>.follows`.
+fn block_follows_idents(rest: &[Segment]) -> Vec<&str> {
+    let mut out: Vec<&str> = Vec::with_capacity(rest.len() * 2 + 1);
+    for seg in rest.iter() {
+        out.push("inputs");
+        out.push(seg.as_str());
+    }
+    out.push("follows");
+    out
+}
+
+/// Expected attrpath idents for a flat follows lookup outside a parent's
+/// block (e.g. inside `inputs = { ... }`): `<S0>.inputs.<S1>...inputs.<SN>.follows`.
+fn flat_follows_idents(path: &[Segment]) -> Vec<&str> {
+    let mut out: Vec<&str> = Vec::with_capacity(path.len() * 2);
+    for (i, seg) in path.iter().enumerate() {
+        if i > 0 {
+            out.push("inputs");
+        }
+        out.push(seg.as_str());
+    }
+    out.push("follows");
+    out
+}
+
+/// Locate an `inputs.<R0>...inputs.<RN>.follows` attr inside an input's
+/// `{ ... }` block and rebuild the surrounding `node`.
 ///
-/// Returns:
-/// - `Some(Some(node))` if follows exists (same target = unchanged node, different = retargeted)
-/// - `None` if no matching follows found
-fn find_existing_flat_follows(
+/// Returns the unchanged outer node on a same-target hit, the retargeted
+/// outer node on a different-target hit, or `None` when no match exists.
+fn find_existing_nested_follows(
     node: &SyntaxNode,
-    parent_id: &str,
-    nested_id: &str,
+    attr_set: &SyntaxNode,
+    rest: &[Segment],
     target: &str,
 ) -> Option<Option<SyntaxNode>> {
-    for child in node.children() {
-        if child.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
-            continue;
-        }
-        let Some(attrpath) = child
-            .children()
-            .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
-        else {
-            continue;
-        };
-        let idents: Vec<String> = attrpath.children().map(|c| c.to_string()).collect();
-
-        // Match `{parent_id}.inputs.{nested_id}.follows`
-        if idents.len() == 4
-            && idents[0] == parent_id
-            && idents[1] == "inputs"
-            && idents[2] == nested_id
-            && idents[3] == "follows"
-        {
-            let value_node = attrpath.next_sibling();
-            let current_target = value_node
-                .as_ref()
-                .map(|v| v.to_string().trim_matches('"').to_string())
-                .unwrap_or_default();
-
-            if current_target == target {
-                return Some(Some(node.clone()));
-            }
-            if let Some(value) = value_node {
-                let new_value = make_quoted_string(target);
-                let new_attr = substitute_child(&child, value.index(), &new_value);
-                return Some(Some(substitute_child(node, child.index(), &new_attr)));
-            }
-        }
+    let expected = block_follows_idents(rest);
+    let found = find_existing_follows(attr_set, &expected, target)?;
+    if found.same_target {
+        return Some(Some(node.clone()));
     }
-    None
+    let value = found.value?;
+    let new_value = make_quoted_string(target);
+    let new_attr = substitute_child(&found.attr, value.index(), &new_value);
+    let new_child = substitute_child(attr_set, found.attr.index(), &new_attr);
+    Some(Some(substitute_child(node, attr_set.index(), &new_child)))
 }
 
-/// Handle NODE_ATTR_SET within an input node.
-/// Processes nested attribute sets containing url and inputs.
+/// Locate a flat `<S0>.inputs.<S1>...inputs.<SN>.follows` attr at `node`'s
+/// level (e.g. inside an `inputs = { ... }` block) and rebuild it the same
+/// way as [`find_existing_nested_follows`].
+fn find_existing_flat_follows(
+    node: &SyntaxNode,
+    path: &[Segment],
+    target: &str,
+) -> Option<Option<SyntaxNode>> {
+    let expected = flat_follows_idents(path);
+    let found = find_existing_follows(node, &expected, target)?;
+    if found.same_target {
+        return Some(Some(node.clone()));
+    }
+    let value = found.value?;
+    let new_value = make_quoted_string(target);
+    let new_attr = substitute_child(&found.attr, value.index(), &new_value);
+    Some(Some(substitute_child(node, found.attr.index(), &new_attr)))
+}
+
+/// Handle a `NODE_ATTR_SET` inside an input node, processing nested
+/// `url` and `inputs` bindings.
 fn handle_input_attr_set(
     inputs: &mut HashMap<String, Input>,
     node: &SyntaxNode,
@@ -960,16 +1192,17 @@ fn handle_input_attr_set(
     for attr in child.children() {
         for leaf in attr.children() {
             if leaf.to_string() == "url" {
-                let id = child.prev_sibling().unwrap();
+                let id_node = child.prev_sibling().unwrap();
+                let id_seg = segment_from_syntax(&id_node);
+                let id_str = id_seg.as_str().to_string();
                 let uri = leaf.next_sibling().unwrap();
-                let input = Input::with_url(id.to_string(), uri.to_string(), uri.text_range());
-                insert_with_ctx(inputs, id.to_string(), input, ctx);
+                let input = Input::with_url(id_seg.clone(), uri.to_string(), uri.text_range());
+                insert_with_ctx(inputs, id_seg.clone(), input, ctx);
 
-                // Remove matched node.
                 if let Change::Remove { ids } = change
-                    && ids
-                        .iter()
-                        .any(|candidate| candidate.to_string() == id.to_string())
+                    && ids.iter().any(|candidate| {
+                        candidate.input().as_str() == id_str && candidate.follows().is_none()
+                    })
                 {
                     return Some(empty_node());
                 }
@@ -979,7 +1212,7 @@ fn handle_input_attr_set(
                     uri: Some(new_uri),
                     ..
                 } = change
-                    && *change_id == id.to_string()
+                    && *change_id == id_str
                 {
                     let new_url = make_quoted_string(new_uri);
                     let new_attr =
@@ -990,15 +1223,16 @@ fn handle_input_attr_set(
             }
 
             if leaf.to_string().starts_with("inputs") {
-                let id = child.prev_sibling().unwrap();
-                let context: Context = id.to_string().into();
+                let id_node = child.prev_sibling().unwrap();
+                let id_seg = segment_from_syntax(&id_node);
+                let context: Context = id_seg.clone().into();
                 let ctx_some = Some(context);
                 if let Some(replacement) = walk_inputs(inputs, child.clone(), &ctx_some, change) {
                     return Some(substitute_child(node, child.index(), &replacement));
                 }
 
-                // Handle deeply nested inputs attrset removal:
-                // `inputs = { nixpkgs = { follows = "nixpkgs"; }; }`
+                // Removal inside a nested inputs attrset:
+                // `inputs = { nixpkgs = { follows = "nixpkgs"; }; }`.
                 if leaf.to_string() == "inputs"
                     && change.is_remove()
                     && let Some(inputs_attrset) = attr
@@ -1015,18 +1249,35 @@ fn handle_input_attr_set(
                         let Some(nested_id) = nested_path.first_child() else {
                             continue;
                         };
-                        if should_remove_nested_input(change, &ctx_some, &nested_id.to_string()) {
+                        let nested_seg = segment_from_syntax(&nested_id);
+                        if should_remove_nested_input(change, &ctx_some, &nested_seg) {
                             let new_inputs_attrset = remove_child_with_whitespace(
                                 &inputs_attrset,
                                 &nested_entry,
                                 nested_entry.index(),
                             );
-                            let new_attr = substitute_child(
-                                &attr,
-                                inputs_attrset.index(),
-                                &new_inputs_attrset,
-                            );
-                            let new_child = substitute_child(child, attr.index(), &new_attr);
+
+                            // Prune the now-empty `inputs = { ... }` binding
+                            // when it became content-empty as a consequence
+                            // of this removal. Comments inside the block are
+                            // user-authored content and suppress pruning.
+                            //
+                            // The pruning is bounded to the `inputs` binding:
+                            // the input's own outer block (e.g. `disko = { url
+                            // = "..."; inputs = { ... }; }`) keeps its url and
+                            // any other siblings intact even if the binding
+                            // itself disappears.
+                            let new_child = if is_attrset_content_empty(&new_inputs_attrset) {
+                                remove_child_with_whitespace(child, &attr, attr.index())
+                            } else {
+                                let new_attr = substitute_child(
+                                    &attr,
+                                    inputs_attrset.index(),
+                                    &new_inputs_attrset,
+                                );
+                                substitute_child(child, attr.index(), &new_attr)
+                            };
+
                             return Some(substitute_child(node, child.index(), &new_child));
                         }
                     }
@@ -1035,36 +1286,38 @@ fn handle_input_attr_set(
         }
     }
 
-    // Handle Change::Follows - add follows to this input's attr set
     if let Change::Follows { input, target } = change {
+        let full_path = input.path();
         let parent_id = input.input();
-        let nested_id = input.follows();
+        let parent_id_str = parent_id.as_str();
+        let target_str = target.to_string();
 
-        // Check if this attr set belongs to the input we want to modify
         if let Some(id_node) = child.prev_sibling()
-            && id_node.to_string() == parent_id
+            && strip_outer_quotes(&id_node.to_string()) == parent_id_str
         {
-            if let Some(nested_id) = nested_id {
-                // Check if follows for this nested_id already exists in the attr set
-                if let Some(result) = find_existing_nested_follows(node, child, nested_id, target) {
+            // Inside the parent's `{ ... }` block, emit the chain relative
+            // to the parent (everything below it).
+            let rest: Vec<Segment> = full_path.segments()[1..].to_vec();
+            if !rest.is_empty() {
+                if let Some(result) = find_existing_nested_follows(node, child, &rest, &target_str)
+                {
                     return result;
                 }
 
-                // Insert the follows attribute into this attr set
-                let follows_node = make_nested_follows_attr(nested_id, target);
+                let follows_node = FollowsKind::BlockNested {
+                    rest: &rest,
+                    target: &target_str,
+                }
+                .emit();
 
-                // Find the last actual child (before the closing brace)
-                // and get whitespace from before it
                 let children: Vec<_> = child.children().collect();
                 if let Some(last_child) = children.last() {
-                    // Insert after the last child with proper whitespace
                     let insert_index = last_child.index() + 1;
 
                     let mut green = child
                         .green()
                         .insert_child(insert_index, follows_node.green().into());
 
-                    // Copy whitespace from before the last child
                     if let Some(whitespace) = get_sibling_whitespace(last_child) {
                         green = green.insert_child(insert_index, whitespace.green().into());
                     }
@@ -1072,7 +1325,7 @@ fn handle_input_attr_set(
                     let new_child = parse_node(&green.to_string());
                     return Some(substitute_child(node, child.index(), &new_child));
                 }
-            } else {
+            } else if full_path.len() == 1 {
                 let has_follows = child.children().any(|attr| {
                     attr.first_child()
                         .and_then(|attrpath| attrpath.first_child())
@@ -1081,7 +1334,10 @@ fn handle_input_attr_set(
                 });
 
                 if !has_follows {
-                    let follows_node = make_follows_attr(target);
+                    let follows_node = FollowsKind::BlockBare {
+                        target: &target_str,
+                    }
+                    .emit();
                     let children: Vec<_> = child.children().collect();
                     if let Some(last_child) = children.last() {
                         let insert_index = insertion_index_after(last_child);
@@ -1104,18 +1360,20 @@ fn handle_input_attr_set(
     None
 }
 
-/// Walk a single input field.
-/// Example:
+/// Walk a single input declaration in either flat or attrset shape:
+///
 /// ```nix
-///  flake-utils.url = "github:numtide/flake-utils";
+/// flake-utils.url = "github:numtide/flake-utils";
 /// ```
+///
 /// or
+///
 /// ```nix
-///  rust-overlay = {
-///  url = "github:oxalica/rust-overlay";
-///  inputs.nixpkgs.follows = "nixpkgs";
-///  inputs.flake-utils.follows = "flake-utils";
-///  };
+/// rust-overlay = {
+///   url = "github:oxalica/rust-overlay";
+///   inputs.nixpkgs.follows = "nixpkgs";
+///   inputs.flake-utils.follows = "flake-utils";
+/// };
 /// ```
 pub fn walk_input(
     inputs: &mut HashMap<String, Input>,
@@ -1137,4 +1395,352 @@ pub fn walk_input(
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::change::{Change, ChangeId};
+    use crate::walk::Walker;
+
+    /// Apply `change` to `flake_text` via [`Walker`] and return the resulting
+    /// flake.nix text. Asserts the walker actually rewrites the tree.
+    fn apply(flake_text: &str, change: &Change) -> String {
+        let mut walker = Walker::new(flake_text);
+        let result = walker
+            .walk(change)
+            .expect("walker error")
+            .expect("walker did not rewrite the tree");
+        result.to_string()
+    }
+
+    /// Like [`apply`], but tolerates the walker returning `None` (no rewrite).
+    fn apply_maybe(flake_text: &str, change: &Change) -> Option<String> {
+        let mut walker = Walker::new(flake_text);
+        walker
+            .walk(change)
+            .expect("walker error")
+            .map(|n| n.to_string())
+    }
+
+    /// Re-run the walker until it converges, mirroring the loop in
+    /// [`FlakeEdit::apply_change`] for `Change::Remove`.
+    fn apply_until_fixed(flake_text: &str, change: &Change) -> String {
+        let mut walker = Walker::new(flake_text);
+        let mut last: Option<String> = None;
+        // Hard cap guards against a future non-monotonic regression in
+        // walker passes. `Change::Remove` is monotonic today, but the
+        // helper has no semantic stake in that.
+        for _ in 0..16 {
+            let Some(changed) = walker.walk(change).expect("walker error") else {
+                break;
+            };
+            let s = changed.to_string();
+            if last.as_ref() == Some(&s) {
+                break;
+            }
+            last = Some(s);
+            walker.root = changed;
+        }
+        last.expect("walker did not rewrite the tree")
+    }
+
+    #[test]
+    fn remove_depth_two_follows_inputs_block_flat() {
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, ... }: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("flake-edit.nested-helper.nixpkgs").unwrap()],
+        };
+        let result = apply(flake, &change);
+
+        assert!(
+            !result.contains("nested-helper"),
+            "depth-2 follows line should be removed, got:\n{result}"
+        );
+        assert!(
+            result.contains("flake-edit.url ="),
+            "depth-1 url declaration must remain intact, got:\n{result}"
+        );
+        assert!(
+            result.contains("flake-edit.inputs.nixpkgs.follows = \"nixpkgs\""),
+            "depth-1 follows must remain intact, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn remove_depth_two_follows_block_style() {
+        let flake = r#"{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.flake-edit = {
+    url = "github:a-kenji/flake-edit";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, ... }: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("flake-edit.nested-helper.nixpkgs").unwrap()],
+        };
+        let result = apply(flake, &change);
+
+        assert!(
+            !result.contains("nested-helper"),
+            "depth-2 follows line should be removed, got:\n{result}"
+        );
+        assert!(
+            result.contains("url = \"github:a-kenji/flake-edit\""),
+            "parent input's url binding must remain intact, got:\n{result}"
+        );
+        assert!(
+            result.contains("inputs.nixpkgs.follows = \"nixpkgs\""),
+            "depth-1 follows in parent block must remain intact, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn remove_depth_three_follows() {
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    omnibus.url = "github:Lehmanator/nix-configs";
+    omnibus.inputs.nixpkgs.follows = "nixpkgs";
+    omnibus.inputs.flops.inputs.POP.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, ... }: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("omnibus.flops.POP.nixpkgs").unwrap()],
+        };
+        let result = apply(flake, &change);
+
+        assert!(
+            !result.contains("flops"),
+            "depth-3 follows line should be removed, got:\n{result}"
+        );
+        assert!(
+            result.contains("omnibus.url ="),
+            "parent url declaration must remain intact, got:\n{result}"
+        );
+        assert!(
+            result.contains("omnibus.inputs.nixpkgs.follows = \"nixpkgs\""),
+            "depth-1 follows must remain intact, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn remove_nested_follows_prunes_empty_intermediate_block() {
+        // The depth-1 follows is the only entry in `disko.inputs = { ... }`.
+        // After removal, the now-empty `inputs = { }` block must be pruned
+        // along with the line that hosted it.
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = _: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("disko.nixpkgs").unwrap()],
+        };
+        let result = apply_until_fixed(flake, &change);
+
+        assert!(
+            !result.contains("inputs = {\n      };"),
+            "empty intermediate `inputs = {{ }}` block must be pruned, got:\n{result}"
+        );
+        assert!(
+            !result.contains("nixpkgs.follows"),
+            "follows line must be removed, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn remove_nested_follows_preserves_comment_inside_block() {
+        // A user-authored comment inside the nested block is content and
+        // must suppress pruning even after the only binding is removed.
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs = {
+        # keep this annotation
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = _: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("disko.nixpkgs").unwrap()],
+        };
+        let result = apply_until_fixed(flake, &change);
+
+        assert!(
+            result.contains("# keep this annotation"),
+            "user comment inside the inputs block must be preserved, got:\n{result}"
+        );
+        assert!(
+            result.contains("inputs = {"),
+            "block carrying a comment must NOT be pruned, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn pre_existing_empty_inputs_block_is_not_touched() {
+        // The user wrote an empty `inputs = { };` deliberately on `disko`,
+        // and a separate sibling `other` carries a follows that *will* be
+        // removed. The prune branch fires while processing `other`, so
+        // the walker actually traverses the tree; the user-authored empty
+        // block on `disko` must remain intact. This guards against the
+        // prune over-firing on pre-existing empties that were not a
+        // consequence of the current removal.
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs = {
+      };
+    };
+
+    other = {
+      url = "github:owner/other";
+      inputs = {
+        nixpkgs = {
+          follows = "nixpkgs";
+        };
+      };
+    };
+  };
+
+  outputs = _: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("other.nixpkgs").unwrap()],
+        };
+        let result = apply_until_fixed(flake, &change);
+
+        assert!(
+            result.contains("url = \"github:nix-community/disko\""),
+            "disko url must remain, got:\n{result}"
+        );
+        // The `disko.inputs = { };` user-authored empty must persist
+        // (whitespace-aware, since indentation may shift slightly).
+        assert!(
+            result.matches("inputs = {").count() >= 2,
+            "pre-existing user-authored empty `inputs = {{ }}` on disko must remain alongside the toplevel block, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_depth_two_follows_does_not_remove_sibling_url() {
+        // The depth-2 path is absent from this flake. The depth-N matcher
+        // must not fall through to the input-removal handlers and strip
+        // the parent `flake-edit.url` line.
+        let flake = r#"{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, ... }: { };
+}
+"#;
+        let change = Change::Remove {
+            ids: vec![ChangeId::parse("flake-edit.nested-helper.nixpkgs").unwrap()],
+        };
+        let result = apply_maybe(flake, &change).unwrap_or_else(|| flake.to_string());
+
+        assert!(
+            result.contains("flake-edit.url = \"github:a-kenji/flake-edit\""),
+            "sibling url line must NOT be removed for a nonexistent depth-2 path, got:\n{result}"
+        );
+        assert!(
+            result.contains("flake-edit.inputs.nixpkgs.follows = \"nixpkgs\""),
+            "sibling depth-1 follows line must NOT be removed, got:\n{result}"
+        );
+        assert!(
+            result.contains("nixpkgs.url ="),
+            "top-level nixpkgs.url must remain intact, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn parse_follows_target_accepts_slash_form() {
+        use crate::follows::Segment;
+        let fallback = Segment::from_unquoted("fallback").unwrap();
+        let parsed = super::parse_follows_target("hyprland/hyprlang", &fallback)
+            .expect("non-empty input must parse to Some");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed.first().as_str(), "hyprland");
+        assert_eq!(parsed.last().as_str(), "hyprlang");
+    }
+
+    #[test]
+    fn parse_follows_target_dot_inside_segment_is_not_a_separator() {
+        use crate::follows::Segment;
+        let fallback = Segment::from_unquoted("fallback").unwrap();
+
+        let single = super::parse_follows_target("hls-1.10", &fallback).unwrap();
+        assert_eq!(single.len(), 1);
+        assert_eq!(single.first().as_str(), "hls-1.10");
+
+        let two = super::parse_follows_target("hls-1.10/nixpkgs", &fallback).unwrap();
+        assert_eq!(two.len(), 2);
+        assert_eq!(two.first().as_str(), "hls-1.10");
+        assert_eq!(two.last().as_str(), "nixpkgs");
+    }
+
+    #[test]
+    fn segment_from_syntax_falls_back_to_sentinel_on_empty_string() {
+        use rnix::SyntaxKind;
+
+        // An empty quoted attribute (`""`) parses but its segment text is
+        // empty, so `Segment::from_source` rejects it and the walker has to
+        // substitute the sentinel to keep traversing.
+        let src = r#"{ inputs."" = {}; }"#;
+        let parsed = rnix::Root::parse(src);
+        fn find_first_string(node: rnix::SyntaxNode) -> Option<rnix::SyntaxNode> {
+            if node.kind() == SyntaxKind::NODE_STRING {
+                return Some(node);
+            }
+            for c in node.children() {
+                if let Some(s) = find_first_string(c) {
+                    return Some(s);
+                }
+            }
+            None
+        }
+        let empty_string = find_first_string(parsed.syntax()).expect("CST has an empty string");
+        let seg = super::segment_from_syntax(&empty_string);
+        assert_eq!(seg.as_str(), super::INVALID_SEGMENT_SENTINEL);
+    }
 }

--- a/src/walk/node.rs
+++ b/src/walk/node.rs
@@ -1,18 +1,18 @@
 use rnix::{Root, SyntaxKind, SyntaxNode};
 
 use crate::change::Change;
+use crate::follows::{AttrPath, Segment};
 
 use super::context::Context;
 
-// Type alias for clearer function signatures
 pub type Node = SyntaxNode;
 
-/// Parse a string into a SyntaxNode.
+/// Parse `s` as a Nix expression and return its [`SyntaxNode`].
 pub fn parse_node(s: &str) -> Node {
     Root::parse(s).syntax()
 }
 
-/// Replace a child in a parent node and return the rebuilt SyntaxNode.
+/// Replace `parent`'s child at `index` with `new_child` and return the rebuilt node.
 pub fn substitute_child(parent: &SyntaxNode, index: usize, new_child: &SyntaxNode) -> Node {
     let green = parent
         .green()
@@ -20,13 +20,43 @@ pub fn substitute_child(parent: &SyntaxNode, index: usize, new_child: &SyntaxNod
     parse_node(&green.to_string())
 }
 
-/// Create an empty syntax node, used when removing nodes.
+/// Empty syntax node used as a removal placeholder.
 pub fn empty_node() -> Node {
     Root::parse("").syntax()
 }
 
-/// Get a whitespace node copied from adjacent siblings, if present.
-/// Checks previous sibling first, then next sibling.
+/// Whether `attr_set` carries no semantic content (no bindings, no comments).
+///
+/// Returns true only for `NODE_ATTR_SET` nodes whose body contains nothing
+/// but braces and whitespace. Comments count as user-authored content and
+/// suppress the empty verdict, so the prune pass must not collapse a block
+/// the user populated with intent. A `NODE_ROOT` wrapper produced by
+/// [`parse_node`] is unwrapped to its inner attrset so re-parsed fragments
+/// flow through the same predicate.
+pub(crate) fn is_attrset_content_empty(node: &SyntaxNode) -> bool {
+    let attr_set = if node.kind() == SyntaxKind::NODE_ROOT {
+        match node.first_child() {
+            Some(inner) => inner,
+            None => return false,
+        }
+    } else {
+        node.clone()
+    };
+    if attr_set.kind() != SyntaxKind::NODE_ATTR_SET {
+        return false;
+    }
+    if attr_set
+        .children()
+        .any(|c| c.kind() == SyntaxKind::NODE_ATTRPATH_VALUE)
+    {
+        return false;
+    }
+    !attr_set
+        .children_with_tokens()
+        .any(|t| t.kind() == SyntaxKind::TOKEN_COMMENT)
+}
+
+/// Whitespace node copied from `node`'s previous sibling (or next, as fallback).
 pub fn get_sibling_whitespace(node: &SyntaxNode) -> Option<Node> {
     if let Some(prev) = node.prev_sibling_or_token()
         && prev.kind() == SyntaxKind::TOKEN_WHITESPACE
@@ -41,9 +71,10 @@ pub fn get_sibling_whitespace(node: &SyntaxNode) -> Option<Node> {
     None
 }
 
-/// Find the insertion index after a reference node, skipping past any trailing
-/// inline whitespace and comments on the same line.
-/// This prevents displacing trailing comments when inserting new nodes.
+/// Insertion index after `node`, skipping trailing same-line whitespace and comments.
+///
+/// Stops at the first newline so trailing comments on the reference line stay attached
+/// to it instead of getting displaced by the inserted node.
 pub fn insertion_index_after(node: &SyntaxNode) -> usize {
     let element: rnix::SyntaxElement = node.clone().into();
     let mut cursor = element.next_sibling_or_token();
@@ -67,8 +98,8 @@ pub fn insertion_index_after(node: &SyntaxNode) -> usize {
     last_index
 }
 
-/// Find the index of adjacent whitespace to strip after removing/replacing a child.
-/// Returns the index of whitespace before the child if present, otherwise after.
+/// Index of `child`'s adjacent whitespace token (preferring the previous sibling)
+/// for stripping after a removal or replacement.
 pub fn adjacent_whitespace_index(child: &rnix::SyntaxElement) -> Option<usize> {
     if let Some(prev) = child.prev_sibling_or_token()
         && prev.kind() == SyntaxKind::TOKEN_WHITESPACE
@@ -83,13 +114,18 @@ pub fn adjacent_whitespace_index(child: &rnix::SyntaxElement) -> Option<usize> {
     }
 }
 
-/// Check if an input should be removed based on the change and context.
-pub fn should_remove_input(change: &Change, ctx: &Option<Context>, input_id: &str) -> bool {
+/// Whether `input_id` should be removed under `change` and `ctx`.
+pub(crate) fn should_remove_input(
+    change: &Change,
+    ctx: &Option<Context>,
+    input_id: &Segment,
+) -> bool {
     if !change.is_remove() {
         return false;
     }
     if let Some(id) = change.id()
-        && id.to_string() == input_id
+        && id.input() == input_id
+        && id.follows().is_none()
     {
         return true;
     }
@@ -101,9 +137,13 @@ pub fn should_remove_input(change: &Change, ctx: &Option<Context>, input_id: &st
     false
 }
 
-/// Check if a nested input should be removed using context-aware matching.
-/// Handles nested input IDs like "poetry2nix.nixpkgs".
-pub fn should_remove_nested_input(change: &Change, ctx: &Option<Context>, input_id: &str) -> bool {
+/// Whether a nested input should be removed, using `ctx` for dotted IDs like
+/// `poetry2nix.nixpkgs`.
+pub(crate) fn should_remove_nested_input(
+    change: &Change,
+    ctx: &Option<Context>,
+    input_id: &Segment,
+) -> bool {
     if !change.is_remove() {
         return false;
     }
@@ -113,54 +153,35 @@ pub fn should_remove_nested_input(change: &Change, ctx: &Option<Context>, input_
     false
 }
 
-/// Create a quoted string node.
-/// Example: `"github:NixOS/nixpkgs"`
+/// Quoted string node, e.g. `"github:NixOS/nixpkgs"`.
 pub fn make_quoted_string(s: &str) -> Node {
     parse_node(&format!("\"{}\"", s))
 }
 
-/// Create a toplevel input URL attribute node.
-/// Example: `inputs.nixpkgs.url = "github:NixOS/nixpkgs";`
+/// Top-level URL attribute, e.g. `inputs.nixpkgs.url = "github:NixOS/nixpkgs";`.
 pub fn make_toplevel_url_attr(id: &str, uri: &str) -> Node {
     parse_node(&format!("inputs.{}.url = \"{}\";", id, uri))
 }
 
-/// Create a toplevel input flake=false attribute node.
-/// Example: `inputs.not_a_flake.flake = false;`
+/// Top-level `flake = false` attribute, e.g. `inputs.not_a_flake.flake = false;`.
 pub fn make_toplevel_flake_false_attr(id: &str) -> Node {
     parse_node(&format!("inputs.{}.flake = false;", id))
 }
 
-/// Create a toplevel nested follows attribute node.
-/// Example: `inputs.crane.inputs.nixpkgs.follows = "nixpkgs";`
-pub fn make_toplevel_nested_follows_attr(parent_id: &str, nested_id: &str, target: &str) -> Node {
-    parse_node(&format!(
-        "inputs.{}.inputs.{}.follows = \"{}\";",
-        parent_id, nested_id, target
-    ))
-}
-
-/// Create a toplevel input follows attribute node.
-/// Example: `inputs.nixpkgs.follows = "clan-core/nixpkgs";`
-pub fn make_toplevel_follows_attr(id: &str, target: &str) -> Node {
-    parse_node(&format!("inputs.{}.follows = \"{}\";", id, target))
-}
-
-/// Create a nested input URL attribute node.
-/// Example: `nixpkgs.url = "github:NixOS/nixpkgs";`
+/// Nested URL attribute, e.g. `nixpkgs.url = "github:NixOS/nixpkgs";`.
 pub fn make_url_attr(id: &str, uri: &str) -> Node {
     parse_node(&format!("{}.url = \"{}\";", id, uri))
 }
 
-/// Create a nested input flake=false attribute node.
-/// Example: `not_a_flake.flake = false;`
+/// Nested `flake = false` attribute, e.g. `not_a_flake.flake = false;`.
 pub fn make_flake_false_attr(id: &str) -> Node {
     parse_node(&format!("{}.flake = false;", id))
 }
 
-/// Create a nested input URL attribute in attrset style.
-/// Example: `vmsh = {\n    url = "github:mic92/vmsh";\n  };`
-/// The `indent` parameter is the base indentation of the entry (e.g., "  " for 2-space indent).
+/// Attrset-style URL attribute, e.g. `vmsh = { url = "github:mic92/vmsh"; };`.
+///
+/// `indent` is the base indentation of the entry (e.g., `"  "` for 2-space indent).
+/// The inner attribute gets one extra level.
 pub fn make_attrset_url_attr(id: &str, uri: &str, indent: &str) -> Node {
     parse_node(&format!(
         "{} = {{\n{}  url = \"{}\";\n{}}};",
@@ -168,7 +189,7 @@ pub fn make_attrset_url_attr(id: &str, uri: &str, indent: &str) -> Node {
     ))
 }
 
-/// Create a nested input URL + flake=false attribute in attrset style.
+/// Attrset-style URL plus `flake = false`.
 pub fn make_attrset_url_flake_false_attr(id: &str, uri: &str, indent: &str) -> Node {
     parse_node(&format!(
         "{} = {{\n{}  url = \"{}\";\n{}  flake = false;\n{}}};",
@@ -176,13 +197,227 @@ pub fn make_attrset_url_flake_false_attr(id: &str, uri: &str, indent: &str) -> N
     ))
 }
 
-/// Create a nested follows attribute node (inside an input block).
-/// Example: `inputs.nixpkgs.follows = "nixpkgs";`
-pub fn make_nested_follows_attr(input: &str, target: &str) -> Node {
-    parse_node(&format!("inputs.{}.follows = \"{}\";", input, target))
+/// Shape of a `follows = ...` attribute to splice into the CST.
+///
+/// Each variant captures both the attrpath layout and the surrounding insertion context.
+/// Per-segment quoting goes through [`Segment::render`] so dotted or leading-digit
+/// segments pick up `"..."` automatically.
+pub enum FollowsKind<'a> {
+    /// `inputs.<id>.follows = "<target>";`, sibling of other `inputs.<...>.url = ...`
+    /// attrs in the outer flake attr-set.
+    TopLevelFlat { id: &'a Segment, target: &'a str },
+    /// `inputs.<S0>.inputs.<S1>...inputs.<SN>.follows = "<target>";`, the fully-qualified
+    /// flat shape used when the outer flake spells inputs as `inputs.<parent>.url = ...`.
+    /// `path` covers every segment from the top-level input to the leaf nested input
+    /// (length `>= 2`).
+    TopLevelNested { path: &'a AttrPath, target: &'a str },
+    /// `<S0>.inputs.<S1>...inputs.<SN>.follows = "<target>";`, sibling inside an
+    /// `inputs = { ... }` block where the parent input is declared as a flat
+    /// `<parent>.url = ...` (no per-input `{ ... }` block).
+    InputsBlockNested { path: &'a AttrPath, target: &'a str },
+    /// `inputs.<R0>.inputs.<R1>...inputs.<RN>.follows = "<target>";`, sibling inside
+    /// a parent input's `<parent> = { ... }` block, or inside an `inputs = { ... }`
+    /// block at a sibling depth of the same shape. `rest` is the path below the
+    /// enclosing parent (length `>= 1`).
+    BlockNested {
+        rest: &'a [Segment],
+        target: &'a str,
+    },
+    /// `follows = "<target>";`, bare follows attr inside a parent input's
+    /// `<parent> = { ... }` block.
+    BlockBare { target: &'a str },
 }
-/// Create a follows attribute node inside an input block.
-/// Example: `follows = "nixpkgs";`
-pub fn make_follows_attr(target: &str) -> Node {
-    parse_node(&format!("follows = \"{}\";", target))
+
+/// Render `segments` as `S0.inputs.S1...inputs.SN` (no leading `inputs.`, no trailing
+/// `.follows`). Per-segment quoting goes through [`Segment::render`].
+fn render_inputs_chain(segments: &[Segment]) -> String {
+    let mut out = String::new();
+    for (i, seg) in segments.iter().enumerate() {
+        if i > 0 {
+            out.push_str(".inputs.");
+        }
+        out.push_str(&seg.render());
+    }
+    out
+}
+
+impl FollowsKind<'_> {
+    /// Render the variant to a [`SyntaxNode`] ready to splice into the CST.
+    pub fn emit(&self) -> Node {
+        match self {
+            FollowsKind::TopLevelFlat { id, target } => {
+                parse_node(&format!("inputs.{}.follows = \"{}\";", id.render(), target))
+            }
+            FollowsKind::TopLevelNested { path, target } => {
+                let chain = render_inputs_chain(path.segments());
+                parse_node(&format!("inputs.{chain}.follows = \"{target}\";"))
+            }
+            FollowsKind::InputsBlockNested { path, target } => {
+                let chain = render_inputs_chain(path.segments());
+                parse_node(&format!("{chain}.follows = \"{target}\";"))
+            }
+            FollowsKind::BlockNested { rest, target } => {
+                let chain = render_inputs_chain(rest);
+                parse_node(&format!("inputs.{chain}.follows = \"{target}\";"))
+            }
+            FollowsKind::BlockBare { target } => parse_node(&format!("follows = \"{}\";", target)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seg(s: &str) -> Segment {
+        Segment::from_unquoted(s).expect("valid segment")
+    }
+
+    #[test]
+    fn follows_kind_top_level_flat_bare_ident() {
+        let id = seg("nixpkgs");
+        let node = FollowsKind::TopLevelFlat {
+            id: &id,
+            target: "github:NixOS/nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.nixpkgs.follows = \"github:NixOS/nixpkgs\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_top_level_flat_quotes_dotted_segment() {
+        let id = seg("hls-1.10");
+        let node = FollowsKind::TopLevelFlat {
+            id: &id,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.\"hls-1.10\".follows = \"nixpkgs\";"
+        );
+    }
+
+    fn path(s: &str) -> AttrPath {
+        AttrPath::parse(s).expect("valid attrpath")
+    }
+
+    #[test]
+    fn follows_kind_top_level_nested() {
+        let p = path("crane.nixpkgs");
+        let node = FollowsKind::TopLevelNested {
+            path: &p,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.crane.inputs.nixpkgs.follows = \"nixpkgs\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_top_level_nested_quotes_dotted_parent() {
+        let p = path("\"hls-1.10\".nixpkgs");
+        let node = FollowsKind::TopLevelNested {
+            path: &p,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.\"hls-1.10\".inputs.nixpkgs.follows = \"nixpkgs\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_top_level_nested_depth_three() {
+        let p = path("neovim.nixvim.flake-parts");
+        let node = FollowsKind::TopLevelNested {
+            path: &p,
+            target: "flake-parts",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.neovim.inputs.nixvim.inputs.flake-parts.follows = \"flake-parts\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_inputs_block_nested() {
+        let p = path("harmonia.nixpkgs");
+        let node = FollowsKind::InputsBlockNested {
+            path: &p,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "harmonia.inputs.nixpkgs.follows = \"nixpkgs\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_inputs_block_nested_depth_three() {
+        let p = path("neovim.nixvim.flake-parts");
+        let node = FollowsKind::InputsBlockNested {
+            path: &p,
+            target: "flake-parts",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "neovim.inputs.nixvim.inputs.flake-parts.follows = \"flake-parts\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_block_nested() {
+        let rest = [seg("nixpkgs")];
+        let node = FollowsKind::BlockNested {
+            rest: &rest,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(node.to_string(), "inputs.nixpkgs.follows = \"nixpkgs\";");
+    }
+
+    #[test]
+    fn follows_kind_block_nested_quotes_dotted() {
+        let rest = [seg("hls-1.10")];
+        let node = FollowsKind::BlockNested {
+            rest: &rest,
+            target: "nixpkgs",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.\"hls-1.10\".follows = \"nixpkgs\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_block_nested_depth_two() {
+        // Inside parent's `{ ... }` block, the rest is everything below it.
+        let rest = [seg("nixvim"), seg("flake-parts")];
+        let node = FollowsKind::BlockNested {
+            rest: &rest,
+            target: "flake-parts",
+        }
+        .emit();
+        assert_eq!(
+            node.to_string(),
+            "inputs.nixvim.inputs.flake-parts.follows = \"flake-parts\";"
+        );
+    }
+
+    #[test]
+    fn follows_kind_block_bare() {
+        let node = FollowsKind::BlockBare { target: "nixpkgs" }.emit();
+        assert_eq!(node.to_string(), "follows = \"nixpkgs\";");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -497,6 +497,95 @@ fn test_add_follow_nonexistent(#[case] fixture: &str, #[case] input: &str, #[cas
     });
 }
 
+/// `add-follow` with a 3+ segment dot path (e.g. `a.b.c`) used to silently
+/// emit malformed Nix because only the first `.` was treated as the
+/// `inputs.` separator. Reject these up front with a depth error.
+#[test]
+fn add_follow_rejects_three_segment_dot_path() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    error_filters(&mut settings);
+    let output = cli()
+        .arg("--flake")
+        .arg(fixture_path("root"))
+        .arg("--diff")
+        .arg("add-follow")
+        .arg("neovim.nixvim.flake-parts")
+        .arg("flake-parts")
+        .output()
+        .expect("run flake-edit");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("depth") || stderr.contains("3 segments"),
+        "stderr should mention depth or segment count, got:\n{stderr}",
+    );
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("root"))
+                .arg("--diff")
+                .arg("add-follow")
+                .arg("neovim.nixvim.flake-parts")
+                .arg("flake-parts")
+        );
+    });
+}
+
+/// Slash-separated input paths are not a recognized syntax: the whole string
+/// becomes a single segment and the existing `Input not found` error must
+/// remain intact (regression guard against accidentally widening the parser).
+#[test]
+fn add_follow_rejects_slash_form_unrecognized() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    error_filters(&mut settings);
+    let output = cli()
+        .arg("--flake")
+        .arg(fixture_path("root"))
+        .arg("--diff")
+        .arg("add-follow")
+        .arg("neovim/nixvim/flake-parts")
+        .arg("flake-parts")
+        .output()
+        .expect("run flake-edit");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        stderr.contains("not found"),
+        "slash-form must hit the existing 'not found' error, got:\n{stderr}",
+    );
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("root"))
+                .arg("--diff")
+                .arg("add-follow")
+                .arg("neovim/nixvim/flake-parts")
+                .arg("flake-parts")
+        );
+    });
+}
+
+#[test]
+fn add_follow_accepts_two_segment_dot_path_unchanged() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("root"))
+                .arg("--diff")
+                .arg("add-follow")
+                .arg("rust-overlay.flake-compat")
+                .arg("flake-utils")
+        );
+    });
+}
+
 /// Test the follow command to automatically follow matching inputs
 #[rstest]
 #[case("centerpiece")] // Two nested nixpkgs inputs that can follow top-level nixpkgs
@@ -510,6 +599,17 @@ fn test_add_follow_nonexistent(#[case] fixture: &str, #[case] input: &str, #[cas
 #[case("stale_follows")] // Stale follows: crane.flake-compat no longer exists in lock
 #[case("stale_follows_invalid_parent")] // Stale follows: nixpkgs.treefmt-nix doesn't exist
 #[case("treefmt_transitive")] // treefmt has treefmt-nix as transitive input that matches top-level
+#[case("multi_hop_cycle")] // multi-hop a -> b -> c declared chain
+#[case("dot_ancestor_cycle")] // dot-named participant in a multi-hop chain
+#[case("lockfile_only_cycle")] // cycle closes only through resolved lockfile edges
+#[case("stale_lockfile_only")] // stale-edge detection alongside the resolver
+#[case("split_inputs_block_and_flat")] // some inputs in a block, neovim flat outside
+#[case("stale_lock")] // declared follows the lockfile didn't apply
+#[case("transitive_grandchild")] // baseline: depth-2 candidate, default max_depth=1 ignores it
+#[case("transitive_grandchild_existing")] // baseline: handwritten depth-2 follows, no-op
+#[case("transitive_grandchild_cycle")] // baseline: depth-2 candidate skipped (cycle)
+#[case("transitive_self_named")] // self-named depth-3 follows must round-trip without removal
+#[case("follow_slash_syntax")] // slash-form `follows = "parent/child"` is the alias of `parent.child`
 fn test_follow(#[case] fixture: &str) {
     let mut settings = insta::Settings::clone_current();
     path_redactions(&mut settings);
@@ -531,6 +631,31 @@ fn test_follow(#[case] fixture: &str) {
 #[rstest]
 #[case("centerpiece", "ignore_treefmt")] // Config ignores treefmt-nix.nixpkgs, only home-manager follows
 #[case("treefmt_transitive", "transitive")] // Transitive follows with transitive_min = 2
+#[case("transitive_grandchild", "deep_follows_2")] // max_depth=2 emits depth-2 follows
+#[case("transitive_grandchild_existing", "deep_follows_2")] // handwritten depth-2 already present, no-op
+#[case("transitive_grandchild_cycle", "deep_follows_2")] // depth-2 candidate skipped due to cycle
+#[case("depth_upstream_redundant", "depth_upstream_redundant")] // upstream propagation makes depth-2 follow redundant; nothing emitted
+#[case("depth_upstream_partial", "depth_upstream_partial")] // partial upstream coverage: nixpkgs skipped, flake-utils emitted
+#[case(
+    "depth_upstream_redundant_declared",
+    "depth_upstream_redundant_declared"
+)] // already-declared depth-2 follow auto-removed
+#[case("depth_upstream_redundant_partial", "depth_upstream_redundant_partial")] // mixed: nixpkgs depth-2 removed, flake-utils kept
+#[case("depth_upstream_redundant_depth3", "depth_upstream_redundant_depth3")] // depth-3 chain auto-removed
+#[case(
+    "transitive_promote_with_upstream_redundant",
+    "transitive_promote_with_upstream_redundant"
+)]
+// transitive_min=2 promotes rust-analyzer-src while sibling depth-2 nixpkgs follow stays suppressed by upstream propagation
+#[case(
+    "transitive_promote_unlocks_deeper",
+    "transitive_promote_unlocks_deeper"
+)]
+// promoting flake-compat to a new top-level unlocks a deeper nested follow with the same canonical name in the same invocation
+#[case("stale_edge_unblocks_follow", "stale_edge_unblocks_follow")]
+// a stale follows declaration would block a valid candidate via the cycle check; the removal and the unblocked follow must land in one invocation
+#[case("prune_empty_intermediate_inputs", "prune_empty_intermediate_inputs")]
+// depth-2 redundant follow is the sole entry of an `inputs = { ... }` block; auto-removal must collapse the now-empty intermediate block
 fn test_follow_with_config(#[case] fixture: &str, #[case] config: &str) {
     let mut settings = insta::Settings::clone_current();
     path_redactions(&mut settings);
@@ -650,6 +775,166 @@ fn test_follow_paths_incompatible_with_lock_flag() {
     });
 }
 
+/// Lockfiles whose `inputs` map contains empty `[]` arrays (a
+/// follows declaration whose chain has been overridden away) must
+/// deserialize and the `follow` subcommand must run to completion.
+#[rstest]
+fn test_follow_empty_indirect_lockfile() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("lock_indirect_empty"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("lock_indirect_empty"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--depth")
+                .arg("2")
+        );
+    });
+}
+
+/// `inputs.X.follows = ""` is a real, intentional Nix idiom for
+/// "this nested input has no follows / pinning override". `list`
+/// must surface it as `=> ""` and `follow` must not synthesize a
+/// bogus self-referential edge from it.
+#[rstest]
+fn test_list_empty_target_follows() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("follows_empty_target"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("follows_empty_target"))
+                .arg("list")
+        );
+    });
+}
+
+#[rstest]
+fn test_follow_empty_target_follows() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("follows_empty_target"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("follows_empty_target"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--depth")
+                .arg("2")
+        );
+    });
+}
+
+/// When the user has declared a parent override like
+/// `clan-core.inputs.treefmt-nix.follows = "systems"`, the auto-deduplicator
+/// must not propose a deeper override
+/// `clan-core.inputs.data-mesher.inputs.treefmt-nix.follows = "treefmt-nix"`
+/// that contradicts the parent's chosen target.
+#[rstest]
+fn test_follow_respects_ancestor() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("follow_respects_ancestor"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("follow_respects_ancestor"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--transitive")
+                .arg("--depth")
+                .arg("6")
+        );
+    });
+}
+
+/// `inputs.X.follows = ""` is the user explicitly nulling a nested input.
+/// `--transitive --depth 6` against a flake with a top-level `treefmt-nix`
+/// must not propose to retarget the nulled follows: doing so would erase
+/// the user's deliberate decision.
+#[rstest]
+fn test_follow_respects_nulled() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("follow_respects_nulled"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("follow_respects_nulled"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--transitive")
+                .arg("--depth")
+                .arg("6")
+        );
+    });
+}
+
+/// Nulled twin of [`test_follow_empty_target_follows`]: `follows = ""`
+/// whose source path is absent from the lockfile must be removed.
+#[rstest]
+fn test_follow_nulled_stale_source_removed() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("nulled_stale_source_removed"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("nulled_stale_source_removed"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--transitive")
+                .arg("--depth")
+                .arg("6")
+        );
+    });
+}
+
+/// Depth-3 sibling of [`test_follow_nulled_stale_source_removed`].
+#[rstest]
+fn test_follow_nulled_stale_depth3() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("nulled_stale_depth3"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("nulled_stale_depth3"))
+                .arg("--diff")
+                .arg("follow")
+                .arg("--transitive")
+                .arg("--depth")
+                .arg("6")
+        );
+    });
+}
+
 /// Test follow with positional path (single file)
 #[rstest]
 #[case("centerpiece")] // Single file with nested nixpkgs inputs
@@ -750,6 +1035,94 @@ fn test_follow_multi_directory() {
     insta::assert_snapshot!("multi_directory_root", root_result);
     insta::assert_snapshot!("multi_directory_other", other_result);
     insta::assert_snapshot!("multi_directory_another", another_result);
+}
+
+/// `follow` on a flake with no `inputs = { ... };` block exits 0 with
+/// a no-op message instead of erroring with `No inputs found in the
+/// flake`. The lock is borrowed from `first_nested_node` so the
+/// fixture's empty-inputs case is what trips the no-op, not an empty
+/// nested-inputs lockfile (both produce the same exit but only the
+/// former regresses).
+#[test]
+fn test_follow_no_inputs() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    stderr_path_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("follow_no_inputs"))
+                .arg("--lock-file")
+                .arg(fixture_lock_path("first_nested_node"))
+                .arg("--no-lock")
+                .arg("--diff")
+                .arg("follow")
+        );
+    });
+}
+
+/// Batch mode (`flake-edit follow PATHS...`) on a mix of inputful and
+/// inputless flakes exits 0, emits the inputful flake's diff, and
+/// produces no `Error processing ...` line for the inputless one.
+#[test]
+fn test_follow_paths_batch_with_inputless() {
+    let tmpdir = tempfile::tempdir().expect("Failed to create tmpdir");
+    let root = tmpdir.path();
+
+    let inputful_dir = root.join("inputful");
+    let inputless_dir = root.join("inputless");
+    fs::create_dir(&inputful_dir).expect("create inputful/");
+    fs::create_dir(&inputless_dir).expect("create inputless/");
+
+    copy_fixture_to_dir("centerpiece", &inputful_dir);
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    fs::copy(
+        format!("{manifest_dir}/tests/fixtures/follow_no_inputs.flake.nix"),
+        inputless_dir.join("flake.nix"),
+    )
+    .expect("copy inputless flake.nix");
+    // Borrow any lock with nested_inputs so loading it succeeds;
+    // missing-lock handling is governed elsewhere.
+    fs::copy(
+        format!("{manifest_dir}/tests/fixtures/first_nested_node.flake.lock"),
+        inputless_dir.join("flake.lock"),
+    )
+    .expect("copy inputless flake.lock");
+
+    let output = Command::new(get_cargo_bin("flake-edit"))
+        .env("NO_COLOR", "1")
+        .arg("--diff")
+        .arg("follow")
+        .arg(inputful_dir.join("flake.nix"))
+        .arg(inputless_dir.join("flake.nix"))
+        .output()
+        .expect("Failed to run flake-edit");
+
+    assert!(
+        output.status.success(),
+        "batch follow failed (status {:?}): stdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Error processing"),
+        "inputless flake produced an error in batch mode: stderr={stderr}",
+    );
+    assert!(
+        !stderr.contains("No inputs found"),
+        "inputless flake reported NoInputs: stderr={stderr}",
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("home-manager") || stdout.contains("treefmt"),
+        "inputful flake's diff did not appear in stdout: stdout={stdout}",
+    );
 }
 
 /// Test follow without arguments (runs on current directory).

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -59,6 +59,54 @@ pub const FIXTURES: &[&str] = &[
     "one_level_nesting_flat_not_a_flake",
     "flat_nested_flat",
     "first_nested_node",
+    // multi-hop / dot-ancestor / lockfile-only cycle resolver fixtures
+    "multi_hop_cycle",
+    "dot_ancestor_cycle",
+    "lockfile_only_cycle",
+    "stale_lockfile_only",
+    "split_inputs_block_and_flat",
+    "stale_lock",
+    // depth-2 follows fixtures
+    "transitive_grandchild",
+    "transitive_grandchild_existing",
+    "transitive_grandchild_cycle",
+    "transitive_self_named",
+    "transitive_promote_unlocks_deeper",
+    // depth-N upstream-redundancy fixtures
+    "depth_upstream_redundant",
+    "depth_upstream_partial",
+    // depth-N upstream-redundancy: auto-removal of already-declared follows
+    "depth_upstream_redundant_declared",
+    "depth_upstream_redundant_partial",
+    "depth_upstream_redundant_depth3",
+    // transitive_min=2 promotion alongside upstream-redundant nested follow
+    "transitive_promote_with_upstream_redundant",
+    // stale-edge removal that simultaneously unblocks a follow candidate
+    "stale_edge_unblocks_follow",
+    // empty-Indirect (`inputs.X = []`) regression fixture
+    "lock_indirect_empty",
+    // empty-target follows (`inputs.X.follows = ""`)
+    "follows_empty_target",
+    // user-declared nulled nested follow that must not be retargeted by
+    // the auto-deduplicator
+    "follow_respects_nulled",
+    // stale-source removal for nulled `follows = ""` declarations
+    "nulled_stale_source_removed",
+    "nulled_stale_depth3",
+    // ancestor-declared nested follow that must not be overridden by a
+    // deeper auto-emission with the same trailing segment
+    "follow_respects_ancestor",
+    // inputless flake (no `inputs = { ... };` block)
+    "follow_no_inputs",
+    // slash-form follows target (`follows = "a/b"`)
+    "follow_slash_syntax",
+    // depth-N redundant follow that is the only entry inside an
+    // `inputs = { ... }` block; auto-removal must prune the now-empty
+    // intermediate block too
+    "prune_empty_intermediate_inputs",
+    // nested URL override on a transitive input must not be parsed as a
+    // follows declaration
+    "nested_url_override",
 ];
 
 /// Create a Walker from a fixture name.

--- a/tests/edit.rs
+++ b/tests/edit.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::{Info, load_flake};
+use flake_edit::app::handler::ListOutput;
 use flake_edit::change::Change;
 use flake_edit::edit::FlakeEdit;
 use flake_edit::walk::Walker;
@@ -17,6 +18,12 @@ use rstest::rstest;
 #[case("one_level_nesting_flat_not_a_flake")]
 #[case("merged_inputs")]
 #[case("merged_inputs_flat")]
+#[case("multi_hop_cycle")]
+#[case("dot_ancestor_cycle")]
+#[case("lockfile_only_cycle")]
+#[case("stale_lockfile_only")]
+#[case("follows_empty_target")]
+#[case("nested_url_override")]
 fn test_flake_edit_list(#[case] fixture: &str) {
     let content = load_flake(fixture);
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
@@ -26,7 +33,7 @@ fn test_flake_edit_list(#[case] fixture: &str) {
         info => &info,
         snapshot_suffix => fixture
     }, {
-        insta::assert_yaml_snapshot!(flake_edit.list());
+        insta::assert_yaml_snapshot!(ListOutput::from(flake_edit.list()));
     });
 }
 
@@ -68,7 +75,7 @@ fn test_add_input(#[case] fixture: &str, #[case] is_flake: bool, #[case] uri: &s
         flake: is_flake,
     };
     let info = Info::with_change(change.clone());
-    let result = flake_edit.apply_change(change).unwrap().unwrap();
+    let result = flake_edit.apply_change(change).unwrap().text.unwrap();
     let suffix = format!("{}_flake_{}", fixture, is_flake);
     insta::with_settings!({
         sort_maps => true,
@@ -90,7 +97,7 @@ fn test_add_with_ref_or_rev() {
     };
     let info = Info::with_change(change.clone());
     insta::with_settings!({sort_maps => true, info => &info}, {
-        insta::assert_snapshot!(flake_edit.apply_change(change).unwrap().unwrap());
+        insta::assert_snapshot!(flake_edit.apply_change(change).unwrap().text.unwrap());
     });
 }
 
@@ -117,14 +124,14 @@ fn test_first_nested_node_add_with_list(#[case] is_flake: bool) {
         info => &info,
         snapshot_suffix => suffix.clone()
     }, {
-        insta::assert_snapshot!("changes", flake_edit.apply_change(change).unwrap().unwrap());
+        insta::assert_snapshot!("changes", flake_edit.apply_change(change).unwrap().text.unwrap());
     });
     insta::with_settings!({
         sort_maps => true,
         info => &info,
         snapshot_suffix => suffix
     }, {
-        insta::assert_yaml_snapshot!("list", flake_edit.curr_list());
+        insta::assert_yaml_snapshot!("list", ListOutput::from(flake_edit.curr_list()));
     });
 }
 
@@ -154,10 +161,10 @@ fn test_remove_input(#[case] fixture: &str, #[case] input_id: &str) {
     let content = load_flake(fixture);
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
-    let result = flake_edit.apply_change(change).unwrap().unwrap();
+    let result = flake_edit.apply_change(change).unwrap().text.unwrap();
     let suffix = format!("{}_{}", fixture, input_id.replace('.', "_"));
     insta::with_settings!({
         sort_maps => true,
@@ -177,7 +184,7 @@ fn test_remove_input_walker(#[case] fixture: &str, #[case] input_id: &str) {
     let content = load_flake(fixture);
     let mut walker = Walker::new(&content);
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
     let result = walker.walk(&change).unwrap().unwrap();
@@ -200,10 +207,10 @@ fn test_remove_nested_input(#[case] fixture: &str, #[case] input_id: &str) {
     let content = load_flake(fixture);
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
-    let result = flake_edit.apply_change(change).unwrap().unwrap();
+    let result = flake_edit.apply_change(change).unwrap().text.unwrap();
     let suffix = format!("{}_{}", fixture, input_id.replace('.', "_"));
     insta::with_settings!({
         sort_maps => true,
@@ -222,10 +229,10 @@ fn test_remove_not_a_flake_input(#[case] fixture: &str, #[case] input_id: &str) 
     let content = load_flake(fixture);
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
-    let result = flake_edit.apply_change(change).unwrap().unwrap();
+    let result = flake_edit.apply_change(change).unwrap().text.unwrap();
     insta::with_settings!({
         sort_maps => true,
         info => &info,
@@ -242,7 +249,7 @@ fn test_first_nested_node_remove_with_list(#[case] input_id: &str) {
     let content = load_flake("first_nested_node");
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
     insta::with_settings!({
@@ -250,14 +257,14 @@ fn test_first_nested_node_remove_with_list(#[case] input_id: &str) {
         info => &info,
         snapshot_suffix => input_id
     }, {
-        insta::assert_snapshot!("changes", flake_edit.apply_change(change).unwrap().unwrap());
+        insta::assert_snapshot!("changes", flake_edit.apply_change(change).unwrap().text.unwrap());
     });
     insta::with_settings!({
         sort_maps => true,
         info => &info,
         snapshot_suffix => input_id
     }, {
-        insta::assert_yaml_snapshot!("list", flake_edit.list());
+        insta::assert_yaml_snapshot!("list", ListOutput::from(flake_edit.list()));
     });
 }
 
@@ -291,7 +298,7 @@ fn test_change_url(#[case] fixture: &str, #[case] input_id: &str, #[case] new_ur
         ref_or_rev: None,
     };
     let info = Info::with_change(change.clone());
-    let result = flake_edit.apply_change(change).unwrap().unwrap();
+    let result = flake_edit.apply_change(change).unwrap().text.unwrap();
     let suffix = format!("{}_{}", fixture, input_id.replace('.', "_"));
     insta::with_settings!({
         sort_maps => true,
@@ -324,9 +331,9 @@ fn test_remove_nonexistent_input_panics() {
     let content = load_flake("completely_flat_toplevel_not_a_flake");
     let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
     let change = Change::Remove {
-        ids: vec!["not-an-input-at-all".to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse("not-an-input-at-all").unwrap()],
     };
-    flake_edit.apply_change(change).unwrap().unwrap();
+    flake_edit.apply_change(change).unwrap().text.unwrap();
 }
 
 #[rstest]
@@ -342,6 +349,6 @@ fn test_walker_inputs(#[case] fixture: &str) {
         info => &info,
         snapshot_suffix => fixture
     }, {
-        insta::assert_yaml_snapshot!(walker.inputs);
+        insta::assert_yaml_snapshot!(ListOutput::from(&walker.inputs));
     });
 }

--- a/tests/fixtures/deep_follows_2.config.toml
+++ b/tests/fixtures/deep_follows_2.config.toml
@@ -1,0 +1,2 @@
+[follow]
+max_depth = 2

--- a/tests/fixtures/depth_upstream_partial.config.toml
+++ b/tests/fixtures/depth_upstream_partial.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 0

--- a/tests/fixtures/depth_upstream_partial.flake.lock
+++ b/tests/fixtures/depth_upstream_partial.flake.lock
@@ -1,0 +1,105 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1700000005,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-edit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nested-helper": "nested-helper"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "type": "github"
+      }
+    },
+    "nested-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "flake-edit",
+          "nixpkgs"
+        ],
+        "flake-utils": "flake-utils_2"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-utils": "flake-utils",
+        "flake-edit": "flake-edit"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/depth_upstream_partial.flake.nix
+++ b/tests/fixtures/depth_upstream_partial.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Depth-2 follow needed for flake-utils, redundant for nixpkgs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      flake-edit,
+    }:
+    { };
+}

--- a/tests/fixtures/depth_upstream_redundant.config.toml
+++ b/tests/fixtures/depth_upstream_redundant.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 0

--- a/tests/fixtures/depth_upstream_redundant.flake.lock
+++ b/tests/fixtures/depth_upstream_redundant.flake.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-edit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nested-helper": "nested-helper"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "type": "github"
+      }
+    },
+    "nested-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "flake-edit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "type": "github"
+      }
+    },
+    "tui-term": {
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "a-kenji",
+        "repo": "tui-term",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "tui-term",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-edit": "flake-edit",
+        "tui-term": "tui-term"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/depth_upstream_redundant.flake.nix
+++ b/tests/fixtures/depth_upstream_redundant.flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "Depth-2 follow already covered by upstream propagation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    tui-term.url = "github:a-kenji/tui-term";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-edit,
+      tui-term,
+    }:
+    { };
+}

--- a/tests/fixtures/depth_upstream_redundant_declared.config.toml
+++ b/tests/fixtures/depth_upstream_redundant_declared.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 0

--- a/tests/fixtures/depth_upstream_redundant_declared.flake.lock
+++ b/tests/fixtures/depth_upstream_redundant_declared.flake.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-edit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nested-helper": "nested-helper"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "type": "github"
+      }
+    },
+    "nested-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "flake-edit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "type": "github"
+      }
+    },
+    "tui-term": {
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "a-kenji",
+        "repo": "tui-term",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "tui-term",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-edit": "flake-edit",
+        "tui-term": "tui-term"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/depth_upstream_redundant_declared.flake.nix
+++ b/tests/fixtures/depth_upstream_redundant_declared.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Depth-2 follow already declared, redundant by upstream propagation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+    tui-term.url = "github:a-kenji/tui-term";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-edit,
+      tui-term,
+    }:
+    { };
+}

--- a/tests/fixtures/depth_upstream_redundant_depth3.config.toml
+++ b/tests/fixtures/depth_upstream_redundant_depth3.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 3
+transitive_min = 0

--- a/tests/fixtures/depth_upstream_redundant_depth3.flake.lock
+++ b/tests/fixtures/depth_upstream_redundant_depth3.flake.lock
@@ -1,0 +1,93 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "omnibus": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "flops": "flops"
+      },
+      "locked": {
+        "lastModified": 1700000010,
+        "narHash": "sha256-OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOA=",
+        "owner": "Lehmanator",
+        "repo": "nix-configs",
+        "rev": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Lehmanator",
+        "repo": "nix-configs",
+        "type": "github"
+      }
+    },
+    "flops": {
+      "inputs": {
+        "nixpkgs": [
+          "omnibus",
+          "nixpkgs"
+        ],
+        "POP": "POP"
+      },
+      "locked": {
+        "lastModified": 1700000011,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFB=",
+        "owner": "example",
+        "repo": "flops",
+        "rev": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "flops",
+        "type": "github"
+      }
+    },
+    "POP": {
+      "inputs": {
+        "nixpkgs": [
+          "omnibus",
+          "flops",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000012,
+        "narHash": "sha256-PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPC=",
+        "owner": "example",
+        "repo": "POP",
+        "rev": "cccccccccccccccccccccccccccccccccccccccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "POP",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "omnibus": "omnibus"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/depth_upstream_redundant_depth3.flake.nix
+++ b/tests/fixtures/depth_upstream_redundant_depth3.flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Depth-3 follow already declared, redundant by upstream propagation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    omnibus.url = "github:Lehmanator/nix-configs";
+    omnibus.inputs.nixpkgs.follows = "nixpkgs";
+    omnibus.inputs.flops.inputs.POP.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      omnibus,
+    }:
+    { };
+}

--- a/tests/fixtures/depth_upstream_redundant_partial.config.toml
+++ b/tests/fixtures/depth_upstream_redundant_partial.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 0

--- a/tests/fixtures/depth_upstream_redundant_partial.flake.lock
+++ b/tests/fixtures/depth_upstream_redundant_partial.flake.lock
@@ -1,0 +1,105 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1700000005,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-edit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nested-helper": "nested-helper"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "type": "github"
+      }
+    },
+    "nested-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "flake-edit",
+          "nixpkgs"
+        ],
+        "flake-utils": "flake-utils_2"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-utils": "flake-utils",
+        "flake-edit": "flake-edit"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/depth_upstream_redundant_partial.flake.nix
+++ b/tests/fixtures/depth_upstream_redundant_partial.flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Depth-2 follows partially redundant: nixpkgs covered by upstream, flake-utils kept";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs.flake-utils.follows = "flake-utils";
+    flake-edit.inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs.nested-helper.inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      flake-edit,
+    }:
+    { };
+}

--- a/tests/fixtures/dot_ancestor_cycle.flake.lock
+++ b/tests/fixtures/dot_ancestor_cycle.flake.lock
@@ -1,0 +1,69 @@
+{
+  "nodes": {
+    "helper": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-HHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHHA=",
+        "owner": "example",
+        "repo": "helper",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "helper",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "inputs": {
+        "helper": [
+          "helper"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-LLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLLA=",
+        "owner": "example",
+        "repo": "hls",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "hls",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "helper": "helper",
+        "hls-1.10": "hls-1.10",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/dot_ancestor_cycle.flake.nix
+++ b/tests/fixtures/dot_ancestor_cycle.flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Multi-hop cycle exercise where one participant is a quoted, dot-named segment (\"hls-1.10\"). Validates that typed structural equality, not URL-prefix string compare, catches the cycle.";
+
+  inputs = {
+    "hls-1.10".url = "github:example/hls";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    helper.url = "github:example/helper";
+
+    # The dotted name participates as both a top-level input and a
+    # nested follow target. URL-prefix string compare misses the cycle
+    # on the embedded "hls-1.10/" form; structural AttrPath equality
+    # catches it.
+    helper.inputs.nixpkgs.follows = "nixpkgs";
+    "hls-1.10".inputs.helper.follows = "helper";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      helper,
+    }:
+    { };
+}

--- a/tests/fixtures/follow_no_inputs.flake.nix
+++ b/tests/fixtures/follow_no_inputs.flake.nix
@@ -1,0 +1,4 @@
+{
+  description = "outputs-only flake";
+  outputs = { ... }: { templates = { }; };
+}

--- a/tests/fixtures/follow_respects_ancestor.flake.lock
+++ b/tests/fixtures/follow_respects_ancestor.flake.lock
@@ -1,0 +1,122 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "data-mesher": {
+      "inputs": {
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "clan-lol",
+        "repo": "data-mesher",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clan-lol",
+        "repo": "data-mesher",
+        "type": "github"
+      }
+    },
+    "clan-core": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "systems"
+        ],
+        "data-mesher": "data-mesher"
+      },
+      "locked": {
+        "lastModified": 1700000005,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "clan-lol",
+        "repo": "clan-core",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clan-lol",
+        "repo": "clan-core",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix",
+        "clan-core": "clan-core"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/follow_respects_ancestor.flake.nix
+++ b/tests/fixtures/follow_respects_ancestor.flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Ancestor-declared follows must not be overridden by deeper proposals";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    clan-core.url = "github:clan-lol/clan-core";
+    clan-core.inputs.nixpkgs.follows = "nixpkgs";
+    # Stub the entire `treefmt-nix` subtree of clan-core to `systems`. The
+    # user explicitly chose this redirect; a deeper auto-emission must
+    # not override it.
+    clan-core.inputs.treefmt-nix.follows = "systems";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      treefmt-nix,
+      clan-core,
+    }:
+    { };
+}

--- a/tests/fixtures/follow_respects_nulled.flake.lock
+++ b/tests/fixtures/follow_respects_nulled.flake.lock
@@ -1,0 +1,70 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "nixos-anywhere": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": []
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixos-anywhere",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix",
+        "nixos-anywhere": "nixos-anywhere"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/follow_respects_nulled.flake.nix
+++ b/tests/fixtures/follow_respects_nulled.flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Nulled nested follows must be respected, not deduplicated";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    nixos-anywhere.url = "github:nix-community/nixos-anywhere";
+    nixos-anywhere.inputs.nixpkgs.follows = "nixpkgs";
+    nixos-anywhere.inputs.treefmt-nix.follows = "";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+      nixos-anywhere,
+    }:
+    { };
+}

--- a/tests/fixtures/follow_slash_syntax.flake.lock
+++ b/tests/fixtures/follow_slash_syntax.flake.lock
@@ -1,0 +1,100 @@
+{
+  "nodes": {
+    "child": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "foo",
+        "repo": "child",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "foo",
+        "repo": "child",
+        "type": "github"
+      }
+    },
+    "consumer": {
+      "inputs": {
+        "child": [
+          "parent",
+          "child"
+        ],
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "foo",
+        "repo": "consumer",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "foo",
+        "repo": "consumer",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parent": {
+      "inputs": {
+        "child": "child"
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "foo",
+        "repo": "parent",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "foo",
+        "repo": "parent",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "consumer": "consumer",
+        "nixpkgs": "nixpkgs",
+        "parent": "parent"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/follow_slash_syntax.flake.nix
+++ b/tests/fixtures/follow_slash_syntax.flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "slash-form follows target: `inputs.X.follows = \"a/b\"` is the syntactic alias of dot form";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    parent.url = "github:foo/parent";
+    consumer.url = "github:foo/consumer";
+    consumer.inputs.child.follows = "parent/child";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      parent,
+      consumer,
+    }:
+    { };
+}

--- a/tests/fixtures/follows_empty_target.flake.lock
+++ b/tests/fixtures/follows_empty_target.flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "nix": {
+      "inputs": {
+        "flake-compat": [],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cccccccccccccccccccccccccccccccccccccccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/follows_empty_target.flake.nix
+++ b/tests/fixtures/follows_empty_target.flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Nested input whose follows target is the empty string";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nix.url = "github:NixOS/nix";
+    nix.inputs.flake-compat.follows = "";
+    nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix,
+    }:
+    { };
+}

--- a/tests/fixtures/lock_indirect_empty.flake.lock
+++ b/tests/fixtures/lock_indirect_empty.flake.lock
@@ -1,0 +1,68 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [],
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": [],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [],
+        "nixpkgs-regression": []
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cccccccccccccccccccccccccccccccccccccccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/lock_indirect_empty.flake.nix
+++ b/tests/fixtures/lock_indirect_empty.flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Nested input whose follows chain is overridden away in the lockfile";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nix.url = "github:NixOS/nix";
+    nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nix,
+    }:
+    { };
+}

--- a/tests/fixtures/lockfile_only_cycle.flake.lock
+++ b/tests/fixtures/lockfile_only_cycle.flake.lock
@@ -1,0 +1,70 @@
+{
+  "_comment": "Hand-edited fixture: flake.nix declares no follows, but `foo.bar = [bar]` and `bar.foo = [foo]` form a 2-hop cycle through resolved edges only.",
+  "nodes": {
+    "bar": {
+      "inputs": {
+        "foo": [
+          "foo"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "example",
+        "repo": "bar",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "bar",
+        "type": "github"
+      }
+    },
+    "foo": {
+      "inputs": {
+        "bar": [
+          "bar"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "example",
+        "repo": "foo",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "foo",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bar": "bar",
+        "foo": "foo",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/lockfile_only_cycle.flake.nix
+++ b/tests/fixtures/lockfile_only_cycle.flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "No follows declared in flake.nix; the cycle exists only in the lockfile's resolved follows. Verifies that lock-only cycles are detected.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    foo.url = "github:example/foo";
+    bar.url = "github:example/bar";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      foo,
+      bar,
+    }:
+    { };
+}

--- a/tests/fixtures/multi_hop_cycle.flake.lock
+++ b/tests/fixtures/multi_hop_cycle.flake.lock
@@ -1,0 +1,86 @@
+{
+  "nodes": {
+    "a": {
+      "inputs": {
+        "b": [
+          "b"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "example",
+        "repo": "a",
+        "rev": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "a",
+        "type": "github"
+      }
+    },
+    "b": {
+      "inputs": {
+        "c": [
+          "c"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "example",
+        "repo": "b",
+        "rev": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "b",
+        "type": "github"
+      }
+    },
+    "c": {
+      "inputs": {
+        "a": "c-a"
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "example",
+        "repo": "c",
+        "rev": "cccccccccccccccccccccccccccccccccccccccc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "c",
+        "type": "github"
+      }
+    },
+    "c-a": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-CACACACACACACACACACACACACACACACACACACACA=",
+        "owner": "example",
+        "repo": "a",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "a",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "a": "a",
+        "b": "b",
+        "c": "c"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/multi_hop_cycle.flake.nix
+++ b/tests/fixtures/multi_hop_cycle.flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Three top-level inputs whose declared follows form a multi-hop chain (a -> b -> c). A naive per-ancestor cycle predicate misses the case where adding c.a.follows = \"a\" would close the chain back to itself; the cycle detector must catch it.";
+
+  inputs = {
+    a.url = "github:example/a";
+    b.url = "github:example/b";
+    c.url = "github:example/c";
+
+    # Declared multi-hop chain: a's nested b follows top-level b,
+    # and b's nested c follows top-level c. If the auto-follow pass
+    # were to propose c.a.follows = "a", the chain a -> b -> c -> a
+    # would close. The cycle detector must reject that proposal.
+    a.inputs.b.follows = "b";
+    b.inputs.c.follows = "c";
+  };
+
+  outputs =
+    {
+      self,
+      a,
+      b,
+      c,
+    }:
+    { };
+}

--- a/tests/fixtures/nested_url_override.flake.lock
+++ b/tests/fixtures/nested_url_override.flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "cl-nix-lite": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-cccccccccccccccccccccccccccccccccccccccccc=",
+        "owner": "verymucho",
+        "repo": "cl-nix-lite",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "verymucho",
+        "repo": "cl-nix-lite",
+        "type": "github"
+      }
+    },
+    "mac-app-util": {
+      "inputs": {
+        "cl-nix-lite": "cl-nix-lite",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm=",
+        "owner": "hraban",
+        "repo": "mac-app-util",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hraban",
+        "repo": "mac-app-util",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "mac-app-util": "mac-app-util",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/nested_url_override.flake.nix
+++ b/tests/fixtures/nested_url_override.flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Nested URL override on a transitive input must not be parsed as a follows declaration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    mac-app-util = {
+      url = "github:hraban/mac-app-util";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.cl-nix-lite.url = "github:verymucho/cl-nix-lite";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      mac-app-util,
+    }:
+    { };
+}

--- a/tests/fixtures/nulled_stale_depth3.flake.lock
+++ b/tests/fixtures/nulled_stale_depth3.flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "omnibus": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "flops": "flops"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "Lehmanator",
+        "repo": "nix-configs",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Lehmanator",
+        "repo": "nix-configs",
+        "type": "github"
+      }
+    },
+    "flops": {
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "x",
+        "repo": "flops",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "x",
+        "repo": "flops",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "omnibus": "omnibus"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/nulled_stale_depth3.flake.nix
+++ b/tests/fixtures/nulled_stale_depth3.flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    omnibus.url = "github:Lehmanator/nix-configs";
+    omnibus.inputs.nixpkgs.follows = "nixpkgs";
+    # `omnibus.flops.gone` is absent from the lockfile.
+    omnibus.inputs.flops.inputs.gone.follows = "";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      omnibus,
+    }:
+    { };
+}

--- a/tests/fixtures/nulled_stale_source_removed.flake.lock
+++ b/tests/fixtures/nulled_stale_source_removed.flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "crane": "crane"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/nulled_stale_source_removed.flake.nix
+++ b/tests/fixtures/nulled_stale_source_removed.flake.nix
@@ -1,0 +1,17 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+    # `crane.gone` is absent from the lockfile.
+    crane.inputs.gone.follows = "";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+    }:
+    { };
+}

--- a/tests/fixtures/prune_empty_intermediate_inputs.config.toml
+++ b/tests/fixtures/prune_empty_intermediate_inputs.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 0

--- a/tests/fixtures/prune_empty_intermediate_inputs.flake.lock
+++ b/tests/fixtures/prune_empty_intermediate_inputs.flake.lock
@@ -1,0 +1,70 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "flake-edit": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nested-helper": "nested-helper"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "flake-edit",
+        "type": "github"
+      }
+    },
+    "nested-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "flake-edit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "a-kenji",
+        "repo": "nested-helper",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "flake-edit": "flake-edit"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/prune_empty_intermediate_inputs.flake.nix
+++ b/tests/fixtures/prune_empty_intermediate_inputs.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Depth-2 redundant follow as the only entry inside `flake-edit.inputs = { ... }`";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-edit.url = "github:a-kenji/flake-edit";
+    flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+    flake-edit.inputs = {
+      nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-edit,
+    }:
+    { };
+}

--- a/tests/fixtures/split_inputs_block_and_flat.flake.lock
+++ b/tests/fixtures/split_inputs_block_and_flat.flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "locked": {
+        "lastModified": 1742669843,
+        "narHash": "sha256-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "locked": {
+        "lastModified": 1742669844,
+        "narHash": "sha256-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "neovim": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1742669845,
+        "narHash": "sha256-ccccccccccccccccccccccccccccccccccccccccccc=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1742669846,
+        "narHash": "sha256-ddddddddddddddddddddddddddddddddddddddddddd=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1742669848,
+        "narHash": "sha256-fffffffffffffffffffffffffffffffffffffffffff=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "neovim": "neovim",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/split_inputs_block_and_flat.flake.nix
+++ b/tests/fixtures/split_inputs_block_and_flat.flake.nix
@@ -1,0 +1,12 @@
+{
+  description = "split-declaration shape: inputs in a block and flat siblings";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  inputs.neovim.url = "github:nix-community/neovim-nightly-overlay";
+
+  outputs = { self, ... }: { };
+}

--- a/tests/fixtures/stale_edge_unblocks_follow.config.toml
+++ b/tests/fixtures/stale_edge_unblocks_follow.config.toml
@@ -1,0 +1,3 @@
+[follow]
+transitive_min = 0
+max_depth = 1

--- a/tests/fixtures/stale_edge_unblocks_follow.flake.lock
+++ b/tests/fixtures/stale_edge_unblocks_follow.flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "X": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "owner",
+        "repo": "X",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "X",
+        "type": "github"
+      }
+    },
+    "X_2": {
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "owner",
+        "repo": "X",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "X",
+        "type": "github"
+      }
+    },
+    "Y": {
+      "inputs": {
+        "Z": [
+          "Z"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "owner",
+        "repo": "Y",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "Y",
+        "type": "github"
+      }
+    },
+    "Z": {
+      "inputs": {
+        "X": "X_2"
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "owner",
+        "repo": "Z",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "owner",
+        "repo": "Z",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "X": "X",
+        "Y": "Y",
+        "Z": "Z"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/stale_edge_unblocks_follow.flake.nix
+++ b/tests/fixtures/stale_edge_unblocks_follow.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "fixture: a stale follows declaration would otherwise block a valid Z.X -> X candidate via the cycle check. The auto-follow command must remove the stale edge AND emit the unblocked follow in a single invocation.";
+
+  inputs = {
+    X.url = "github:owner/X";
+    X.inputs.Y.follows = "Y";
+    Y.url = "github:owner/Y";
+    Y.inputs.Z.follows = "Z";
+    Z.url = "github:owner/Z";
+  };
+
+  outputs =
+    {
+      self,
+      X,
+      Y,
+      Z,
+    }:
+    { };
+}

--- a/tests/fixtures/stale_lock.flake.lock
+++ b/tests/fixtures/stale_lock.flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1766774972,
+        "narHash": "sha256-8qxEFpj4dVmIuPn9j9z6NTbU+hrcGjBOvaxTzre5HmM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "01bc1d404a51a0a07e9d8759cd50a7903e218c82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/stale_lock.flake.nix
+++ b/tests/fixtures/stale_lock.flake.nix
@@ -1,0 +1,23 @@
+{
+  description = "Test flake with a follows declaration the lockfile didn't apply.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    crane.url = "github:ipetkov/crane";
+    # User added this declaration but never ran `nix flake lock`. The lock
+    # still resolves crane.nixpkgs to crane's own bundled nixpkgs node.
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+    # Stale follows: crane no longer has a nested input named `gone`. Triggers
+    # the auto-follow removal path so validate_full runs.
+    crane.inputs.gone.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      crane,
+    }:
+    { };
+}

--- a/tests/fixtures/stale_lockfile_only.flake.lock
+++ b/tests/fixtures/stale_lockfile_only.flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "foo": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "example",
+        "repo": "foo",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "foo",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "foo": "foo",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/stale_lockfile_only.flake.nix
+++ b/tests/fixtures/stale_lockfile_only.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "flake.nix declares follows for nested inputs that do not exist in the lockfile. Exercises stale-edge detection.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    foo.url = "github:example/foo";
+
+    # foo no longer has nested inputs `bar` or `baz`; both follows are stale.
+    foo.inputs.bar.follows = "nixpkgs";
+    foo.inputs.baz.follows = "nixpkgs";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      foo,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_grandchild.flake.lock
+++ b/tests/fixtures/transitive_grandchild.flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "neovim": {
+      "inputs": {
+        "nixvim": "nixvim"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "nixvim": {
+      "inputs": {
+        "flake-parts": "flake-parts_2"
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "neovim": "neovim"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_grandchild.flake.nix
+++ b/tests/fixtures/transitive_grandchild.flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "deep-follows fixture: depth-2 dedup candidate is the only available follow";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    neovim.url = "github:nix-community/neovim-nightly-overlay";
+  };
+
+  outputs =
+    {
+      self,
+      flake-parts,
+      neovim,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_grandchild_cycle.flake.lock
+++ b/tests/fixtures/transitive_grandchild_cycle.flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "neovim": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixvim": "nixvim"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "nixvim": {
+      "inputs": {
+        "flake-parts": "flake-parts_2"
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": [
+          "neovim",
+          "flake-parts"
+        ],
+        "neovim": "neovim"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_grandchild_cycle.flake.nix
+++ b/tests/fixtures/transitive_grandchild_cycle.flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "deep-follows fixture: candidate would create a cycle (top-level flake-parts follows neovim/flake-parts)";
+
+  inputs = {
+    flake-parts.follows = "neovim/flake-parts";
+    neovim.url = "github:nix-community/neovim-nightly-overlay";
+  };
+
+  outputs =
+    {
+      self,
+      flake-parts,
+      neovim,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_grandchild_existing.flake.lock
+++ b/tests/fixtures/transitive_grandchild_existing.flake.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "neovim": {
+      "inputs": {
+        "nixvim": "nixvim"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "neovim-nightly-overlay",
+        "type": "github"
+      }
+    },
+    "nixvim": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "neovim": "neovim"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_grandchild_existing.flake.nix
+++ b/tests/fixtures/transitive_grandchild_existing.flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "deep-follows fixture: depth-2 follows already declared by hand";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    neovim.url = "github:nix-community/neovim-nightly-overlay";
+    neovim.inputs.nixvim.inputs.flake-parts.follows = "flake-parts";
+  };
+
+  outputs =
+    {
+      self,
+      flake-parts,
+      neovim,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_promote_unlocks_deeper.config.toml
+++ b/tests/fixtures/transitive_promote_unlocks_deeper.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 2

--- a/tests/fixtures/transitive_promote_unlocks_deeper.flake.lock
+++ b/tests/fixtures/transitive_promote_unlocks_deeper.flake.lock
@@ -1,0 +1,136 @@
+{
+  "nodes": {
+    "alpha": {
+      "inputs": {
+        "flake-compat": "flake_compat"
+      },
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "example",
+        "repo": "alpha",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "alpha",
+        "type": "github"
+      }
+    },
+    "beta": {
+      "inputs": {
+        "flake-compat": "flake_compat_2"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "example",
+        "repo": "beta",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "beta",
+        "type": "github"
+      }
+    },
+    "gamma": {
+      "inputs": {
+        "helper": "helper"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "example",
+        "repo": "gamma",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "gamma",
+        "type": "github"
+      }
+    },
+    "helper": {
+      "inputs": {
+        "flake-compat": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "example",
+        "repo": "helper",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "example",
+        "repo": "helper",
+        "type": "github"
+      }
+    },
+    "flake_compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake_compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700000005,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000006,
+        "narHash": "sha256-GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7777777777777777777777777777777777777777",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "alpha": "alpha",
+        "beta": "beta",
+        "gamma": "gamma",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_promote_unlocks_deeper.flake.nix
+++ b/tests/fixtures/transitive_promote_unlocks_deeper.flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "promoting flake-compat to top-level unlocks a deeper helper.flake-compat follow in the same invocation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    alpha.url = "github:example/alpha";
+    beta.url = "github:example/beta";
+    gamma.url = "github:example/gamma";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      alpha,
+      beta,
+      gamma,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_promote_with_upstream_redundant.config.toml
+++ b/tests/fixtures/transitive_promote_with_upstream_redundant.config.toml
@@ -1,0 +1,3 @@
+[follow]
+max_depth = 2
+transitive_min = 2

--- a/tests/fixtures/transitive_promote_with_upstream_redundant.flake.lock
+++ b/tests/fixtures/transitive_promote_with_upstream_redundant.flake.lock
@@ -1,0 +1,124 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "intermediate": "intermediate",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "fenix2": {
+      "inputs": {
+        "rust-analyzer-src": "rust-analyzer-src_2"
+      },
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-community",
+        "repo": "fenix-alt",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix-alt",
+        "type": "github"
+      }
+    },
+    "intermediate": {
+      "inputs": {
+        "nixpkgs": [
+          "fenix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "nix-community",
+        "repo": "fenix-intermediate",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix-intermediate",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700000004,
+        "narHash": "sha256-EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "5555555555555555555555555555555555555555",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-analyzer-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700000005,
+        "narHash": "sha256-FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "6666666666666666666666666666666666666666",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "stable",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "fenix": "fenix",
+        "fenix2": "fenix2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_promote_with_upstream_redundant.flake.nix
+++ b/tests/fixtures/transitive_promote_with_upstream_redundant.flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "transitive_min=2 promotion fires while sibling depth-2 follow is suppressed by upstream propagation";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
+    fenix2.url = "github:nix-community/fenix-alt";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      fenix,
+      fenix2,
+    }:
+    { };
+}

--- a/tests/fixtures/transitive_self_named.flake.lock
+++ b/tests/fixtures/transitive_self_named.flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "agenix": {
+      "inputs": {
+        "agenix": "agenix_2"
+      },
+      "locked": {
+        "lastModified": 1700000000,
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "1111111111111111111111111111111111111111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "agenix_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1700000001,
+        "narHash": "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBA=",
+        "owner": "ryantm",
+        "repo": "agenix",
+        "rev": "2222222222222222222222222222222222222222",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ryantm",
+        "repo": "agenix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1700000002,
+        "narHash": "sha256-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCA=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "3333333333333333333333333333333333333333",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1700000003,
+        "narHash": "sha256-DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDA=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "4444444444444444444444444444444444444444",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "agenix": "agenix",
+        "systems": "systems"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/fixtures/transitive_self_named.flake.nix
+++ b/tests/fixtures/transitive_self_named.flake.nix
@@ -1,0 +1,19 @@
+{
+  description = "self-named transitive: lock has parent.parent.leaf, declared inside parent block";
+
+  inputs = {
+    systems.url = "github:nix-systems/default";
+    agenix = {
+      url = "github:ryantm/agenix";
+      inputs.agenix.inputs.systems.follows = "systems";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      systems,
+      agenix,
+    }:
+    { };
+}

--- a/tests/follow_idempotence.rs
+++ b/tests/follow_idempotence.rs
@@ -1,0 +1,90 @@
+//! `flake-edit follow` must reach a fixed point in a single invocation: a
+//! second run on the resulting `flake.nix` produces no further changes.
+
+use insta_cmd::get_cargo_bin;
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn cli() -> Command {
+    let mut cmd = Command::new(get_cargo_bin("flake-edit"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn fixture_path(name: &str) -> String {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    format!("{dir}/tests/fixtures/{name}.flake.nix")
+}
+
+fn fixture_lock_path(name: &str) -> String {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    format!("{dir}/tests/fixtures/{name}.flake.lock")
+}
+
+fn fixture_config_path(name: &str) -> String {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    format!("{dir}/tests/fixtures/{name}.config.toml")
+}
+
+/// Run `flake-edit follow` against a copy of the fixture, then run it again
+/// against the resulting `flake.nix`. Assert the second run made no changes.
+fn assert_idempotent(fixture: &str, config: Option<&str>) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake_dest = tmp.path().join("flake.nix");
+    let lock_dest = tmp.path().join("flake.lock");
+    fs::copy(fixture_path(fixture), &flake_dest).expect("copy flake.nix");
+    fs::copy(fixture_lock_path(fixture), &lock_dest).expect("copy flake.lock");
+
+    run_follow(&flake_dest, &lock_dest, config, "first run");
+
+    let after_first = fs::read_to_string(&flake_dest).expect("read after first run");
+
+    run_follow(&flake_dest, &lock_dest, config, "second run");
+
+    let after_second = fs::read_to_string(&flake_dest).expect("read after second run");
+
+    assert_eq!(
+        after_first, after_second,
+        "fixture {fixture} is not idempotent: second run mutated the flake.nix",
+    );
+}
+
+fn run_follow(flake: &Path, lock: &Path, config: Option<&str>, label: &str) {
+    let mut cmd = cli();
+    cmd.arg("--flake").arg(flake).arg("--lock-file").arg(lock);
+    if let Some(c) = config {
+        cmd.arg("--config").arg(fixture_config_path(c));
+    }
+    cmd.arg("follow");
+    let output = cmd.output().unwrap_or_else(|e| panic!("{label}: {e}"));
+    assert!(
+        output.status.success(),
+        "{label} failed (status {:?}): stdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[rstest]
+#[case("transitive_self_named", None)] // self-named nested-path round-trip
+#[case(
+    "transitive_promote_unlocks_deeper",
+    Some("transitive_promote_unlocks_deeper")
+)] // top-level promotion plus a deeper follow that depends on it
+#[case("transitive_grandchild", Some("deep_follows_2"))] // depth-2 emission
+#[case("stale_edge_unblocks_follow", Some("stale_edge_unblocks_follow"))] // stale-edge removal that simultaneously unblocks a follow candidate
+#[case("follows_empty_target", None)] // empty `follows = ""` must not oscillate
+#[case("follow_respects_nulled", None)] // nulled `follows = ""` must be respected
+#[case("follow_respects_ancestor", None)] // ancestor-declared subtree must not be overridden
+#[case("nulled_stale_source_removed", None)]
+#[case("nulled_stale_depth3", None)]
+#[case(
+    "prune_empty_intermediate_inputs",
+    Some("prune_empty_intermediate_inputs")
+)] // empty intermediate `inputs = { ... }` block prune must converge
+fn follow_is_idempotent(#[case] fixture: &str, #[case] config: Option<&str>) {
+    assert_idempotent(fixture, config);
+}

--- a/tests/graph_helpers.rs
+++ b/tests/graph_helpers.rs
@@ -1,0 +1,151 @@
+//! Test helpers for [`flake_edit::follows::FollowsGraph`].
+//!
+//! Shared assertion primitives for integration tests that build graphs
+//! from on-disk fixtures. Every helper accepts attribute paths as `&str`
+//! and parses them through [`AttrPath::parse`].
+
+#![allow(dead_code)]
+
+mod common;
+
+use common::load_fixtures;
+use flake_edit::edit::FlakeEdit;
+use flake_edit::follows::{AttrPath, Edge, FollowsGraph};
+use flake_edit::lock::FlakeLock;
+
+/// Build the [`FollowsGraph`] for a fixture pair (`<name>.flake.nix` +
+/// `<name>.flake.lock`).
+pub fn build_graph(fixture: &str) -> FollowsGraph {
+    let (flake_nix, flake_lock) = load_fixtures(fixture);
+    let mut edit = FlakeEdit::from_text(&flake_nix).expect("fixture flake.nix parses");
+    let inputs = edit.list().clone();
+    let lock = FlakeLock::read_from_str(&flake_lock).expect("fixture flake.lock parses");
+    FollowsGraph::from_flake(&inputs, &lock)
+}
+
+#[track_caller]
+pub fn assert_graph_has_edge(g: &FollowsGraph, parent: &str, nested: &str, target: &str) {
+    let parent_path = AttrPath::parse(parent).expect("parent parses as AttrPath");
+    let nested_seg =
+        flake_edit::follows::Segment::from_unquoted(nested).expect("nested segment is unquoted");
+    let mut source = parent_path;
+    source.push(nested_seg);
+    let target_path = AttrPath::parse(target).expect("target parses as AttrPath");
+    let outgoing = g.outgoing(&source);
+    assert!(
+        outgoing.iter().any(|e| e.follows == target_path),
+        "expected edge {source} -> {target_path}; outgoing: {outgoing:?}",
+    );
+}
+
+#[track_caller]
+pub fn assert_no_cycle(g: &FollowsGraph) {
+    let cycles = g.cycles();
+    assert!(
+        cycles.is_empty(),
+        "expected no cycles in graph, found: {cycles:?}",
+    );
+}
+
+#[track_caller]
+pub fn assert_cycle_contains(g: &FollowsGraph, attr_path: &str) {
+    let needle = AttrPath::parse(attr_path).expect("cycle attr_path parses");
+    let cycles = g.cycles();
+    let hit = cycles.iter().any(|c| {
+        c.edges
+            .iter()
+            .any(|e| e.source == needle || e.follows == needle)
+    });
+    assert!(
+        hit,
+        "expected a cycle containing {needle}; cycles: {cycles:?}",
+    );
+}
+
+#[track_caller]
+pub fn assert_stale_edges(g: &FollowsGraph, expected: &[&str]) {
+    let mut got: Vec<String> = g
+        .stale_edges()
+        .iter()
+        .map(|e| e.source.to_string())
+        .collect();
+    got.sort();
+    let mut want: Vec<String> = expected.iter().map(|s| s.to_string()).collect();
+    want.sort();
+    assert_eq!(
+        got, want,
+        "stale_edges() mismatch: got {got:?}, want {want:?}",
+    );
+}
+
+/// Convenience: assert that adding `proposed_source` -> `proposed_target` to
+/// the graph would close a cycle. Source / target parsed via [`AttrPath::parse`].
+#[track_caller]
+pub fn assert_would_create_cycle(g: &FollowsGraph, source: &str, follows: &str) {
+    let edge = make_proposed_edge(source, follows);
+    assert!(
+        g.would_create_cycle(&edge),
+        "expected proposed edge {source} -> {follows} to close a cycle",
+    );
+}
+
+#[track_caller]
+pub fn assert_would_not_create_cycle(g: &FollowsGraph, source: &str, follows: &str) {
+    let edge = make_proposed_edge(source, follows);
+    assert!(
+        !g.would_create_cycle(&edge),
+        "expected proposed edge {source} -> {follows} to not close a cycle",
+    );
+}
+
+fn make_proposed_edge(source: &str, follows: &str) -> Edge {
+    use flake_edit::follows::EdgeOrigin;
+    use flake_edit::input::Range;
+    Edge {
+        source: AttrPath::parse(source).expect("source parses as AttrPath"),
+        follows: AttrPath::parse(follows).expect("follows parses as AttrPath"),
+        origin: EdgeOrigin::Declared {
+            range: Range { start: 0, end: 0 },
+        },
+    }
+}
+
+#[test]
+fn helpers_build_graph_for_multi_hop_cycle() {
+    let g = build_graph("multi_hop_cycle");
+    // The flake.nix declares the chain `a.b -> b` and `b.c -> c`.
+    // The graph has no cycles in its declared form; the resolver's
+    // multi-hop logic is exercised via the inner `would_create_cycle`
+    // unit tests in `src/follows/graph.rs`. Here we just pin the edges.
+    assert_graph_has_edge(&g, "a", "b", "b");
+    assert_graph_has_edge(&g, "b", "c", "c");
+    assert_no_cycle(&g);
+}
+
+#[test]
+fn helpers_build_graph_for_dot_ancestor_cycle() {
+    let g = build_graph("dot_ancestor_cycle");
+    assert_graph_has_edge(&g, "helper", "nixpkgs", "nixpkgs");
+    assert_graph_has_edge(&g, "\"hls-1.10\"", "helper", "helper");
+    assert_no_cycle(&g);
+}
+
+#[test]
+fn helpers_build_graph_for_lockfile_only_cycle() {
+    let g = build_graph("lockfile_only_cycle");
+    // flake.nix declares no follows; the lockfile alone produces
+    // `foo.bar -> bar` and `bar.foo -> foo` as resolved edges.
+    assert_no_cycle(&g);
+    // The merged graph still contains the resolved edges from the lockfile,
+    // even though declared form is empty.
+    assert_graph_has_edge(&g, "foo", "bar", "bar");
+    assert_graph_has_edge(&g, "bar", "foo", "foo");
+}
+
+#[test]
+fn helpers_build_graph_for_stale_lockfile_only() {
+    let g = build_graph("stale_lockfile_only");
+    // Both `foo.bar` and `foo.baz` are declared in flake.nix but neither
+    // nested input exists in the lockfile.
+    assert_stale_edges(&g, &["foo.bar", "foo.baz"]);
+}

--- a/tests/snapshots/cli__add_follow_accepts_two_segment_dot_path_unchanged.snap
+++ b/tests/snapshots/cli__add_follow_accepts_two_segment_dot_path_unchanged.snap
@@ -1,0 +1,29 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/root.flake.nix"
+    - "--diff"
+    - add-follow
+    - rust-overlay.flake-compat
+    - flake-utils
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -10,6 +10,7 @@
+       url = "github:oxalica/rust-overlay";
+       inputs.nixpkgs.follows = "nixpkgs";
+       inputs.flake-utils.follows = "flake-utils";
++      inputs.flake-compat.follows = "flake-utils";
+     };
+     crane = {
+       url = "github:ipetkov/crane";
+
+----- stderr -----

--- a/tests/snapshots/cli__add_follow_rejects_slash_form_unrecognized.snap
+++ b/tests/snapshots/cli__add_follow_rejects_slash_form_unrecognized.snap
@@ -1,0 +1,26 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/root.flake.nix"
+    - "--diff"
+    - add-follow
+    - neovim/nixvim/flake-parts
+    - flake-parts
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: 
+   0: Input 'neovim/nixvim/flake-parts' not found in the flake.
+
+      To add it:
+        flake-edit add neovim/nixvim/flake-parts <flakeref>
+
+      To see all current inputs: flake-edit list

--- a/tests/snapshots/cli__add_follow_rejects_three_segment_dot_path.snap
+++ b/tests/snapshots/cli__add_follow_rejects_three_segment_dot_path.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/root.flake.nix"
+    - "--diff"
+    - add-follow
+    - neovim.nixvim.flake-parts
+    - flake-parts
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+Error: 
+   0: `add-follow` accepts only depth-1 paths of the form `parent.child`; got 'neovim.nixvim.flake-parts' (3 segments).
+
+      Use `flake-edit follow` for deeper paths (depth bounded by `follow.max_depth` in your config).

--- a/tests/snapshots/cli__follow@dot_ancestor_cycle.snap
+++ b/tests/snapshots/cli__follow@dot_ancestor_cycle.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 522
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/dot_ancestor_cycle.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/dot_ancestor_cycle.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@follow_slash_syntax.snap
+++ b/tests/snapshots/cli__follow@follow_slash_syntax.snap
@@ -1,0 +1,30 @@
+---
+source: tests/cli.rs
+assertion_line: 618
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follow_slash_syntax.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/follow_slash_syntax.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -6,6 +6,7 @@
+     parent.url = "github:foo/parent";
+     consumer.url = "github:foo/consumer";
+     consumer.inputs.child.follows = "parent/child";
++    consumer.inputs.nixpkgs.follows = "nixpkgs";
+   };
+
+   outputs =
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@lockfile_only_cycle.snap
+++ b/tests/snapshots/cli__follow@lockfile_only_cycle.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 522
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/lockfile_only_cycle.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/lockfile_only_cycle.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@multi_hop_cycle.snap
+++ b/tests/snapshots/cli__follow@multi_hop_cycle.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 522
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/multi_hop_cycle.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/multi_hop_cycle.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@split_inputs_block_and_flat.snap
+++ b/tests/snapshots/cli__follow@split_inputs_block_and_flat.snap
@@ -1,0 +1,30 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/split_inputs_block_and_flat.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/split_inputs_block_and_flat.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -7,6 +7,8 @@
+   };
+
+   inputs.neovim.url = "github:nix-community/neovim-nightly-overlay";
++  inputs.neovim.inputs.flake-parts.follows = "flake-parts";
++  inputs.neovim.inputs.nixpkgs.follows = "nixpkgs";
+
+   outputs = { self, ... }: { };
+ }
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@stale_follows.snap
+++ b/tests/snapshots/cli__follow@stale_follows.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli.rs
+assertion_line: 616
 info:
   program: flake-edit
   args:
@@ -27,3 +28,4 @@ exit_code: 0
      flake-compat.url = "github:edolstra/flake-compat";
 
 ----- stderr -----
+warning: stale follows at line 8, column 17: crane.flake-compat -> flake-compat (source no longer present in flake.lock)

--- a/tests/snapshots/cli__follow@stale_follows_invalid_parent.snap
+++ b/tests/snapshots/cli__follow@stale_follows_invalid_parent.snap
@@ -29,3 +29,4 @@ exit_code: 0
    outputs = { self, nixpkgs , treefmt-nix }: { };
 
 ----- stderr -----
+warning: stale follows at line 4, column 19: nixpkgs.treefmt-nix -> treefmt-nix (source no longer present in flake.lock)

--- a/tests/snapshots/cli__follow@stale_lock.snap
+++ b/tests/snapshots/cli__follow@stale_lock.snap
@@ -1,0 +1,32 @@
+---
+source: tests/cli.rs
+assertion_line: 616
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/stale_lock.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/stale_lock.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -10,7 +10,6 @@
+     crane.inputs.nixpkgs.follows = "nixpkgs";
+     # Stale follows: crane no longer has a nested input named `gone`. Triggers
+     # the auto-follow removal path so validate_full runs.
+-    crane.inputs.gone.follows = "nixpkgs";
+   };
+
+   outputs =
+
+----- stderr -----
+warning: stale follows at line 7, column 17: crane.gone -> nixpkgs (source no longer present in flake.lock)
+warning: stale-lock follows at line 7, column 17: crane.nixpkgs -> nixpkgs (flake.lock resolves to <none>; run `nix flake lock`)

--- a/tests/snapshots/cli__follow@stale_lockfile_only.snap
+++ b/tests/snapshots/cli__follow@stale_lockfile_only.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 522
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/stale_lockfile_only.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/stale_lockfile_only.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Nothing to deduplicate.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@transitive_grandchild.snap
+++ b/tests/snapshots/cli__follow@transitive_grandchild.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 618
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@transitive_grandchild_cycle.snap
+++ b/tests/snapshots/cli__follow@transitive_grandchild_cycle.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 618
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild_cycle.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild_cycle.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@transitive_grandchild_existing.snap
+++ b/tests/snapshots/cli__follow@transitive_grandchild_existing.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 618
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild_existing.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild_existing.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow@transitive_self_named.snap
+++ b/tests/snapshots/cli__follow@transitive_self_named.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+assertion_line: 617
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_self_named.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_self_named.flake.lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_empty_indirect_lockfile.snap
+++ b/tests/snapshots/cli__follow_empty_indirect_lockfile.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/lock_indirect_empty.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/lock_indirect_empty.flake.lock"
+    - "--diff"
+    - follow
+    - "--depth"
+    - "2"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_empty_target_follows.snap
+++ b/tests/snapshots/cli__follow_empty_target_follows.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follows_empty_target.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/follows_empty_target.flake.lock"
+    - "--diff"
+    - follow
+    - "--depth"
+    - "2"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_no_inputs.snap
+++ b/tests/snapshots/cli__follow_no_inputs.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follow_no_inputs.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/first_nested_node.flake.lock"
+    - "--no-lock"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Nothing to deduplicate.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_nulled_stale_depth3.snap
+++ b/tests/snapshots/cli__follow_nulled_stale_depth3.snap
@@ -1,0 +1,32 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/nulled_stale_depth3.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/nulled_stale_depth3.flake.lock"
+    - "--diff"
+    - follow
+    - "--transitive"
+    - "--depth"
+    - "6"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -4,7 +4,6 @@
+     omnibus.url = "github:Lehmanator/nix-configs";
+     omnibus.inputs.nixpkgs.follows = "nixpkgs";
+     # `omnibus.flops.gone` is absent from the lockfile.
+-    omnibus.inputs.flops.inputs.gone.follows = "";
+   };
+
+   outputs =
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_nulled_stale_source_removed.snap
+++ b/tests/snapshots/cli__follow_nulled_stale_source_removed.snap
@@ -1,0 +1,32 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/nulled_stale_source_removed.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/nulled_stale_source_removed.flake.lock"
+    - "--diff"
+    - follow
+    - "--transitive"
+    - "--depth"
+    - "6"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -4,7 +4,6 @@
+     crane.url = "github:ipetkov/crane";
+     crane.inputs.nixpkgs.follows = "nixpkgs";
+     # `crane.gone` is absent from the lockfile.
+-    crane.inputs.gone.follows = "";
+   };
+
+   outputs =
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_paths_batch.snap
+++ b/tests/snapshots/cli__follow_paths_batch.snap
@@ -15,9 +15,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-Error processing [FIXTURES]/centerpiece.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
-Error processing [FIXTURES]/first_nested_node.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
 Error: 
-   0: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
-   1: IoError: No such file or directory (os error 2)
-   2: No such file or directory (os error 2)
+   0: 2 file(s) failed during batch processing:
+        - [FIXTURES]/centerpiece.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
+        - [FIXTURES]/first_nested_node.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)

--- a/tests/snapshots/cli__follow_paths_single@centerpiece.snap
+++ b/tests/snapshots/cli__follow_paths_single@centerpiece.snap
@@ -14,8 +14,6 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-Error processing [FIXTURES]/centerpiece.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
 Error: 
-   0: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)
-   1: IoError: No such file or directory (os error 2)
-   2: No such file or directory (os error 2)
+   0: 1 file(s) failed during batch processing:
+        - [FIXTURES]/centerpiece.flake.nix: Could not read lock file '[FIXTURES]/flake.lock': IoError: No such file or directory (os error 2)

--- a/tests/snapshots/cli__follow_respects_ancestor.snap
+++ b/tests/snapshots/cli__follow_respects_ancestor.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follow_respects_ancestor.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/follow_respects_ancestor.flake.lock"
+    - "--diff"
+    - follow
+    - "--transitive"
+    - "--depth"
+    - "6"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_respects_nulled.snap
+++ b/tests/snapshots/cli__follow_respects_nulled.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follow_respects_nulled.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/follow_respects_nulled.flake.lock"
+    - "--diff"
+    - follow
+    - "--transitive"
+    - "--depth"
+    - "6"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@depth_upstream_partial_depth_upstream_partial.snap
+++ b/tests/snapshots/cli__follow_with_config@depth_upstream_partial_depth_upstream_partial.snap
@@ -1,0 +1,32 @@
+---
+source: tests/cli.rs
+assertion_line: 644
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/depth_upstream_partial.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/depth_upstream_partial.flake.lock"
+    - "--config"
+    - "[FIXTURES]/depth_upstream_partial.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -7,6 +7,7 @@
+     flake-edit.url = "github:a-kenji/flake-edit";
+     flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+     flake-edit.inputs.flake-utils.follows = "flake-utils";
++    flake-edit.inputs.nested-helper.inputs.flake-utils.follows = "flake-utils";
+   };
+
+   outputs =
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_declared_depth_upstream_redundant_declared.snap
+++ b/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_declared_depth_upstream_redundant_declared.snap
@@ -1,0 +1,33 @@
+---
+source: tests/cli.rs
+assertion_line: 646
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/depth_upstream_redundant_declared.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/depth_upstream_redundant_declared.flake.lock"
+    - "--config"
+    - "[FIXTURES]/depth_upstream_redundant_declared.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -5,7 +5,6 @@
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+     flake-edit.url = "github:a-kenji/flake-edit";
+     flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+-    flake-edit.inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+     tui-term.url = "github:a-kenji/tui-term";
+   };
+
+
+----- stderr -----
+warning: stale-lock follows at line 6, column 22: flake-edit.nested-helper.nixpkgs -> nixpkgs (flake.lock resolves to flake-edit.nixpkgs; run `nix flake lock`)

--- a/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_depth3_depth_upstream_redundant_depth3.snap
+++ b/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_depth3_depth_upstream_redundant_depth3.snap
@@ -1,0 +1,33 @@
+---
+source: tests/cli.rs
+assertion_line: 646
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/depth_upstream_redundant_depth3.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/depth_upstream_redundant_depth3.flake.lock"
+    - "--config"
+    - "[FIXTURES]/depth_upstream_redundant_depth3.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -5,7 +5,6 @@
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+     omnibus.url = "github:Lehmanator/nix-configs";
+     omnibus.inputs.nixpkgs.follows = "nixpkgs";
+-    omnibus.inputs.flops.inputs.POP.inputs.nixpkgs.follows = "nixpkgs";
+   };
+
+   outputs =
+
+----- stderr -----
+warning: stale-lock follows at line 6, column 19: omnibus.flops.POP.nixpkgs -> nixpkgs (flake.lock resolves to omnibus.flops.nixpkgs; run `nix flake lock`)

--- a/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_depth_upstream_redundant.snap
+++ b/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_depth_upstream_redundant.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+assertion_line: 644
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/depth_upstream_redundant.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/depth_upstream_redundant.flake.lock"
+    - "--config"
+    - "[FIXTURES]/depth_upstream_redundant.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_partial_depth_upstream_redundant_partial.snap
+++ b/tests/snapshots/cli__follow_with_config@depth_upstream_redundant_partial_depth_upstream_redundant_partial.snap
@@ -1,0 +1,34 @@
+---
+source: tests/cli.rs
+assertion_line: 646
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/depth_upstream_redundant_partial.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/depth_upstream_redundant_partial.flake.lock"
+    - "--config"
+    - "[FIXTURES]/depth_upstream_redundant_partial.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -7,7 +7,6 @@
+     flake-edit.url = "github:a-kenji/flake-edit";
+     flake-edit.inputs.nixpkgs.follows = "nixpkgs";
+     flake-edit.inputs.flake-utils.follows = "flake-utils";
+-    flake-edit.inputs.nested-helper.inputs.nixpkgs.follows = "nixpkgs";
+     flake-edit.inputs.nested-helper.inputs.flake-utils.follows = "flake-utils";
+   };
+
+
+----- stderr -----
+warning: stale-lock follows at line 7, column 22: flake-edit.nested-helper.flake-utils -> flake-utils (flake.lock resolves to <none>; run `nix flake lock`)
+warning: stale-lock follows at line 7, column 22: flake-edit.nested-helper.nixpkgs -> nixpkgs (flake.lock resolves to flake-edit.nixpkgs; run `nix flake lock`)

--- a/tests/snapshots/cli__follow_with_config@prune_empty_intermediate_inputs_prune_empty_intermediate_inputs.snap
+++ b/tests/snapshots/cli__follow_with_config@prune_empty_intermediate_inputs_prune_empty_intermediate_inputs.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/prune_empty_intermediate_inputs.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/prune_empty_intermediate_inputs.flake.lock"
+    - "--config"
+    - "[FIXTURES]/prune_empty_intermediate_inputs.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@stale_edge_unblocks_follow_stale_edge_unblocks_follow.snap
+++ b/tests/snapshots/cli__follow_with_config@stale_edge_unblocks_follow_stale_edge_unblocks_follow.snap
@@ -1,0 +1,36 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/stale_edge_unblocks_follow.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/stale_edge_unblocks_follow.flake.lock"
+    - "--config"
+    - "[FIXTURES]/stale_edge_unblocks_follow.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -3,10 +3,10 @@
+
+   inputs = {
+     X.url = "github:owner/X";
+-    X.inputs.Y.follows = "Y";
+     Y.url = "github:owner/Y";
+     Y.inputs.Z.follows = "Z";
+     Z.url = "github:owner/Z";
++    Z.inputs.X.follows = "X";
+   };
+
+   outputs =
+
+----- stderr -----
+warning: stale follows at line 5, column 13: X.Y -> Y (source no longer present in flake.lock)

--- a/tests/snapshots/cli__follow_with_config@transitive_grandchild_cycle_deep_follows_2.snap
+++ b/tests/snapshots/cli__follow_with_config@transitive_grandchild_cycle_deep_follows_2.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+assertion_line: 643
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild_cycle.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild_cycle.flake.lock"
+    - "--config"
+    - "[FIXTURES]/deep_follows_2.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@transitive_grandchild_deep_follows_2.snap
+++ b/tests/snapshots/cli__follow_with_config@transitive_grandchild_deep_follows_2.snap
@@ -1,0 +1,32 @@
+---
+source: tests/cli.rs
+assertion_line: 643
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild.flake.lock"
+    - "--config"
+    - "[FIXTURES]/deep_follows_2.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -4,6 +4,7 @@
+   inputs = {
+     flake-parts.url = "github:hercules-ci/flake-parts";
+     neovim.url = "github:nix-community/neovim-nightly-overlay";
++    neovim.inputs.nixvim.inputs.flake-parts.follows = "flake-parts";
+   };
+
+   outputs =
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@transitive_grandchild_existing_deep_follows_2.snap
+++ b/tests/snapshots/cli__follow_with_config@transitive_grandchild_existing_deep_follows_2.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+assertion_line: 643
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_grandchild_existing.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_grandchild_existing.flake.lock"
+    - "--config"
+    - "[FIXTURES]/deep_follows_2.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All inputs are already deduplicated.
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@transitive_promote_unlocks_deeper_transitive_promote_unlocks_deeper.snap
+++ b/tests/snapshots/cli__follow_with_config@transitive_promote_unlocks_deeper_transitive_promote_unlocks_deeper.snap
@@ -1,0 +1,44 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_promote_unlocks_deeper.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_promote_unlocks_deeper.flake.lock"
+    - "--config"
+    - "[FIXTURES]/transitive_promote_unlocks_deeper.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -4,8 +4,12 @@
+   inputs = {
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+     alpha.url = "github:example/alpha";
++    alpha.inputs.flake-compat.follows = "flake-compat";
+     beta.url = "github:example/beta";
++    beta.inputs.flake-compat.follows = "flake-compat";
+     gamma.url = "github:example/gamma";
++    gamma.inputs.helper.inputs.flake-compat.follows = "flake-compat";
++    flake-compat.url = "github:edolstra/flake-compat";
+   };
+
+   outputs =
+@@ -15,6 +19,7 @@
+       alpha,
+       beta,
+       gamma,
++      flake-compat,
+     }:
+     { };
+ }
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@transitive_promote_with_upstream_redundant_transitive_promote_with_upstream_redundant.snap
+++ b/tests/snapshots/cli__follow_with_config@transitive_promote_with_upstream_redundant_transitive_promote_with_upstream_redundant.snap
@@ -1,0 +1,43 @@
+---
+source: tests/cli.rs
+assertion_line: 653
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/transitive_promote_with_upstream_redundant.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/transitive_promote_with_upstream_redundant.flake.lock"
+    - "--config"
+    - "[FIXTURES]/transitive_promote_with_upstream_redundant.config.toml"
+    - "--diff"
+    - follow
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -5,7 +5,10 @@
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+     fenix.url = "github:nix-community/fenix";
+     fenix.inputs.nixpkgs.follows = "nixpkgs";
++    fenix.inputs.rust-analyzer-src.follows = "rust-analyzer-src";
+     fenix2.url = "github:nix-community/fenix-alt";
++    fenix2.inputs.rust-analyzer-src.follows = "rust-analyzer-src";
++    rust-analyzer-src.url = "github:rust-lang/rust-analyzer/nightly";
+   };
+
+   outputs =
+@@ -14,6 +17,7 @@
+       nixpkgs,
+       fenix,
+       fenix2,
++      rust-analyzer-src,
+     }:
+     { };
+ }
+
+----- stderr -----

--- a/tests/snapshots/cli__follow_with_config@treefmt_transitive_transitive.snap
+++ b/tests/snapshots/cli__follow_with_config@treefmt_transitive_transitive.snap
@@ -25,9 +25,9 @@ exit_code: 0
      treefmt-nix.url = "github:numtide/treefmt-nix";
 +    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
      treefmt.url = "github:numtide/treefmt";
-+    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
 +    treefmt.inputs.nixpkgs.follows = "nixpkgs";
-+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
++    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
++    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    };
 
    outputs =

--- a/tests/snapshots/cli__follow_with_transitive_flag@treefmt_transitive_2.snap
+++ b/tests/snapshots/cli__follow_with_transitive_flag@treefmt_transitive_2.snap
@@ -25,9 +25,9 @@ exit_code: 0
      treefmt-nix.url = "github:numtide/treefmt-nix";
 +    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
      treefmt.url = "github:numtide/treefmt";
-+    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
 +    treefmt.inputs.nixpkgs.follows = "nixpkgs";
-+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
++    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
++    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    };
 
    outputs =

--- a/tests/snapshots/cli__follow_with_transitive_flag_default@treefmt_transitive.snap
+++ b/tests/snapshots/cli__follow_with_transitive_flag_default@treefmt_transitive.snap
@@ -24,9 +24,9 @@ exit_code: 0
      treefmt-nix.url = "github:numtide/treefmt-nix";
 +    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
      treefmt.url = "github:numtide/treefmt";
-+    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
 +    treefmt.inputs.nixpkgs.follows = "nixpkgs";
-+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
++    treefmt.inputs.treefmt-nix.follows = "treefmt-nix";
++    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    };
 
    outputs =

--- a/tests/snapshots/cli__list@completely_flat_toplevel.snap
+++ b/tests/snapshots/cli__list@completely_flat_toplevel.snap
@@ -12,14 +12,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· flake-utelinos - "github:numtide/flake-utils"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· flake-utelinos - github:numtide/flake-utils
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@completely_flat_toplevel_alt.snap
+++ b/tests/snapshots/cli__list@completely_flat_toplevel_alt.snap
@@ -12,14 +12,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· flake-utelinos - "github:numtide/flake-utils"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· flake-utelinos - github:numtide/flake-utils
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@deeply_nested_inputs.snap
+++ b/tests/snapshots/cli__list@deeply_nested_inputs.snap
@@ -12,8 +12,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· disko - "github:nix-community/disko"
-     nixpkgs => "nixpkgs"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
+· disko - github:nix-community/disko
+     nixpkgs => nixpkgs
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@first_nested_node.snap
+++ b/tests/snapshots/cli__list@first_nested_node.snap
@@ -12,10 +12,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· flake-compat - "github:edolstra/flake-compat"
-· naersk - "github:nix-community/naersk/master"
-     nixpkgs => "nixpkgs"
-· nixpkgs - "github:NixOS/nixpkgs/nixpkgs-unstable"
-· utils - "github:numtide/flake-utils"
+· flake-compat - github:edolstra/flake-compat
+· naersk - github:nix-community/naersk/master
+     nixpkgs => nixpkgs
+· nixpkgs - github:NixOS/nixpkgs/nixpkgs-unstable
+· utils - github:numtide/flake-utils
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@flat_nested_flat.snap
+++ b/tests/snapshots/cli__list@flat_nested_flat.snap
@@ -12,10 +12,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· flake-utils - "github:numtide/flake-utils/master"
-· nixpkgs - "github:NixOS/nixpkgs/nixos-unstable"
-· poetry2nix - "github:nix-community/poetry2nix/master"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· flake-utils - github:numtide/flake-utils/master
+· nixpkgs - github:NixOS/nixpkgs/nixos-unstable
+· poetry2nix - github:nix-community/poetry2nix/master
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@follows_cycle.snap
+++ b/tests/snapshots/cli__list@follows_cycle.snap
@@ -12,9 +12,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· harmonia - "github:nix-community/harmonia"
-     nixpkgs => "nixpkgs"
-· nixpkgs - "github:NixOS/nixpkgs/nixos-unstable"
-· treefmt-nix <= "harmonia/treefmt-nix"
+· harmonia - github:nix-community/harmonia
+     nixpkgs => nixpkgs
+· nixpkgs - github:NixOS/nixpkgs/nixos-unstable
+· treefmt-nix <= harmonia/treefmt-nix
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@one_level_nesting_flat.snap
+++ b/tests/snapshots/cli__list@one_level_nesting_flat.snap
@@ -12,14 +12,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· flake-utelinos - "github:numtide/flake-utils"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· flake-utelinos - github:numtide/flake-utils
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@root.snap
+++ b/tests/snapshots/cli__list@root.snap
@@ -12,14 +12,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· flake-utils - "github:numtide/flake-utils"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· flake-utils - github:numtide/flake-utils
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@root_alt.snap
+++ b/tests/snapshots/cli__list@root_alt.snap
@@ -12,14 +12,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· flake-utelinos - "github:numtide/flake-utils"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· flake-utelinos - github:numtide/flake-utils
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list@toplevel_nesting.snap
+++ b/tests/snapshots/cli__list@toplevel_nesting.snap
@@ -12,13 +12,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-· crane - "github:ipetkov/crane"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
-     rust-overlay => "rust-overlay"
-· nixpkgs - "github:nixos/nixpkgs/nixos-unstable"
-· rust-overlay - "github:oxalica/rust-overlay"
-     flake-utils => "flake-utils"
-     nixpkgs => "nixpkgs"
+· crane - github:ipetkov/crane
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
+     rust-overlay => rust-overlay
+· nixpkgs - github:nixos/nixpkgs/nixos-unstable
+· rust-overlay - github:oxalica/rust-overlay
+     flake-utils => flake-utils
+     nixpkgs => nixpkgs
 
 ----- stderr -----

--- a/tests/snapshots/cli__list_empty_target_follows.snap
+++ b/tests/snapshots/cli__list_empty_target_follows.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/follows_empty_target.flake.nix"
+    - "--lock-file"
+    - "[FIXTURES]/follows_empty_target.flake.lock"
+    - list
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+· nix - github:NixOS/nix
+     flake-compat => ""
+     nixpkgs => nixpkgs
+· nixpkgs - github:NixOS/nixpkgs/nixos-unstable
+
+----- stderr -----

--- a/tests/snapshots/cli__list_format@root_json.snap
+++ b/tests/snapshots/cli__list_format@root_json.snap
@@ -14,6 +14,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-{"crane":{"id":"crane","flake":true,"url":"\"github:ipetkov/crane\"","follows":[{"Indirect":["flake-utils","\"flake-utils\""]},{"Indirect":["nixpkgs","\"nixpkgs\""]},{"Indirect":["rust-overlay","\"rust-overlay\""]}],"range":{"start":373,"end":395}},"flake-utils":{"id":"flake-utils","flake":true,"url":"\"github:numtide/flake-utils\"","follows":[],"range":{"start":153,"end":181}},"nixpkgs":{"id":"nixpkgs","flake":true,"url":"\"github:nixos/nixpkgs/nixos-unstable\"","follows":[],"range":{"start":91,"end":128}},"rust-overlay":{"id":"rust-overlay","flake":true,"url":"\"github:oxalica/rust-overlay\"","follows":[{"Indirect":["flake-utils","\"flake-utils\""]},{"Indirect":["nixpkgs","\"nixpkgs\""]}],"range":{"start":217,"end":246}}}
+{"inputs":{"crane":{"id":"crane","url":"github:ipetkov/crane","flake":true},"flake-utils":{"id":"flake-utils","url":"github:numtide/flake-utils","flake":true},"nixpkgs":{"id":"nixpkgs","url":"github:nixos/nixpkgs/nixos-unstable","flake":true},"rust-overlay":{"id":"rust-overlay","url":"github:oxalica/rust-overlay","flake":true}},"follows":[{"parent":"crane","nested":"flake-utils","target":"flake-utils","kind":"indirect"},{"parent":"crane","nested":"nixpkgs","target":"nixpkgs","kind":"indirect"},{"parent":"crane","nested":"rust-overlay","target":"rust-overlay","kind":"indirect"},{"parent":"rust-overlay","nested":"flake-utils","target":"flake-utils","kind":"indirect"},{"parent":"rust-overlay","nested":"nixpkgs","target":"nixpkgs","kind":"indirect"}]}
 
 ----- stderr -----

--- a/tests/snapshots/cli__list_format@root_raw.snap
+++ b/tests/snapshots/cli__list_format@root_raw.snap
@@ -16,22 +16,66 @@ exit_code: 0
 ----- stdout -----
 {
     "crane": Input {
-        id: "crane",
+        id: Segment(
+            "crane",
+        ),
         flake: true,
-        url: "\"github:ipetkov/crane\"",
+        url: "github:ipetkov/crane",
         follows: [
-            Indirect(
-                "flake-utils",
-                "\"flake-utils\"",
-            ),
-            Indirect(
-                "nixpkgs",
-                "\"nixpkgs\"",
-            ),
-            Indirect(
-                "rust-overlay",
-                "\"rust-overlay\"",
-            ),
+            Indirect {
+                path: AttrPath(
+                    [
+                        Segment(
+                            "flake-utils",
+                        ),
+                    ],
+                ),
+                target: Some(
+                    AttrPath(
+                        [
+                            Segment(
+                                "flake-utils",
+                            ),
+                        ],
+                    ),
+                ),
+            },
+            Indirect {
+                path: AttrPath(
+                    [
+                        Segment(
+                            "nixpkgs",
+                        ),
+                    ],
+                ),
+                target: Some(
+                    AttrPath(
+                        [
+                            Segment(
+                                "nixpkgs",
+                            ),
+                        ],
+                    ),
+                ),
+            },
+            Indirect {
+                path: AttrPath(
+                    [
+                        Segment(
+                            "rust-overlay",
+                        ),
+                    ],
+                ),
+                target: Some(
+                    AttrPath(
+                        [
+                            Segment(
+                                "rust-overlay",
+                            ),
+                        ],
+                    ),
+                ),
+            },
         ],
         range: Range {
             start: 373,
@@ -39,9 +83,11 @@ exit_code: 0
         },
     },
     "flake-utils": Input {
-        id: "flake-utils",
+        id: Segment(
+            "flake-utils",
+        ),
         flake: true,
-        url: "\"github:numtide/flake-utils\"",
+        url: "github:numtide/flake-utils",
         follows: [],
         range: Range {
             start: 153,
@@ -49,9 +95,11 @@ exit_code: 0
         },
     },
     "nixpkgs": Input {
-        id: "nixpkgs",
+        id: Segment(
+            "nixpkgs",
+        ),
         flake: true,
-        url: "\"github:nixos/nixpkgs/nixos-unstable\"",
+        url: "github:nixos/nixpkgs/nixos-unstable",
         follows: [],
         range: Range {
             start: 91,
@@ -59,18 +107,48 @@ exit_code: 0
         },
     },
     "rust-overlay": Input {
-        id: "rust-overlay",
+        id: Segment(
+            "rust-overlay",
+        ),
         flake: true,
-        url: "\"github:oxalica/rust-overlay\"",
+        url: "github:oxalica/rust-overlay",
         follows: [
-            Indirect(
-                "flake-utils",
-                "\"flake-utils\"",
-            ),
-            Indirect(
-                "nixpkgs",
-                "\"nixpkgs\"",
-            ),
+            Indirect {
+                path: AttrPath(
+                    [
+                        Segment(
+                            "flake-utils",
+                        ),
+                    ],
+                ),
+                target: Some(
+                    AttrPath(
+                        [
+                            Segment(
+                                "flake-utils",
+                            ),
+                        ],
+                    ),
+                ),
+            },
+            Indirect {
+                path: AttrPath(
+                    [
+                        Segment(
+                            "nixpkgs",
+                        ),
+                    ],
+                ),
+                target: Some(
+                    AttrPath(
+                        [
+                            Segment(
+                                "nixpkgs",
+                            ),
+                        ],
+                    ),
+                ),
+            },
         ],
         range: Range {
             start: 217,

--- a/tests/snapshots/cli__remove@deeply_nested_inputs_nixpkgs.snap
+++ b/tests/snapshots/cli__remove@deeply_nested_inputs_nixpkgs.snap
@@ -16,20 +16,21 @@ exit_code: 0
 ----- stdout -----
 --- original
 +++ modified
-@@ -2,14 +2,10 @@
+@@ -2,15 +2,8 @@
    description = "Deeply nested inputs attrset";
 
    inputs = {
 -    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
      disko = {
-       url = "github:nix-community/disko";
-       inputs = {
+-      url = "github:nix-community/disko";
+-      inputs = {
 -        nixpkgs = {
 -          follows = "nixpkgs";
 -        };
-       };
+-      };
      };
    };
+
 
 ----- stderr -----

--- a/tests/snapshots/cli__remove@root_alt_nixpkgs.snap
+++ b/tests/snapshots/cli__remove@root_alt_nixpkgs.snap
@@ -16,7 +16,7 @@ exit_code: 0
 ----- stdout -----
 --- original
 +++ modified
-@@ -2,7 +2,6 @@
+@@ -2,21 +2,16 @@
    description = "Manage your flake inputs comfortably.";
 
    inputs = {
@@ -24,17 +24,15 @@ exit_code: 0
 
      flake-utelinos.url = "github:numtide/flake-utils";
 
-@@ -9,7 +8,6 @@
      rust-overlay = {
-       url = "github:oxalica/rust-overlay";
+-      url = "github:oxalica/rust-overlay";
        inputs = {
 -        nixpkgs.follows = "nixpkgs";
          flake-utils.follows = "flake-utils";
        };
      };
-@@ -16,7 +14,6 @@
      crane = {
-       url = "github:ipetkov/crane";
+-      url = "github:ipetkov/crane";
        inputs = {
 -        nixpkgs.follows = "nixpkgs";
          rust-overlay.follows = "rust-overlay";

--- a/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel.snap
+++ b/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 381
-    end: 403
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 147
-    end: 175
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 78
-    end: 115
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 205
-    end: 234
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_alt.snap
+++ b/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_alt.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 466
-    end: 488
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 150
-    end: 178
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 86
-    end: 123
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 256
-    end: 285
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_not_a_flake.snap
+++ b/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_not_a_flake.snap
@@ -1,62 +1,49 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 381
-    end: 403
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 147
-    end: 175
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 78
-    end: 115
-not-a-flake:
-  id: not-a-flake
-  flake: true
-  url: "\"github:a-kenji/not-a-flake\""
-  follows: []
-  range:
-    start: 603
-    end: 631
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 205
-    end: 234
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  not-a-flake:
+    id: not-a-flake
+    url: "github:a-kenji/not-a-flake"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_not_a_flake_nested.snap
+++ b/tests/snapshots/edit__flake_edit_list@completely_flat_toplevel_not_a_flake_nested.snap
@@ -1,62 +1,49 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 381
-    end: 403
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 147
-    end: 175
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 78
-    end: 115
-not-a-flake:
-  id: not-a-flake
-  flake: true
-  url: "\"github:a-kenji/not-a-flake\""
-  follows: []
-  range:
-    start: 611
-    end: 639
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 205
-    end: 234
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  not-a-flake:
+    id: not-a-flake
+    url: "github:a-kenji/not-a-flake"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@dot_ancestor_cycle.snap
+++ b/tests/snapshots/edit__flake_edit_list@dot_ancestor_cycle.snap
@@ -1,0 +1,29 @@
+---
+source: tests/edit.rs
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  helper:
+    id: helper
+    url: "github:example/helper"
+    flake: true
+  hls-1.10:
+    id: hls-1.10
+    url: "github:example/hls"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: helper
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: hls-1.10
+    nested: helper
+    target: helper
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@follows_empty_target.snap
+++ b/tests/snapshots/edit__flake_edit_list@follows_empty_target.snap
@@ -1,0 +1,25 @@
+---
+source: tests/edit.rs
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  nix:
+    id: nix
+    url: "github:NixOS/nix"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: nix
+    nested: flake-compat
+    target: ""
+    kind: indirect
+  - parent: nix
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@lockfile_only_cycle.snap
+++ b/tests/snapshots/edit__flake_edit_list@lockfile_only_cycle.snap
@@ -1,0 +1,21 @@
+---
+source: tests/edit.rs
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  bar:
+    id: bar
+    url: "github:example/bar"
+    flake: true
+  foo:
+    id: foo
+    url: "github:example/foo"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows: []

--- a/tests/snapshots/edit__flake_edit_list@merged_inputs.snap
+++ b/tests/snapshots/edit__flake_edit_list@merged_inputs.snap
@@ -1,42 +1,29 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-home-manager:
-  id: home-manager
-  flake: true
-  url: "\"github:nix-community/home-manager\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 195
-    end: 230
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 123
-    end: 160
-plugin-a:
-  id: plugin-a
-  flake: true
-  url: "\"github:foo/plugin-a/v2.0\""
-  follows: []
-  range:
-    start: 358
-    end: 384
-plugin-b:
-  id: plugin-b
-  flake: true
-  url: "\"github:foo/plugin-b/v1.8.2\""
-  follows: []
-  range:
-    start: 443
-    end: 471
+inputs:
+  home-manager:
+    id: home-manager
+    url: "github:nix-community/home-manager"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+  plugin-a:
+    id: plugin-a
+    url: "github:foo/plugin-a/v2.0"
+    flake: true
+  plugin-b:
+    id: plugin-b
+    url: "github:foo/plugin-b/v1.8.2"
+    flake: true
+follows:
+  - parent: home-manager
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@merged_inputs_flat.snap
+++ b/tests/snapshots/edit__flake_edit_list@merged_inputs_flat.snap
@@ -1,34 +1,25 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-extra:
-  id: extra
-  flake: true
-  url: "\"github:foo/extra\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 234
-    end: 252
-flake-utils:
-  id: flake-utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 159
-    end: 187
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 98
-    end: 135
+inputs:
+  extra:
+    id: extra
+    url: "github:foo/extra"
+    flake: true
+  flake-utils:
+    id: flake-utils
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: extra
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@multi_hop_cycle.snap
+++ b/tests/snapshots/edit__flake_edit_list@multi_hop_cycle.snap
@@ -1,0 +1,29 @@
+---
+source: tests/edit.rs
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  a:
+    id: a
+    url: "github:example/a"
+    flake: true
+  b:
+    id: b
+    url: "github:example/b"
+    flake: true
+  c:
+    id: c
+    url: "github:example/c"
+    flake: true
+follows:
+  - parent: a
+    nested: b
+    target: b
+    kind: indirect
+  - parent: b
+    nested: c
+    target: c
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@nested_url_override.snap
+++ b/tests/snapshots/edit__flake_edit_list@nested_url_override.snap
@@ -1,0 +1,22 @@
+---
+source: tests/edit.rs
+assertion_line: 36
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  mac-app-util:
+    id: mac-app-util
+    url: "github:hraban/mac-app-util"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: mac-app-util
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@one_level_nesting_flat_not_a_flake.snap
+++ b/tests/snapshots/edit__flake_edit_list@one_level_nesting_flat_not_a_flake.snap
@@ -1,70 +1,53 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-also-not-a-flake:
-  id: also-not-a-flake
-  flake: false
-  url: "\"github:a-kenji/also-not-a-flake\""
-  follows: []
-  range:
-    start: 131
-    end: 164
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 462
-    end: 484
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 248
-    end: 276
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 184
-    end: 221
-not-a-flake:
-  id: not-a-flake
-  flake: false
-  url: "\"github:a-kenji/not-a-flake\""
-  follows: []
-  range:
-    start: 664
-    end: 692
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 301
-    end: 330
+inputs:
+  also-not-a-flake:
+    id: also-not-a-flake
+    url: "github:a-kenji/also-not-a-flake"
+    flake: false
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  not-a-flake:
+    id: not-a-flake
+    url: "github:a-kenji/not-a-flake"
+    flake: false
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@root.snap
+++ b/tests/snapshots/edit__flake_edit_list@root.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 373
-    end: 395
-flake-utils:
-  id: flake-utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 153
-    end: 181
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 91
-    end: 128
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 217
-    end: 246
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utils:
+    id: flake-utils
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@root_alt.snap
+++ b/tests/snapshots/edit__flake_edit_list@root_alt.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 392
-    end: 414
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 156
-    end: 184
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 91
-    end: 128
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 220
-    end: 249
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@stale_lockfile_only.snap
+++ b/tests/snapshots/edit__flake_edit_list@stale_lockfile_only.snap
@@ -1,0 +1,25 @@
+---
+source: tests/edit.rs
+expression: "ListOutput::from(flake_edit.list())"
+info:
+  flake_nix: ""
+  changes: []
+---
+inputs:
+  foo:
+    id: foo
+    url: "github:example/foo"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: foo
+    nested: bar
+    target: nixpkgs
+    kind: indirect
+  - parent: foo
+    nested: baz
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__flake_edit_list@toplevel_nesting.snap
+++ b/tests/snapshots/edit__flake_edit_list@toplevel_nesting.snap
@@ -1,46 +1,41 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 292
-    end: 314
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 62
-    end: 99
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 138
-    end: 167
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__list@flake_false.snap
+++ b/tests/snapshots/edit__list@flake_false.snap
@@ -1,42 +1,29 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.curr_list()
+expression: "ListOutput::from(flake_edit.curr_list())"
 info:
   flake_nix: ""
   changes: []
 ---
-flake-compat:
-  id: flake-compat
-  flake: true
-  url: "\"github:edolstra/flake-compat\""
-  follows: []
-  range:
-    start: 297
-    end: 327
-naersk:
-  id: naersk
-  flake: true
-  url: "\"github:nix-community/naersk/master\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 72
-    end: 108
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixpkgs-unstable\""
-  follows: []
-  range:
-    start: 177
-    end: 216
-utils:
-  id: utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 234
-    end: 262
+inputs:
+  flake-compat:
+    id: flake-compat
+    url: "github:edolstra/flake-compat"
+    flake: true
+  naersk:
+    id: naersk
+    url: "github:nix-community/naersk/master"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixpkgs-unstable"
+    flake: true
+  utils:
+    id: utils
+    url: "github:numtide/flake-utils"
+    flake: true
+follows:
+  - parent: naersk
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__list@flake_true.snap
+++ b/tests/snapshots/edit__list@flake_true.snap
@@ -1,42 +1,29 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.curr_list()
+expression: "ListOutput::from(flake_edit.curr_list())"
 info:
   flake_nix: ""
   changes: []
 ---
-flake-compat:
-  id: flake-compat
-  flake: true
-  url: "\"github:edolstra/flake-compat\""
-  follows: []
-  range:
-    start: 297
-    end: 327
-naersk:
-  id: naersk
-  flake: true
-  url: "\"github:nix-community/naersk/master\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 72
-    end: 108
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixpkgs-unstable\""
-  follows: []
-  range:
-    start: 177
-    end: 216
-utils:
-  id: utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 234
-    end: 262
+inputs:
+  flake-compat:
+    id: flake-compat
+    url: "github:edolstra/flake-compat"
+    flake: true
+  naersk:
+    id: naersk
+    url: "github:nix-community/naersk/master"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixpkgs-unstable"
+    flake: true
+  utils:
+    id: utils
+    url: "github:numtide/flake-utils"
+    flake: true
+follows:
+  - parent: naersk
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__list@naersk.snap
+++ b/tests/snapshots/edit__list@naersk.snap
@@ -1,33 +1,24 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes:
     - Remove:
-        id: naersk
+        ids:
+          - naersk
 ---
-flake-compat:
-  id: flake-compat
-  flake: true
-  url: "\"github:edolstra/flake-compat\""
-  follows: []
-  range:
-    start: 183
-    end: 213
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixpkgs-unstable\""
-  follows: []
-  range:
-    start: 63
-    end: 102
-utils:
-  id: utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 120
-    end: 148
+inputs:
+  flake-compat:
+    id: flake-compat
+    url: "github:edolstra/flake-compat"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixpkgs-unstable"
+    flake: true
+  utils:
+    id: utils
+    url: "github:numtide/flake-utils"
+    flake: true
+follows: []

--- a/tests/snapshots/edit__list@utils.snap
+++ b/tests/snapshots/edit__list@utils.snap
@@ -1,36 +1,28 @@
 ---
 source: tests/edit.rs
-expression: flake_edit.list()
+expression: "ListOutput::from(flake_edit.list())"
 info:
   flake_nix: ""
   changes:
     - Remove:
-        id: utils
+        ids:
+          - utils
 ---
-flake-compat:
-  id: flake-compat
-  flake: true
-  url: "\"github:edolstra/flake-compat\""
-  follows: []
-  range:
-    start: 251
-    end: 281
-naersk:
-  id: naersk
-  flake: true
-  url: "\"github:nix-community/naersk/master\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 72
-    end: 108
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixpkgs-unstable\""
-  follows: []
-  range:
-    start: 177
-    end: 216
+inputs:
+  flake-compat:
+    id: flake-compat
+    url: "github:edolstra/flake-compat"
+    flake: true
+  naersk:
+    id: naersk
+    url: "github:nix-community/naersk/master"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixpkgs-unstable"
+    flake: true
+follows:
+  - parent: naersk
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__remove_nested_input@deeply_nested_inputs_disko_nixpkgs.snap
+++ b/tests/snapshots/edit__remove_nested_input@deeply_nested_inputs_disko_nixpkgs.snap
@@ -15,9 +15,6 @@ info:
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
 
     disko = {
-      url = "github:nix-community/disko";
-      inputs = {
-      };
     };
   };
 

--- a/tests/snapshots/edit__remove_nested_input@one_level_nesting_flat_rust-overlay_flake-utils.snap
+++ b/tests/snapshots/edit__remove_nested_input@one_level_nesting_flat_rust-overlay_flake-utils.snap
@@ -1,11 +1,13 @@
 ---
 source: tests/edit.rs
+assertion_line: 218
 expression: result
 info:
   flake_nix: ""
   changes:
     - Remove:
-        id: rust-overlay.flake-utils
+        ids:
+          - rust-overlay.flake-utils
 ---
 {
   description = "Edit your flake inputs with ease";

--- a/tests/snapshots/edit__remove_nested_input@root_rust-overlay_flake-utils.snap
+++ b/tests/snapshots/edit__remove_nested_input@root_rust-overlay_flake-utils.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/edit.rs
+assertion_line: 218
 expression: result
 info:
   flake_nix: ""

--- a/tests/snapshots/edit__walker_inputs@first_nested_node.snap
+++ b/tests/snapshots/edit__walker_inputs@first_nested_node.snap
@@ -1,42 +1,29 @@
 ---
 source: tests/edit.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-flake-compat:
-  id: flake-compat
-  flake: true
-  url: "\"github:edolstra/flake-compat\""
-  follows: []
-  range:
-    start: 297
-    end: 327
-naersk:
-  id: naersk
-  flake: true
-  url: "\"github:nix-community/naersk/master\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 72
-    end: 108
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixpkgs-unstable\""
-  follows: []
-  range:
-    start: 177
-    end: 216
-utils:
-  id: utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 234
-    end: 262
+inputs:
+  flake-compat:
+    id: flake-compat
+    url: "github:edolstra/flake-compat"
+    flake: true
+  naersk:
+    id: naersk
+    url: "github:nix-community/naersk/master"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixpkgs-unstable"
+    flake: true
+  utils:
+    id: utils
+    url: "github:numtide/flake-utils"
+    flake: true
+follows:
+  - parent: naersk
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/edit__walker_inputs@one_level_nesting_flat.snap
+++ b/tests/snapshots/edit__walker_inputs@one_level_nesting_flat.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/edit.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 364
-    end: 386
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 150
-    end: 178
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 86
-    end: 123
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 203
-    end: 232
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@completely_flat_toplevel.snap
+++ b/tests/snapshots/walker__walker_list_inputs@completely_flat_toplevel.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 381
-    end: 403
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 147
-    end: 175
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 78
-    end: 115
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 205
-    end: 234
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@completely_flat_toplevel_alt.snap
+++ b/tests/snapshots/walker__walker_list_inputs@completely_flat_toplevel_alt.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 466
-    end: 488
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 150
-    end: 178
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 86
-    end: 123
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 256
-    end: 285
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@deeply_nested_inputs.snap
+++ b/tests/snapshots/walker__walker_list_inputs@deeply_nested_inputs.snap
@@ -1,26 +1,21 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-disko:
-  id: disko
-  flake: true
-  url: "\"github:nix-community/disko\""
-  follows:
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 148
-    end: 176
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 82
-    end: 119
+inputs:
+  disko:
+    id: disko
+    url: "github:nix-community/disko"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+follows:
+  - parent: disko
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@flat_nested_flat.snap
+++ b/tests/snapshots/walker__walker_list_inputs@flat_nested_flat.snap
@@ -1,37 +1,29 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-flake-utils:
-  id: flake-utils
-  flake: true
-  url: "\"github:numtide/flake-utils/master\""
-  follows: []
-  range:
-    start: 133
-    end: 168
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:NixOS/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 67
-    end: 104
-poetry2nix:
-  id: poetry2nix
-  flake: true
-  url: "\"github:nix-community/poetry2nix/master\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 292
-    end: 332
+inputs:
+  flake-utils:
+    id: flake-utils
+    url: "github:numtide/flake-utils/master"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:NixOS/nixpkgs/nixos-unstable"
+    flake: true
+  poetry2nix:
+    id: poetry2nix
+    url: "github:nix-community/poetry2nix/master"
+    flake: true
+follows:
+  - parent: poetry2nix
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: poetry2nix
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@one_level_nesting_flat.snap
+++ b/tests/snapshots/walker__walker_list_inputs@one_level_nesting_flat.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 364
-    end: 386
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 150
-    end: 178
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 86
-    end: 123
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 203
-    end: 232
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@root.snap
+++ b/tests/snapshots/walker__walker_list_inputs@root.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 373
-    end: 395
-flake-utils:
-  id: flake-utils
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 153
-    end: 181
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 91
-    end: 128
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 217
-    end: 246
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utils:
+    id: flake-utils
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@root_alt.snap
+++ b/tests/snapshots/walker__walker_list_inputs@root_alt.snap
@@ -1,54 +1,45 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 392
-    end: 414
-flake-utelinos:
-  id: flake-utelinos
-  flake: true
-  url: "\"github:numtide/flake-utils\""
-  follows: []
-  range:
-    start: 156
-    end: 184
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 91
-    end: 128
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 220
-    end: 249
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  flake-utelinos:
+    id: flake-utelinos
+    url: "github:numtide/flake-utils"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/snapshots/walker__walker_list_inputs@toplevel_nesting.snap
+++ b/tests/snapshots/walker__walker_list_inputs@toplevel_nesting.snap
@@ -1,46 +1,41 @@
 ---
 source: tests/walker.rs
-expression: walker.inputs
+expression: "ListOutput::from(&walker.inputs)"
 info:
   flake_nix: ""
   changes: []
 ---
-crane:
-  id: crane
-  flake: true
-  url: "\"github:ipetkov/crane\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-    - Indirect:
-        - rust-overlay
-        - "\"rust-overlay\""
-  range:
-    start: 292
-    end: 314
-nixpkgs:
-  id: nixpkgs
-  flake: true
-  url: "\"github:nixos/nixpkgs/nixos-unstable\""
-  follows: []
-  range:
-    start: 62
-    end: 99
-rust-overlay:
-  id: rust-overlay
-  flake: true
-  url: "\"github:oxalica/rust-overlay\""
-  follows:
-    - Indirect:
-        - flake-utils
-        - "\"flake-utils\""
-    - Indirect:
-        - nixpkgs
-        - "\"nixpkgs\""
-  range:
-    start: 138
-    end: 167
+inputs:
+  crane:
+    id: crane
+    url: "github:ipetkov/crane"
+    flake: true
+  nixpkgs:
+    id: nixpkgs
+    url: "github:nixos/nixpkgs/nixos-unstable"
+    flake: true
+  rust-overlay:
+    id: rust-overlay
+    url: "github:oxalica/rust-overlay"
+    flake: true
+follows:
+  - parent: crane
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: crane
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect
+  - parent: crane
+    nested: rust-overlay
+    target: rust-overlay
+    kind: indirect
+  - parent: rust-overlay
+    nested: flake-utils
+    target: flake-utils
+    kind: indirect
+  - parent: rust-overlay
+    nested: nixpkgs
+    target: nixpkgs
+    kind: indirect

--- a/tests/walker.rs
+++ b/tests/walker.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::{Info, load_flake};
+use flake_edit::app::handler::ListOutput;
 use flake_edit::change::Change;
 use flake_edit::walk::Walker;
 use rstest::rstest;
@@ -24,7 +25,7 @@ fn test_walker_list_inputs(#[case] fixture: &str) {
         info => &info,
         snapshot_suffix => fixture
     }, {
-        insta::assert_yaml_snapshot!(walker.inputs);
+        insta::assert_yaml_snapshot!(ListOutput::from(&walker.inputs));
     });
 }
 
@@ -65,7 +66,7 @@ fn test_walker_remove_input(#[case] fixture: &str, #[case] input_id: &str) {
     let content = load_flake(fixture);
     let mut walker = Walker::new(&content);
     let change = Change::Remove {
-        ids: vec![input_id.to_owned().into()],
+        ids: vec![flake_edit::change::ChangeId::parse(input_id).unwrap()],
     };
     let info = Info::with_change(change.clone());
     let result = walker.walk(&change).unwrap().unwrap();


### PR DESCRIPTION
Support auto follows of more than one level.
We now traverse the flake inputs through a bounded `DFS` with cycle detection, meaning we should now support arbitrary nesting. This is still gated through the `depth` flag, because I am not sure if that is default behavior we actually want.

Example:

```
$ flake-edit follow --depth 2
```

Will now deduplicate inputs up to depth 2, meaning two `follow` invocations. This can also be combined with the `transitive` flag.

Example:

```
$ flake-edit follow --transitive --depth 2
```

This is *almost* certainly not what we want by default, because this could change a lot of inputs. As this *may* promote a lot of transitive inputs.
But I am open to feedback here.