### PR TITLE
follow/lock: Relock follow edits with `offline`

### DIFF
--- a/src/app/editor.rs
+++ b/src/app/editor.rs
@@ -68,16 +68,18 @@ impl Editor {
         FlakeEdit::from_text(&self.text())
     }
 
-    fn run_nix_flake_lock(&self) -> io::Result<()> {
+    fn run_nix_flake_lock(&self, offline: bool) -> io::Result<()> {
         let flake_dir = match self.flake.path.parent() {
             Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
             _ => PathBuf::from("."),
         };
 
-        let output = Command::new("nix")
-            .args(["flake", "lock"])
-            .current_dir(&flake_dir)
-            .output()?;
+        let mut cmd = Command::new("nix");
+        if offline {
+            cmd.arg("--offline");
+        }
+        cmd.args(["flake", "lock"]);
+        let output = cmd.current_dir(&flake_dir).output()?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -109,7 +111,7 @@ impl Editor {
             self.flake.write(new_content)?;
 
             if !state.no_lock
-                && let Err(e) = self.run_nix_flake_lock()
+                && let Err(e) = self.run_nix_flake_lock(state.lock_offline)
             {
                 eprintln!("Warning: Failed to update lockfile: {}", e);
             }

--- a/src/app/follow/auto.rs
+++ b/src/app/follow/auto.rs
@@ -72,6 +72,7 @@ pub fn run_batch(
             Ok(s) => s
                 .with_diff(args.diff())
                 .with_no_lock(args.no_lock())
+                .with_lock_offline(true)
                 .with_interactive(false)
                 .with_lock_file(Some(lock_path))
                 .with_no_cache(args.no_cache())

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -247,10 +247,12 @@ pub fn run(args: CliArgs) -> Result<()> {
             if let Some(max) = depth {
                 state.config.follow.max_depth = *max;
             }
+            state.lock_offline = true;
             follow::auto::run(&editor, &mut flake_edit, &state)?;
         }
 
         Command::AddFollow { input, target } => {
+            state.lock_offline = true;
             follow::add_follow(
                 &editor,
                 &mut flake_edit,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -18,6 +18,9 @@ pub struct AppState {
     pub diff: bool,
     /// Skip running nix flake lock after changes
     pub no_lock: bool,
+    /// Pass `--offline` to `nix flake lock`. Set for follows-only edits so
+    /// the lockfile refresh works without network access.
+    pub lock_offline: bool,
     /// Allow interactive TUI prompts
     pub interactive: bool,
     /// Disable reading from and writing to the completion cache
@@ -40,6 +43,7 @@ impl AppState {
             lock_file: None,
             diff: false,
             no_lock: false,
+            lock_offline: false,
             interactive: true,
             no_cache: false,
             cache_path: None,
@@ -54,6 +58,11 @@ impl AppState {
 
     pub fn with_no_lock(mut self, no_lock: bool) -> Self {
         self.no_lock = no_lock;
+        self
+    }
+
+    pub fn with_lock_offline(mut self, lock_offline: bool) -> Self {
+        self.lock_offline = lock_offline;
         self
     }
 


### PR DESCRIPTION
Relock follow edits with the `offline` flag. Making it compatible with
being run in nix sandboxes. For example the `treefmt-nix` check.
