### PR TITLE
feat(cli/toggle): init the toggle subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There is a mechanism to deduplicate transitive dependencies: `flake-edit.inputs.
     - [`$ flake-edit change`](#-flake-edit-change)
     - [`$ flake-edit pin`](#-flake-edit-pin)
     - [`$ flake-edit unpin`](#-flake-edit-unpin)
+    - [`$ flake-edit toggle`](#-flake-edit-toggle)
     - [`$ flake-edit list`](#-flake-edit-list)
     - [`$ flake-edit follow`](#-flake-edit-follow)
     - [`$ flake-edit config`](#-flake-edit-config)
@@ -44,7 +45,7 @@ There is a mechanism to deduplicate transitive dependencies: `flake-edit.inputs.
 <!-- `$ flake-edit help` -->
 
 ```
-Edit your flake inputs with ease.
+Edit your flake inputs with ease
 
 Usage: flake-edit [OPTIONS] <COMMAND>
 
@@ -63,6 +64,8 @@ Commands:
           Pin inputs to their current or a specified rev
   unpin
           Unpin an input so it tracks the upstream default again
+  toggle
+          Toggle an input between its active url and a stored alternate
   follow
           Automatically add and remove follows declarations
   add-follow
@@ -74,23 +77,32 @@ Commands:
 
 Options:
       --flake <FLAKE>
-          Location of the `flake.nix` file, that will be used. Defaults to `flake.nix` in the current directory
+          Path to `flake.nix`, or a directory containing `flake.nix`. Defaults to `flake.nix` in the current directory
+
       --lock-file <LOCK_FILE>
           Location of the `flake.lock` file. Defaults to `flake.lock` in the current directory
+
       --diff
-          Print a diff of the changes, will not write the changes to disk
+          Print a diff of the changes instead of writing them to disk
+
       --no-lock
           Skip updating the lockfile after editing flake.nix
+
       --non-interactive
           Disable interactive prompts
+
       --no-cache
           Disable reading from and writing to the completion cache
+
       --cache <CACHE>
           Path to a custom cache file
+
       --config <CONFIG>
           Path to a custom configuration file
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 ```
@@ -240,6 +252,47 @@ Options:
 ```
 ![flake-edit unpin example](https://vhs.charm.sh/vhs-G8Eo84Ysjpt5c09Q9VD4u.gif)
 
+### `$ flake-edit toggle`
+<!-- `$ flake-edit help toggle` -->
+
+```
+Toggle an input between its active url and a stored alternate.
+
+Alternates live as commented copies of the url line next to the active one. Flipping moves only the comment marker.
+
+Usage: flake-edit toggle [OPTIONS] [INPUT] [REF]
+
+Arguments:
+  [INPUT]
+          An input id, or a flake reference to activate
+
+  [REF]
+          The variant to activate, stored as a new alternate when not yet present
+
+Options:
+  -r, --remove
+          Remove the resolved variant's line instead of activating it. Removing the active url flips to the stored alternate first
+
+      --config <CONFIG>
+          Path to a custom configuration file
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+![flake-edit toggle flip example](https://vhs.charm.sh/vhs-7JYfXoaZVtOUqDPmCfFe8.gif)
+
+Switch an input to a new variant, keeping the previous url as a commented alternative.
+When working on flakes you might want to quickly switch between a local checkout, or an alternative branch.
+This allows you to quickly toggle between all the alternative commented inputs that have the same input ID.
+
+![flake-edit toggle example](https://vhs.charm.sh/vhs-1acgBYYAYs8evMb0lkOXXZ.gif)
+
+This toggles the selected input with its matching ID and also adds the new input as its active ID.
+This can quickly be undone through `flake-edit toggle --remove [ID]`, which will activate the commented out
+section that was selected, but will remove the already activated ID again.
+![flake-edit toggle remove example](https://vhs.charm.sh/vhs-5I9lK4p4d5xZwXpR1PyTdt.gif)
+
+
 ### `$ flake-edit list`
 <!-- `$ flake-edit help list` -->
 
@@ -250,7 +303,7 @@ Usage: flake-edit list [OPTIONS]
 
 Options:
       --format <FORMAT>
-          [default: detailed]
+          [default: detailed] [possible values: simple, toplevel, detailed, json]
       --config <CONFIG>
           Path to a custom configuration file
   -h, --help
@@ -280,6 +333,9 @@ Arguments:
 Options:
       --transitive [<TRANSITIVE>]
           Enable transitive follows deduplication, promoting shared nested inputs to top-level when they appear at least N times. Defaults to 2 if no value is given. Overrides the config file's `follow.transitive_min`
+
+      --depth <DEPTH>
+          Maximum depth of follows declarations to write. Omitting the flag writes follows at every depth the lockfile graph supports. `--depth N` caps emission: 1 writes only `parent.child.follows`, 2 also writes `parent.child.grandchild.follows`, and so on. Overrides the config file's `follow.max_depth`
 
       --config <CONFIG>
           Path to a custom configuration file
@@ -410,6 +466,13 @@ Run `flake-edit config --print-default` to create a default configuration:
 # Example: if nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
 # follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs
 # aliases = { nixpkgs = ["nixpkgs-lib"] }
+
+# Maximum depth of follows declarations to write.
+# Unset (the default) writes follows at every depth the lockfile graph
+# supports. Set an explicit number to cap the depth: 1 writes only
+# `parent.nested.follows = "target"`, 2 also writes
+# `parent.middle.grandchild.follows = "target"`, and so on.
+# max_depth = 1
 ```
 
 ## As a library

--- a/assets/tape/toggle_add.tape
+++ b/assets/tape/toggle_add.tape
@@ -1,0 +1,71 @@
+# VHS documentation
+#
+# Output:
+#   Output <path>.gif               Create a GIF output at the given <path>
+#   Output <path>.mp4               Create an MP4 output at the given <path>
+#   Output <path>.webm              Create a WebM output at the given <path>
+#
+# Require:
+#   Require <string>                Ensure a program is on the $PATH to proceed
+#
+# Settings:
+#   Set FontSize <number>           Set the font size of the terminal
+#   Set FontFamily <string>         Set the font family of the terminal
+#   Set Height <number>             Set the height of the terminal
+#   Set Width <number>              Set the width of the terminal
+#   Set LetterSpacing <float>       Set the font letter spacing (tracking)
+#   Set LineHeight <float>          Set the font line height
+#   Set LoopOffset <float>%         Set the starting frame offset for the GIF loop
+#   Set Theme <json|string>         Set the theme of the terminal
+#   Set Padding <number>            Set the padding of the terminal
+#   Set Framerate <number>          Set the framerate of the recording
+#   Set PlaybackSpeed <float>       Set the playback speed of the recording
+#   Set MarginFill <file|#000000>   Set the file or color the margin will be filled with.
+#   Set Margin <number>             Set the size of the margin. Has no effect if MarginFill isn't set.
+#   Set BorderRadius <number>       Set terminal border radius, in pixels.
+#   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
+#   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
+#   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms.
+#
+# Sleep:
+#   Sleep <time>                    Sleep for a set amount of <time> in seconds
+#
+# Type:
+#   Type[@<time>] "<characters>"    Type <characters> into the terminal with a
+#                                   <time> delay between each character
+#
+# Keys:
+#   Backspace[@<time>] [number]     Press the Backspace key
+#   Down[@<time>] [number]          Press the Down key
+#   Enter[@<time>] [number]         Press the Enter key
+#   Space[@<time>] [number]         Press the Space key
+#   Tab[@<time>] [number]           Press the Tab key
+#   Left[@<time>] [number]          Press the Left Arrow key
+#   Right[@<time>] [number]         Press the Right Arrow key
+#   Up[@<time>] [number]            Press the Up Arrow key
+#   Down[@<time>] [number]          Press the Down Arrow key
+#   PageUp[@<time>] [number]        Press the Page Up key
+#   PageDown[@<time>] [number]      Press the Page Down key
+#   Ctrl+<key>                      Press the Control key + <key> (e.g. Ctrl+C)
+#
+# Display:
+#   Hide                            Hide the subsequent commands from the output
+#   Show                            Show the subsequent commands in the output
+
+Output output/toggle_add.gif
+
+Require echo
+
+Set Shell "fish"
+Set FontSize 32
+Set Width 1300
+Set Height 600
+
+Hide
+#Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter
+Type "set -x fish_function_path ''" Enter
+Type "clear" Enter
+Show
+
+Type "flake-edit --diff toggle rust-overlay github:a-kenji/rust-overlay" Sleep 1000ms Enter
+Sleep 5s

--- a/assets/tape/toggle_flip.tape
+++ b/assets/tape/toggle_flip.tape
@@ -1,0 +1,74 @@
+# VHS documentation
+#
+# Output:
+#   Output <path>.gif               Create a GIF output at the given <path>
+#   Output <path>.mp4               Create an MP4 output at the given <path>
+#   Output <path>.webm              Create a WebM output at the given <path>
+#
+# Require:
+#   Require <string>                Ensure a program is on the $PATH to proceed
+#
+# Settings:
+#   Set FontSize <number>           Set the font size of the terminal
+#   Set FontFamily <string>         Set the font family of the terminal
+#   Set Height <number>             Set the height of the terminal
+#   Set Width <number>              Set the width of the terminal
+#   Set LetterSpacing <float>       Set the font letter spacing (tracking)
+#   Set LineHeight <float>          Set the font line height
+#   Set LoopOffset <float>%         Set the starting frame offset for the GIF loop
+#   Set Theme <json|string>         Set the theme of the terminal
+#   Set Padding <number>            Set the padding of the terminal
+#   Set Framerate <number>          Set the framerate of the recording
+#   Set PlaybackSpeed <float>       Set the playback speed of the recording
+#   Set MarginFill <file|#000000>   Set the file or color the margin will be filled with.
+#   Set Margin <number>             Set the size of the margin. Has no effect if MarginFill isn't set.
+#   Set BorderRadius <number>       Set terminal border radius, in pixels.
+#   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
+#   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
+#   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms.
+#
+# Sleep:
+#   Sleep <time>                    Sleep for a set amount of <time> in seconds
+#
+# Type:
+#   Type[@<time>] "<characters>"    Type <characters> into the terminal with a
+#                                   <time> delay between each character
+#
+# Keys:
+#   Backspace[@<time>] [number]     Press the Backspace key
+#   Down[@<time>] [number]          Press the Down key
+#   Enter[@<time>] [number]         Press the Enter key
+#   Space[@<time>] [number]         Press the Space key
+#   Tab[@<time>] [number]           Press the Tab key
+#   Left[@<time>] [number]          Press the Left Arrow key
+#   Right[@<time>] [number]         Press the Right Arrow key
+#   Up[@<time>] [number]            Press the Up Arrow key
+#   Down[@<time>] [number]          Press the Down Arrow key
+#   PageUp[@<time>] [number]        Press the Page Up key
+#   PageDown[@<time>] [number]      Press the Page Down key
+#   Ctrl+<key>                      Press the Control key + <key> (e.g. Ctrl+C)
+#
+# Display:
+#   Hide                            Hide the subsequent commands from the output
+#   Show                            Show the subsequent commands in the output
+
+Output output/toggle_flip.gif
+
+Require echo
+
+Set Shell "fish"
+Set FontSize 32
+Set Width 1300
+Set Height 600
+
+# The flake in ./toggle_flip already carries a commented alternate next to the
+# active rust-overlay url, so a bare `toggle` just flips the comment marker.
+Hide
+#Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter
+Type "set -x fish_function_path ''" Enter
+Type "cd toggle_flip" Enter
+Type "clear" Enter
+Show
+
+Type "flake-edit --diff toggle rust-overlay" Sleep 1000ms Enter
+Sleep 5s

--- a/assets/tape/toggle_flip/flake.nix
+++ b/assets/tape/toggle_flip/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "Edit your flake inputs with ease";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    # rust-overlay.url = "github:a-kenji/rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = _: { };
+}

--- a/assets/tape/toggle_remove.tape
+++ b/assets/tape/toggle_remove.tape
@@ -1,0 +1,75 @@
+# VHS documentation
+#
+# Output:
+#   Output <path>.gif               Create a GIF output at the given <path>
+#   Output <path>.mp4               Create an MP4 output at the given <path>
+#   Output <path>.webm              Create a WebM output at the given <path>
+#
+# Require:
+#   Require <string>                Ensure a program is on the $PATH to proceed
+#
+# Settings:
+#   Set FontSize <number>           Set the font size of the terminal
+#   Set FontFamily <string>         Set the font family of the terminal
+#   Set Height <number>             Set the height of the terminal
+#   Set Width <number>              Set the width of the terminal
+#   Set LetterSpacing <float>       Set the font letter spacing (tracking)
+#   Set LineHeight <float>          Set the font line height
+#   Set LoopOffset <float>%         Set the starting frame offset for the GIF loop
+#   Set Theme <json|string>         Set the theme of the terminal
+#   Set Padding <number>            Set the padding of the terminal
+#   Set Framerate <number>          Set the framerate of the recording
+#   Set PlaybackSpeed <float>       Set the playback speed of the recording
+#   Set MarginFill <file|#000000>   Set the file or color the margin will be filled with.
+#   Set Margin <number>             Set the size of the margin. Has no effect if MarginFill isn't set.
+#   Set BorderRadius <number>       Set terminal border radius, in pixels.
+#   Set WindowBar <string>          Set window bar type. (one of: Rings, RingsRight, Colorful, ColorfulRight)
+#   Set WindowBarSize <number>      Set window bar size, in pixels. Default is 40.
+#   Set TypingSpeed <time>          Set the typing speed of the terminal. Default is 50ms.
+#
+# Sleep:
+#   Sleep <time>                    Sleep for a set amount of <time> in seconds
+#
+# Type:
+#   Type[@<time>] "<characters>"    Type <characters> into the terminal with a
+#                                   <time> delay between each character
+#
+# Keys:
+#   Backspace[@<time>] [number]     Press the Backspace key
+#   Down[@<time>] [number]          Press the Down key
+#   Enter[@<time>] [number]         Press the Enter key
+#   Space[@<time>] [number]         Press the Space key
+#   Tab[@<time>] [number]           Press the Tab key
+#   Left[@<time>] [number]          Press the Left Arrow key
+#   Right[@<time>] [number]         Press the Right Arrow key
+#   Up[@<time>] [number]            Press the Up Arrow key
+#   Down[@<time>] [number]          Press the Down Arrow key
+#   PageUp[@<time>] [number]        Press the Page Up key
+#   PageDown[@<time>] [number]      Press the Page Down key
+#   Ctrl+<key>                      Press the Control key + <key> (e.g. Ctrl+C)
+#
+# Display:
+#   Hide                            Hide the subsequent commands from the output
+#   Show                            Show the subsequent commands in the output
+
+Output output/toggle_remove.gif
+
+Require echo
+
+Set Shell "fish"
+Set FontSize 32
+Set Width 1300
+Set Height 600
+
+# The flake in ./toggle_remove is in the post-add state: rust-overlay is on the
+# a-kenji fork with the original oxalica url stored as a commented alternate.
+# `toggle --remove` discards the active url and reverts to that alternate.
+Hide
+#Type "echo 'Welcome to VHS!'" Sleep 500ms  Enter
+Type "set -x fish_function_path ''" Enter
+Type "cd toggle_remove" Enter
+Type "clear" Enter
+Show
+
+Type "flake-edit --diff toggle --remove rust-overlay" Sleep 1000ms Enter
+Sleep 5s

--- a/assets/tape/toggle_remove/flake.nix
+++ b/assets/tape/toggle_remove/flake.nix
@@ -1,0 +1,11 @@
+{
+  description = "Edit your flake inputs with ease";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
+    # rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.url = "github:a-kenji/rust-overlay";
+  };
+
+  outputs = _: { };
+}

--- a/docs/man/flake-edit.md
+++ b/docs/man/flake-edit.md
@@ -36,13 +36,32 @@ Pin an input to its current revision:
 > flake-edit pin nixpkgs
 > ```
 
+Toggle an input between its active url and a stored alternate:
+
+> ```
+> flake-edit toggle rust-overlay
+> ```
+
+Switch an input to a local checkout, storing the previous url as a
+commented alternate:
+
+> ```
+> flake-edit toggle ../rust-overlay
+> ```
+
+Remove a stored variant's line and flip to the alternative first:
+
+> ```
+> flake-edit toggle --remove ../rust-overlay
+> ```
+
 Preview changes without applying them:
 
 > ```
 > flake-edit --diff add home-manager github:nix-community/home-manager
 > ```
 
-Add input without updating lockfile:
+Add input without updating the lockfile:
 
 > ```
 > flake-edit --no-lock add nixos-hardware github:NixOS/nixos-hardware

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -19,6 +19,7 @@ pub mod follow;
 pub mod list;
 mod pin;
 mod remove;
+mod toggle;
 mod update;
 mod uri;
 
@@ -28,6 +29,7 @@ pub use config::config;
 pub use list::list;
 pub use pin::{pin, unpin};
 pub use remove::remove;
+pub use toggle::toggle;
 pub use update::update;
 pub use uri::UriOptions;
 
@@ -54,6 +56,20 @@ enum ConfirmResult {
     Back,
 }
 
+/// One round of the fuzzy picker. `None` means the user cancelled.
+pub(super) fn pick_one(
+    state: &AppState,
+    title: &str,
+    prompt: &str,
+    items: Vec<String>,
+) -> Result<Option<(String, bool)>> {
+    let select_app = tui::App::select_one(title, prompt, items, state.diff);
+    let Some(tui::AppResult::SingleSelect(result)) = tui::run(select_app)? else {
+        return Ok(None);
+    };
+    Ok(Some((result.item, result.show_diff)))
+}
+
 /// Interactive single-select loop with confirmation.
 ///
 /// 1. Show selection screen
@@ -75,14 +91,9 @@ where
     OnApplied: Fn(&str, ExtraData),
 {
     loop {
-        let select_app = tui::App::select_one(title, prompt, items.clone(), state.diff);
-        let Some(tui::AppResult::SingleSelect(result)) = tui::run(select_app)? else {
+        let Some((id, show_diff)) = pick_one(state, title, prompt, items.clone())? else {
             return Ok(());
         };
-        let tui::SingleSelectResult {
-            item: id,
-            show_diff,
-        } = result;
         let (change, extra_data) = make_change(&id)?;
 
         match confirm_or_apply(editor, state, title, &change, show_diff)? {

--- a/src/app/commands/toggle.rs
+++ b/src/app/commands/toggle.rs
@@ -1,0 +1,880 @@
+//! `flake-edit toggle`: flip an input between its active URL and a
+//! stored alternate.
+//!
+//! `toggle [INPUT] [REF]`, and any omitted coordinate is inferred. A
+//!
+//! `--remove` deletes the resolved variant's line instead of activating it.
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use nix_uri::FlakeRef;
+
+use crate::change::{Change, ChangeId};
+use crate::edit::{FlakeEdit, ToggleState};
+use crate::error::Error as FlakeError;
+
+use super::super::editor::Editor;
+use super::super::error::{RefCandidate, ToggleAction, ToggleCandidate};
+use super::super::state::AppState;
+use super::{ConfirmResult, Error, Result, apply_change, confirm_or_apply, pick_one};
+
+pub fn toggle(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    input: Option<String>,
+    reference: Option<String>,
+    remove: bool,
+) -> Result<()> {
+    let states = flake_edit.toggle_states()?;
+    let flake_dir = flake_dir(state);
+    let res = Resolve {
+        states: &states,
+        flake_dir: &flake_dir,
+        action: if remove {
+            ToggleAction::Remove
+        } else {
+            ToggleAction::Activate
+        },
+    };
+
+    match (input, reference) {
+        (None, None) => toggle_no_args(editor, flake_edit, state, &res),
+        (Some(arg), None) if is_ref_shaped(&arg) => {
+            let ref_arg = RefArg::parse(&arg, res.action)?;
+            toggle_by_ref(editor, flake_edit, state, &res, &ref_arg)
+        }
+        (Some(id), None) => {
+            validate_id(flake_edit, res.states, &id)?;
+            act_within_input(editor, flake_edit, state, &res, &id)
+        }
+        (Some(id), Some(reference)) => {
+            validate_id(flake_edit, res.states, &id)?;
+            let ref_arg = RefArg::parse(&reference, res.action)?;
+            act_on_ref(editor, flake_edit, state, &res, &id, &ref_arg)
+        }
+        (None, Some(_)) => unreachable!("clap fills positional arguments in order"),
+    }
+}
+
+/// Read-only resolution context shared by every invocation form.
+struct Resolve<'a> {
+    /// Toggle surface per input id, from [`FlakeEdit::toggle_states`].
+    states: &'a BTreeMap<String, ToggleState>,
+    /// Directory of the edited `flake.nix`, for relative `path:` variants.
+    flake_dir: &'a Path,
+    /// What to do with the resolved variant.
+    action: ToggleAction,
+}
+
+/// Directory holding the edited `flake.nix`. Relative `path:` variants
+/// stored in the file resolve against it.
+fn flake_dir(state: &AppState) -> PathBuf {
+    match state.flake_path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => PathBuf::from("."),
+    }
+}
+
+/// Shape-based classification of the single positional argument.
+fn is_ref_shaped(arg: &str) -> bool {
+    arg.contains(':') || arg.contains('/') || arg.starts_with('.') || arg.starts_with('~')
+}
+
+/// The id must parse, name a declared input, and that input must carry a
+/// url binding.
+fn validate_id(
+    flake_edit: &FlakeEdit,
+    states: &BTreeMap<String, ToggleState>,
+    id: &str,
+) -> Result<()> {
+    ChangeId::parse(id).map_err(|source| Error::InvalidInputId {
+        id: id.to_string(),
+        source,
+    })?;
+    if !flake_edit.curr_list().contains_key(id) {
+        return Err(Error::ToggleUnknownInput { id: id.to_string() });
+    }
+    if !states.contains_key(id) {
+        return Err(FlakeError::NoUrlToToggle(id.to_string()).into());
+    }
+    Ok(())
+}
+
+/// A parsed, normalized ref argument.
+struct RefArg {
+    /// Exactly what the user typed.
+    typed: String,
+    /// The form a newly created alternate stores: the typed text, with only
+    /// a `path:` prefix added to bare directories.
+    store_as: String,
+    /// Canonicalized location for path-shaped refs whose directory
+    /// exists. Existence is the typo guard for activation, and the
+    /// ladder's later stages need the directory. A removal target may be
+    /// gone, leaving only the literal spelling to match on.
+    canonical_path: Option<PathBuf>,
+    /// Parsed flake reference for everything else.
+    flake_ref: Option<FlakeRef>,
+}
+
+impl RefArg {
+    fn parse(typed: &str, action: ToggleAction) -> Result<Self> {
+        if let Some(path) = path_part(typed) {
+            let canonical_path = match std::fs::canonicalize(path) {
+                Ok(canonical) => Some(canonical),
+                // A removal may name an alternate whose directory is
+                // gone. Matching falls back to the literal spelling.
+                Err(_) if action == ToggleAction::Remove => None,
+                Err(source) => {
+                    return Err(Error::TogglePathMissing {
+                        path: typed.to_string(),
+                        source,
+                    });
+                }
+            };
+            let store_as = if typed.starts_with("path:") {
+                typed.to_string()
+            } else {
+                format!("path:{typed}")
+            };
+            Ok(Self {
+                typed: typed.to_string(),
+                store_as,
+                canonical_path,
+                flake_ref: None,
+            })
+        } else {
+            let flake_ref: FlakeRef = typed.parse().map_err(|source| Error::InvalidUri {
+                uri: typed.to_string(),
+                source,
+            })?;
+            Ok(Self {
+                typed: typed.to_string(),
+                store_as: typed.to_string(),
+                canonical_path: None,
+                flake_ref: Some(flake_ref),
+            })
+        }
+    }
+}
+
+/// Filesystem part of a path-shaped ref, or `None` for non-path refs.
+fn path_part(typed: &str) -> Option<&str> {
+    if let Some(rest) = typed.strip_prefix("path:") {
+        return Some(rest);
+    }
+    (typed.starts_with('.') || typed.starts_with('/') || typed.starts_with('~')).then_some(typed)
+}
+
+fn variants(state: &ToggleState) -> impl Iterator<Item = &String> {
+    std::iter::once(&state.active).chain(state.alternates.iter())
+}
+
+fn variant_equals(variant: &str, ref_arg: &RefArg, flake_dir: &Path) -> bool {
+    if let Some(canonical) = &ref_arg.canonical_path {
+        return variant_path(variant, flake_dir).is_some_and(|p| p == *canonical);
+    }
+    if let Some(flake_ref) = &ref_arg.flake_ref {
+        return variant
+            .parse::<FlakeRef>()
+            .is_ok_and(|v| v.to_canonical_string() == flake_ref.to_canonical_string());
+    }
+    variant == ref_arg.store_as || variant == ref_arg.typed
+}
+
+/// Canonical filesystem location of a path-style variant. Relative paths
+/// stored in `flake.nix` are relative to the flake's directory.
+fn variant_path(variant: &str, flake_dir: &Path) -> Option<PathBuf> {
+    let raw = variant
+        .strip_prefix("path:")
+        .or_else(|| (variant.starts_with('/') || variant.starts_with('.')).then_some(variant))?;
+    let absolute = if Path::new(raw).is_absolute() {
+        PathBuf::from(raw)
+    } else {
+        flake_dir.join(raw)
+    };
+    std::fs::canonicalize(absolute).ok()
+}
+
+/// `(host, owner, repo)` identity used by the ladder's second stage,
+/// lowercased for comparison.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RepoIdentity {
+    host: String,
+    owner: String,
+    repo: String,
+}
+
+impl RepoIdentity {
+    fn new(host: &str, owner: &str, repo: &str) -> Self {
+        Self {
+            host: host.to_lowercase(),
+            owner: owner.to_lowercase(),
+            repo: repo.trim_end_matches(".git").to_lowercase(),
+        }
+    }
+}
+
+/// Identity granularities, tried loosest-last. The looser ones let a fork
+/// checkout whose `origin` is the fork find the input declared with
+/// upstream's owner.
+#[derive(Clone, Copy)]
+enum Granularity {
+    HostOwnerRepo,
+    HostRepo,
+    Repo,
+}
+
+impl Granularity {
+    fn matches(self, a: &RepoIdentity, b: &RepoIdentity) -> bool {
+        match self {
+            Self::HostOwnerRepo => a == b,
+            Self::HostRepo => a.host == b.host && a.repo == b.repo,
+            Self::Repo => a.repo == b.repo,
+        }
+    }
+}
+
+/// Identities the ref itself resolves to: the parsed forge coordinates,
+/// or every configured git remote of a path checkout. A path that is not
+/// a git checkout contributes nothing here.
+fn ref_identities(ref_arg: &RefArg) -> Vec<RepoIdentity> {
+    if let Some(path) = &ref_arg.canonical_path {
+        return git_remote_urls(path)
+            .iter()
+            .filter_map(|url| parse_remote_url(url))
+            .collect();
+    }
+    ref_arg
+        .flake_ref
+        .as_ref()
+        .and_then(flake_ref_identity)
+        .into_iter()
+        .collect()
+}
+
+fn flake_ref_identity(flake_ref: &FlakeRef) -> Option<RepoIdentity> {
+    if let Some(forge) = flake_ref.forge_identity() {
+        return Some(RepoIdentity::new(&forge.domain, &forge.owner, &forge.repo));
+    }
+    match (flake_ref.domain(), flake_ref.owner(), flake_ref.repo()) {
+        (Some(domain), Some(owner), Some(repo)) => Some(RepoIdentity::new(domain, owner, repo)),
+        _ => None,
+    }
+}
+
+fn variant_identity(variant: &str) -> Option<RepoIdentity> {
+    flake_ref_identity(&variant.parse::<FlakeRef>().ok()?)
+}
+
+/// Remote URLs from the checkout's git config. Reading the config keeps
+/// the heuristic local and fast. Failures (no git, not a repo) degrade to
+/// an empty list.
+fn git_remote_urls(dir: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["config", "--get-regexp", r"^remote\..*\.url$"])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once(' ').map(|(_, url)| url.trim().to_string()))
+        .collect()
+}
+
+/// Parse a git remote URL to its identity. Handles scp-like syntax
+/// (`git@host:owner/repo.git`) and URL forms. The owner is the path
+/// segment directly before the repo.
+fn parse_remote_url(url: &str) -> Option<RepoIdentity> {
+    let (host, path) = if let Some((_, rest)) = url.split_once("://") {
+        let (authority, path) = rest.split_once('/')?;
+        let host = authority.rsplit('@').next()?.split(':').next()?;
+        (host, path)
+    } else if let Some((authority, path)) = url.split_once(':') {
+        (authority.rsplit('@').next()?, path)
+    } else {
+        return None;
+    };
+    let path = path.trim_end_matches('/').trim_end_matches(".git");
+    let mut segments = path.rsplit('/');
+    let repo = segments.next()?;
+    if repo.is_empty() {
+        return None;
+    }
+    let owner = segments.next().unwrap_or("");
+    Some(RepoIdentity::new(host, owner, repo))
+}
+
+/// Repo or directory name the ref answers to, for the ladder's third
+/// stage.
+fn ref_name(ref_arg: &RefArg) -> Option<String> {
+    if let Some(path) = &ref_arg.canonical_path {
+        return path.file_name().map(|n| n.to_string_lossy().into_owned());
+    }
+    if let Some(flake_ref) = &ref_arg.flake_ref {
+        return flake_ref
+            .repo()
+            .or_else(|| flake_ref.id())
+            .map(|name| name.trim_end_matches(".git").to_string());
+    }
+    // A dead path keeps the basename of its typed spelling.
+    Path::new(path_part(&ref_arg.typed)?)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+}
+
+/// The matching ladder of the ref form. The first stage that yields any
+/// candidates decides. Later stages are not consulted.
+fn ladder(
+    states: &BTreeMap<String, ToggleState>,
+    ref_arg: &RefArg,
+    flake_dir: &Path,
+) -> Vec<RefCandidate> {
+    let mut found: Vec<RefCandidate> = states
+        .iter()
+        .filter_map(|(id, state)| {
+            variants(state)
+                .find(|v| variant_equals(v, ref_arg, flake_dir))
+                .map(|variant| RefCandidate {
+                    id: id.clone(),
+                    reason: format!("{variant} is a stored variant"),
+                })
+        })
+        .collect();
+    if !found.is_empty() {
+        return found;
+    }
+
+    let ref_ids = ref_identities(ref_arg);
+    if !ref_ids.is_empty() {
+        let how = if ref_arg.canonical_path.is_some() {
+            "matches a git remote"
+        } else {
+            "matches the repository"
+        };
+        for granularity in [
+            Granularity::HostOwnerRepo,
+            Granularity::HostRepo,
+            Granularity::Repo,
+        ] {
+            let hits: Vec<RefCandidate> = states
+                .iter()
+                .filter_map(|(id, state)| {
+                    variants(state)
+                        .find(|v| {
+                            variant_identity(v).is_some_and(|vid| {
+                                ref_ids.iter().any(|rid| granularity.matches(rid, &vid))
+                            })
+                        })
+                        .map(|variant| RefCandidate {
+                            id: id.clone(),
+                            reason: format!("{variant} {how}"),
+                        })
+                })
+                .collect();
+            if !hits.is_empty() {
+                return hits;
+            }
+        }
+    }
+
+    if let Some(name) = ref_name(ref_arg) {
+        found = states
+            .keys()
+            .filter(|id| **id == name)
+            .map(|id| RefCandidate {
+                id: id.clone(),
+                reason: "the name matches the input id".to_string(),
+            })
+            .collect();
+    }
+    found
+}
+
+/// What activating a ref means for one resolved input.
+enum RefTarget {
+    /// The ref equals a stored alternate, so uncomment it.
+    Activate(String),
+    /// The ref equals the active variant, so flip back to the stored side.
+    ActiveNamed,
+    /// Not stored yet, so create a new alternate.
+    Synthesize(String),
+}
+
+fn target_for_ref(state: &ToggleState, ref_arg: &RefArg, flake_dir: &Path) -> RefTarget {
+    if let Some(alternate) = state
+        .alternates
+        .iter()
+        .find(|v| variant_equals(v, ref_arg, flake_dir))
+    {
+        return RefTarget::Activate(alternate.clone());
+    }
+    if variant_equals(&state.active, ref_arg, flake_dir) {
+        return RefTarget::ActiveNamed;
+    }
+    RefTarget::Synthesize(ref_arg.store_as.clone())
+}
+
+fn toggle_change(id: &str, state: &ToggleState, uri: String) -> Result<Change> {
+    let change_id = ChangeId::parse(id).map_err(|source| Error::InvalidInputId {
+        id: id.to_string(),
+        source,
+    })?;
+    Ok(Change::Toggle {
+        id: change_id,
+        uri,
+        previous: state.active.clone(),
+    })
+}
+
+fn remove_change(id: &str, uri: String, activate: Option<String>) -> Result<Change> {
+    let change_id = ChangeId::parse(id).map_err(|source| Error::InvalidInputId {
+        id: id.to_string(),
+        source,
+    })?;
+    Ok(Change::ToggleRemove {
+        id: change_id,
+        uri,
+        activate,
+    })
+}
+
+/// The change acting on one inactive variant of `id`: activate it, or
+/// revert to it by discarding the currently active url.
+fn within_change(
+    action: ToggleAction,
+    id: &str,
+    toggle_state: &ToggleState,
+    uri: String,
+) -> Result<Change> {
+    match action {
+        ToggleAction::Activate => toggle_change(id, toggle_state, uri),
+        ToggleAction::Remove => remove_change(id, toggle_state.active.clone(), Some(uri)),
+    }
+}
+
+/// Deleting only a comment line cannot change the resolved source, so
+/// such removals skip the lockfile refresh.
+fn effective_state(state: &AppState, change: &Change) -> AppState {
+    let mut state = state.clone();
+    if matches!(change, Change::ToggleRemove { activate: None, .. }) {
+        state.no_lock = true;
+    }
+    state
+}
+
+fn apply_toggle_change(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    change: Change,
+) -> Result<()> {
+    let state = effective_state(state, &change);
+    apply_change(editor, flake_edit, &state, change)
+}
+
+fn toggle_no_args(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+) -> Result<()> {
+    let toggleable: Vec<(&String, &ToggleState)> = res
+        .states
+        .iter()
+        .filter(|(_, s)| !s.alternates.is_empty())
+        .collect();
+    match toggleable.as_slice() {
+        [] => Err(Error::NoToggleableInputs),
+        [(id, _)] => act_within_input(editor, flake_edit, state, res, id),
+        _ if state.interactive => pick_input_and_act(editor, flake_edit, state, res, {
+            toggleable
+                .iter()
+                .map(|(id, s)| ((*id).clone(), format!("{id} ({})", s.active)))
+                .collect()
+        }),
+        _ => Err(Error::MultipleToggleableInputs {
+            candidates: toggleable
+                .into_iter()
+                .map(|(id, s)| ToggleCandidate {
+                    id: id.clone(),
+                    variants: variants(s).cloned().collect(),
+                })
+                .collect(),
+        }),
+    }
+}
+
+fn toggle_by_ref(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+    ref_arg: &RefArg,
+) -> Result<()> {
+    let candidates = ladder(res.states, ref_arg, res.flake_dir);
+    match candidates.as_slice() {
+        [] => Err(Error::ToggleRefUnmatched {
+            reference: ref_arg.typed.clone(),
+        }),
+        [candidate] => act_on_ref(
+            editor,
+            flake_edit,
+            state,
+            res,
+            &candidate.id.clone(),
+            ref_arg,
+        ),
+        _ if state.interactive => {
+            let items = candidates
+                .iter()
+                .map(|c| (c.id.clone(), format!("{} ({})", c.id, c.reason)))
+                .collect();
+            pick_input_and_act_ref(editor, flake_edit, state, res, items, ref_arg)
+        }
+        _ => Err(Error::ToggleRefAmbiguous {
+            reference: ref_arg.typed.clone(),
+            candidates,
+        }),
+    }
+}
+
+/// Act on `ref_arg` against the already-resolved input `id`.
+///
+/// Activation creates a new alternate when the ref is not yet stored.
+/// Removal refuses to invent one. Naming the active variant flips
+/// to the stored side (and, for removal, deletes the previously active
+/// line instead of keeping it as a comment).
+fn act_on_ref(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+    id: &str,
+    ref_arg: &RefArg,
+) -> Result<()> {
+    let toggle_state = &res.states[id];
+    match (
+        target_for_ref(toggle_state, ref_arg, res.flake_dir),
+        res.action,
+    ) {
+        (RefTarget::Activate(uri) | RefTarget::Synthesize(uri), ToggleAction::Activate) => {
+            let change = toggle_change(id, toggle_state, uri)?;
+            apply_toggle_change(editor, flake_edit, state, change)
+        }
+        (RefTarget::Activate(uri), ToggleAction::Remove) => {
+            let change = remove_change(id, uri, None)?;
+            apply_toggle_change(editor, flake_edit, state, change)
+        }
+        (RefTarget::Synthesize(_), ToggleAction::Remove) => Err(Error::ToggleRemoveUnstored {
+            reference: ref_arg.typed.clone(),
+            id: id.to_string(),
+            active: toggle_state.active.clone(),
+            alternates: toggle_state.alternates.clone(),
+        }),
+        (RefTarget::ActiveNamed, ToggleAction::Activate) => {
+            match toggle_state.alternates.as_slice() {
+                [] => Err(Error::ToggleAlreadyActive {
+                    reference: ref_arg.typed.clone(),
+                    id: id.to_string(),
+                }),
+                _ => act_within_input(editor, flake_edit, state, res, id),
+            }
+        }
+        (RefTarget::ActiveNamed, ToggleAction::Remove) => {
+            match toggle_state.alternates.as_slice() {
+                [] => Err(Error::ToggleRemoveActive {
+                    reference: ref_arg.typed.clone(),
+                    id: id.to_string(),
+                }),
+                [only] => {
+                    let change =
+                        remove_change(id, toggle_state.active.clone(), Some(only.clone()))?;
+                    apply_toggle_change(editor, flake_edit, state, change)
+                }
+                _ if state.interactive => {
+                    pick_replacement_and_remove(editor, flake_edit, state, id, toggle_state)
+                }
+                _ => Err(Error::ToggleAmbiguousVariant {
+                    id: id.to_string(),
+                    active: toggle_state.active.clone(),
+                    alternates: toggle_state.alternates.clone(),
+                    action: ToggleAction::Activate,
+                }),
+            }
+        }
+    }
+}
+
+/// Act on `id`'s stored side: one alternate flips (or is deleted)
+/// silently, several open the variant picker (or error
+/// non-interactively), none is an error.
+fn act_within_input(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+    id: &str,
+) -> Result<()> {
+    let toggle_state = &res.states[id];
+    match toggle_state.alternates.as_slice() {
+        [] => Err(Error::ToggleNoAlternate { id: id.to_string() }),
+        [only] => {
+            let change = within_change(res.action, id, toggle_state, only.clone())?;
+            apply_toggle_change(editor, flake_edit, state, change)
+        }
+        _ if state.interactive => match res.action {
+            ToggleAction::Activate => {
+                pick_variant_and_act(editor, flake_edit, state, res.action, id, toggle_state)
+            }
+            ToggleAction::Remove => {
+                pick_replacement_and_remove(editor, flake_edit, state, id, toggle_state)
+            }
+        },
+        _ => Err(Error::ToggleAmbiguousVariant {
+            id: id.to_string(),
+            active: toggle_state.active.clone(),
+            alternates: toggle_state.alternates.clone(),
+            action: ToggleAction::Activate,
+        }),
+    }
+}
+
+/// Apply `change` through the confirm-with-diff screen, printing the
+/// success line once applied.
+fn confirm_toggle(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    change: Change,
+    show_diff: bool,
+) -> Result<Option<bool>> {
+    let state = effective_state(state, &change);
+    let outcome = flake_edit.apply_change(change.clone())?;
+    let Some(text) = outcome.text else {
+        println!("Nothing changed.");
+        return Ok(Some(true));
+    };
+    match confirm_or_apply(editor, &state, "Toggle", &text, show_diff)? {
+        ConfirmResult::Applied => {
+            for msg in change.success_messages() {
+                println!("{msg}");
+            }
+            Ok(Some(true))
+        }
+        ConfirmResult::Back => Ok(Some(false)),
+        ConfirmResult::Cancelled => Ok(None),
+    }
+}
+
+/// Variant picker for one input: fuzzy-select among the inactive
+/// variants, with the active one shown in the prompt for context.
+fn pick_variant_and_act(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    action: ToggleAction,
+    id: &str,
+    toggle_state: &ToggleState,
+) -> Result<()> {
+    let prompt = match action {
+        ToggleAction::Activate => format!("Select variant (active: {})", toggle_state.active),
+        ToggleAction::Remove => {
+            format!("Select variant to remove (active: {})", toggle_state.active)
+        }
+    };
+    loop {
+        let Some((uri, show_diff)) =
+            pick_one(state, "Toggle", &prompt, toggle_state.alternates.clone())?
+        else {
+            return Ok(());
+        };
+        let change = within_change(action, id, toggle_state, uri)?;
+        match confirm_toggle(editor, flake_edit, state, change, show_diff)? {
+            Some(true) | None => return Ok(()),
+            Some(false) => continue,
+        }
+    }
+}
+
+/// Replacement picker for removing the active url: fuzzy-select the
+/// alternate that takes its place.
+fn pick_replacement_and_remove(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    id: &str,
+    toggle_state: &ToggleState,
+) -> Result<()> {
+    let prompt = format!("Select replacement (removing: {})", toggle_state.active);
+    loop {
+        let Some((uri, show_diff)) =
+            pick_one(state, "Toggle", &prompt, toggle_state.alternates.clone())?
+        else {
+            return Ok(());
+        };
+        let change = remove_change(id, toggle_state.active.clone(), Some(uri))?;
+        match confirm_toggle(editor, flake_edit, state, change, show_diff)? {
+            Some(true) | None => return Ok(()),
+            Some(false) => continue,
+        }
+    }
+}
+
+/// Input picker for the no-argument form: fuzzy-select among the
+/// toggleable inputs, then continue per the variant rules.
+fn pick_input_and_act(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+    items: Vec<(String, String)>,
+) -> Result<()> {
+    let by_item: BTreeMap<String, String> = items
+        .iter()
+        .map(|(id, item)| (item.clone(), id.clone()))
+        .collect();
+    loop {
+        let Some((item, show_diff)) = pick_one(
+            state,
+            "Toggle",
+            "Select input",
+            items.iter().map(|(_, item)| item.clone()).collect(),
+        )?
+        else {
+            return Ok(());
+        };
+        let id = &by_item[&item];
+        let toggle_state = &res.states[id];
+        match toggle_state.alternates.as_slice() {
+            [only] => {
+                let change = within_change(res.action, id, toggle_state, only.clone())?;
+                match confirm_toggle(editor, flake_edit, state, change, show_diff)? {
+                    Some(true) | None => return Ok(()),
+                    Some(false) => continue,
+                }
+            }
+            _ => {
+                return match res.action {
+                    ToggleAction::Activate => pick_variant_and_act(
+                        editor,
+                        flake_edit,
+                        state,
+                        res.action,
+                        id,
+                        toggle_state,
+                    ),
+                    // Mirror the bare-id path: removal picks the
+                    // replacement for the discarded active url.
+                    ToggleAction::Remove => {
+                        pick_replacement_and_remove(editor, flake_edit, state, id, toggle_state)
+                    }
+                };
+            }
+        }
+    }
+}
+
+/// Input picker for an ambiguous ref: fuzzy-select among the ladder's
+/// candidates, then act on the ref against the chosen input.
+fn pick_input_and_act_ref(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    res: &Resolve<'_>,
+    items: Vec<(String, String)>,
+    ref_arg: &RefArg,
+) -> Result<()> {
+    let by_item: BTreeMap<String, String> = items
+        .iter()
+        .map(|(id, item)| (item.clone(), id.clone()))
+        .collect();
+    let Some((item, _show_diff)) = pick_one(
+        state,
+        "Toggle",
+        "Select input",
+        items.iter().map(|(_, item)| item.clone()).collect(),
+    )?
+    else {
+        return Ok(());
+    };
+    let id = by_item[&item].clone();
+    act_on_ref(editor, flake_edit, state, res, &id, ref_arg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ref_shape_classification() {
+        for ref_like in [
+            "github:owner/repo",
+            "../rust-overlay",
+            "./checkout",
+            "~/dev/overlay",
+            "/abs/path",
+            "owner/repo",
+            "path:../x",
+        ] {
+            assert!(is_ref_shaped(ref_like), "{ref_like} should be a ref");
+        }
+        for id_like in ["rust-overlay", "nixpkgs", "crane"] {
+            assert!(!is_ref_shaped(id_like), "{id_like} should be an id");
+        }
+    }
+
+    #[test]
+    fn remote_url_parsing_covers_common_forms() {
+        let cases = [
+            (
+                "https://github.com/oxalica/rust-overlay.git",
+                ("github.com", "oxalica", "rust-overlay"),
+            ),
+            (
+                "git@github.com:oxalica/rust-overlay.git",
+                ("github.com", "oxalica", "rust-overlay"),
+            ),
+            (
+                "ssh://git@github.com/oxalica/rust-overlay",
+                ("github.com", "oxalica", "rust-overlay"),
+            ),
+            (
+                "https://gitlab.com/group/subgroup/repo",
+                ("gitlab.com", "subgroup", "repo"),
+            ),
+        ];
+        for (url, (host, owner, repo)) in cases {
+            let identity = parse_remote_url(url).expect(url);
+            assert_eq!(identity, RepoIdentity::new(host, owner, repo), "{url}");
+        }
+        assert!(parse_remote_url("not-a-url").is_none());
+    }
+
+    #[test]
+    fn forge_ref_identity_resolves_canonical_host() {
+        let identity = variant_identity("github:NixOS/nixpkgs/nixos-unstable").unwrap();
+        assert_eq!(
+            identity,
+            RepoIdentity::new("github.com", "nixos", "nixpkgs")
+        );
+    }
+
+    #[test]
+    fn granularities_loosen_in_order() {
+        let declared = RepoIdentity::new("github.com", "oxalica", "rust-overlay");
+        let fork = RepoIdentity::new("github.com", "a-kenji", "rust-overlay");
+        let elsewhere = RepoIdentity::new("git.example.org", "mirror", "rust-overlay");
+        assert!(!Granularity::HostOwnerRepo.matches(&fork, &declared));
+        assert!(Granularity::HostRepo.matches(&fork, &declared));
+        assert!(!Granularity::HostRepo.matches(&elsewhere, &declared));
+        assert!(Granularity::Repo.matches(&elsewhere, &declared));
+    }
+}

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -116,6 +116,117 @@ pub enum Error {
     Batch {
         failures: Vec<(PathBuf, Box<Error>)>,
     },
+
+    /// `toggle` was invoked without arguments and no input stores an
+    /// alternate.
+    #[error("no toggleable inputs in flake.nix")]
+    NoToggleableInputs,
+
+    /// `toggle` was invoked without arguments, several inputs store
+    /// alternates, and no interactive picker is available.
+    #[error("multiple toggleable inputs")]
+    MultipleToggleableInputs { candidates: Vec<ToggleCandidate> },
+
+    /// `toggle` named an input id that the flake does not declare.
+    #[error("no input named '{id}' in flake.nix")]
+    ToggleUnknownInput { id: String },
+
+    /// `toggle` named an input that has no stored alternate to flip to.
+    #[error("input '{id}' has no stored alternate")]
+    ToggleNoAlternate { id: String },
+
+    /// The input stores several alternates and no interactive picker is
+    /// available to choose between them.
+    #[error(
+        "input '{id}' has {count} variants, cannot infer which to {action}",
+        count = alternates.len() + 1
+    )]
+    ToggleAmbiguousVariant {
+        id: String,
+        active: String,
+        alternates: Vec<String>,
+        action: ToggleAction,
+    },
+
+    /// The matching ladder found no input for the given reference.
+    #[error("could not match '{reference}' to any input")]
+    ToggleRefUnmatched { reference: String },
+
+    /// One matching-ladder stage yielded several inputs and no interactive
+    /// picker is available.
+    #[error("'{reference}' matches multiple inputs")]
+    ToggleRefAmbiguous {
+        reference: String,
+        candidates: Vec<RefCandidate>,
+    },
+
+    /// A path-shaped reference does not exist on disk.
+    #[error("could not read path '{path}'")]
+    TogglePathMissing {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The named reference is already the input's active variant and no
+    /// alternate is stored to flip back to.
+    #[error(
+        "'{reference}' is already the active variant of '{id}'\n       and no alternate is stored"
+    )]
+    ToggleAlreadyActive { reference: String, id: String },
+
+    /// `toggle --remove` resolved a reference that is not stored on the
+    /// input, so there is nothing to remove.
+    #[error("'{reference}' is not a stored variant of '{id}'")]
+    ToggleRemoveUnstored {
+        reference: String,
+        id: String,
+        active: String,
+        alternates: Vec<String>,
+    },
+
+    /// `toggle --remove` named the input's active url while no alternate
+    /// is stored to take its place. Honoring it would leave the input
+    /// url-less.
+    #[error("'{reference}' is the active url of '{id}' and no alternate is stored to replace it")]
+    ToggleRemoveActive { reference: String, id: String },
+}
+
+/// What `toggle` does with the resolved variant, for error wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToggleAction {
+    /// Make the variant the active url.
+    Activate,
+    /// Delete the variant's line.
+    Remove,
+}
+
+impl std::fmt::Display for ToggleAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Activate => write!(f, "activate"),
+            Self::Remove => write!(f, "remove"),
+        }
+    }
+}
+
+/// One toggleable input named in [`Error::MultipleToggleableInputs`].
+#[derive(Debug, Clone)]
+pub struct ToggleCandidate {
+    /// Input id.
+    pub id: String,
+    /// Every variant of the input, the active one first.
+    pub variants: Vec<String>,
+}
+
+/// One input the matching ladder offered for an ambiguous ref, named in
+/// [`Error::ToggleRefAmbiguous`].
+#[derive(Debug, Clone)]
+pub struct RefCandidate {
+    /// Input id.
+    pub id: String,
+    /// The variant that matched and the way it matched.
+    pub reason: String,
 }
 
 impl Error {
@@ -145,6 +256,36 @@ impl Error {
     pub fn validation_bullets(&self) -> Option<Vec<String>> {
         match self {
             Self::ValidationAfterEdit(errs) => Some(errs.iter().map(|e| e.to_string()).collect()),
+            _ => None,
+        }
+    }
+
+    /// Candidate listings for the ambiguous `toggle` errors, one bullet per
+    /// candidate. Returns `None` for other variants.
+    pub fn candidate_bullets(&self) -> Option<Vec<String>> {
+        match self {
+            Self::MultipleToggleableInputs { candidates } => Some(
+                candidates
+                    .iter()
+                    .map(|c| format!("{}: {}", c.id, c.variants.join(" <-> ")))
+                    .collect(),
+            ),
+            Self::ToggleAmbiguousVariant {
+                active, alternates, ..
+            }
+            | Self::ToggleRemoveUnstored {
+                active, alternates, ..
+            } => Some(
+                std::iter::once(format!("{active} (active)"))
+                    .chain(alternates.iter().cloned())
+                    .collect(),
+            ),
+            Self::ToggleRefAmbiguous { candidates, .. } => Some(
+                candidates
+                    .iter()
+                    .map(|c| format!("{} ({})", c.id, c.reason))
+                    .collect(),
+            ),
             _ => None,
         }
     }

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -40,6 +40,7 @@ pub fn run(args: CliArgs) -> Result<()> {
         Command::Update { .. } => dispatch_update(&args, &editor, &mut flake_edit, &state)?,
         Command::Pin { .. } => dispatch_pin(&args, &editor, &mut flake_edit, &state)?,
         Command::Unpin { .. } => dispatch_unpin(&args, &editor, &mut flake_edit, &state)?,
+        Command::Toggle { .. } => dispatch_toggle(&args, &editor, &mut flake_edit, &state)?,
         Command::Follow { .. } => dispatch_follow(&args, &editor, &mut flake_edit, &mut state)?,
         Command::AddFollow { .. } => {
             dispatch_add_follow(&args, &editor, &mut flake_edit, &mut state)?
@@ -207,6 +208,30 @@ fn dispatch_unpin(
     commands::unpin(editor, flake_edit, state, id.clone())
 }
 
+fn dispatch_toggle(
+    args: &CliArgs,
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+) -> Result<()> {
+    let Command::Toggle {
+        input,
+        reference,
+        remove,
+    } = args.subcommand()
+    else {
+        unreachable!("wrong Command variant");
+    };
+    commands::toggle(
+        editor,
+        flake_edit,
+        state,
+        input.clone(),
+        reference.clone(),
+        *remove,
+    )
+}
+
 fn dispatch_follow(
     args: &CliArgs,
     editor: &Editor,
@@ -272,6 +297,14 @@ fn dispatch_completion(args: &CliArgs, flake_edit: &mut FlakeEdit, no_cache: boo
             if let Ok(lock) = crate::lock::FlakeLock::from_default_path() {
                 for nested in lock.nested_inputs() {
                     println!("{}", nested.path);
+                }
+            }
+        }
+        CompletionMode::Toggle => {
+            let states = flake_edit.toggle_states()?;
+            for (id, state) in states {
+                if !state.alternates.is_empty() {
+                    println!("{}", id);
                 }
             }
         }

--- a/src/bin/flake-edit/render.rs
+++ b/src/bin/flake-edit/render.rs
@@ -42,6 +42,12 @@ pub(crate) fn report(err: &app::Error) {
         }
     }
 
+    if let Some(bullets) = err.candidate_bullets() {
+        for line in bullets {
+            let _ = writeln!(stderr, "  - {line}");
+        }
+    }
+
     write_caused_by_chain(&mut stderr, &style, err);
 
     if let Some(hint) = hint_for(err) {
@@ -112,6 +118,7 @@ fn write_caused_by_chain(out: &mut impl io::Write, style: &Style, err: &app::Err
 /// headline.
 fn hint_for(err: &app::Error) -> Option<String> {
     use app::Error;
+    use app::error::ToggleAction;
     match err {
         Error::Flake(inner) => inner.hint(),
         Error::FollowsCreateFailed { id } => Some(format!(
@@ -127,6 +134,50 @@ fn hint_for(err: &app::Error) -> Option<String> {
         Error::Batch { .. } => {
             Some("run `flake-edit list` against each failing file to verify input names".into())
         }
+        Error::NoToggleableInputs => Some(
+            "an input is toggleable when a commented alternate sits next to its url, e.g.\n        \
+             rust-overlay.url = \"github:oxalica/rust-overlay\";\n        \
+             # rust-overlay.url = \"github:a-kenji/rust-overlay\";\n      \
+             store one with `flake-edit toggle <id> <ref>`"
+                .into(),
+        ),
+        Error::MultipleToggleableInputs { .. } => {
+            Some("pick one with `flake-edit toggle <id>`".into())
+        }
+        Error::ToggleUnknownInput { .. } => {
+            Some("run `flake-edit list` to see the current inputs".into())
+        }
+        Error::ToggleNoAlternate { id } => Some(format!(
+            "store one and switch to it with `flake-edit toggle {id} <ref>`"
+        )),
+        Error::ToggleAmbiguousVariant { id, action, .. } => match action {
+            ToggleAction::Activate => {
+                Some(format!("name the variant: `flake-edit toggle {id} <ref>`"))
+            }
+            ToggleAction::Remove => Some(format!(
+                "name the variant: `flake-edit toggle --remove {id} <ref>`"
+            )),
+        },
+        Error::ToggleRefUnmatched { reference } => Some(format!(
+            "no variant, git remote, or directory name corresponds to an input; name it\n      \
+             explicitly: `flake-edit toggle <id> {reference}`"
+        )),
+        Error::ToggleRefAmbiguous { reference, .. } => Some(format!(
+            "name the input explicitly: `flake-edit toggle <id> {reference}`"
+        )),
+        Error::TogglePathMissing { .. } => {
+            Some("check the path, or pass a remote ref like `github:owner/repo`".into())
+        }
+        Error::ToggleAlreadyActive { id, .. } => Some(format!(
+            "store one with `flake-edit toggle {id} <other-ref>`"
+        )),
+        Error::ToggleRemoveUnstored { id, .. } => Some(format!(
+            "name one of the stored variants: `flake-edit toggle --remove {id} <ref>`"
+        )),
+        Error::ToggleRemoveActive { id, .. } => Some(format!(
+            "set a new url with `flake-edit change {id} <uri>`, or drop the input with \
+             `flake-edit remove {id}`"
+        )),
         _ => None,
     }
 }

--- a/src/change.rs
+++ b/src/change.rs
@@ -29,6 +29,32 @@ pub enum Change {
         /// The input to follow.
         target: AttrPath,
     },
+    /// Make `uri` the active url of an input, keeping the previously
+    /// active url as a commented alternate on the adjacent line.
+    ///
+    /// When `uri` matches a stored alternate, that comment is uncommented
+    /// in place. Otherwise the new url is written directly below the
+    /// deactivated one. Lines never move, only the comment marker.
+    Toggle {
+        id: ChangeId,
+        /// The url to activate.
+        uri: String,
+        /// The url active before the toggle, for the success message.
+        previous: String,
+    },
+    /// Delete a stored variant's line from an input.
+    ///
+    /// When `uri` names a commented alternate, its line is deleted and the
+    /// active url stays put. When `uri` names the active url, `activate`
+    /// names the stored alternate that is uncommented in its place and the
+    /// previously active line is deleted rather than kept as a comment.
+    ToggleRemove {
+        id: ChangeId,
+        /// The variant whose line is removed.
+        uri: String,
+        /// The alternate activated when `uri` is the active url.
+        activate: Option<String>,
+    },
 }
 
 /// Identifier for an input or nested-input target of a [`Change`].
@@ -133,6 +159,7 @@ impl Change {
             Change::Remove { ids } => ids.first().cloned(),
             Change::Change { id, .. } => id.clone(),
             Change::Follows { input, .. } => Some(input.clone()),
+            Change::Toggle { id, .. } | Change::ToggleRemove { id, .. } => Some(id.clone()),
         }
     }
 
@@ -152,6 +179,7 @@ impl Change {
     pub fn uri(&self) -> Option<&String> {
         match self {
             Change::Change { uri, .. } | Change::Add { uri, .. } => uri.as_ref(),
+            Change::Toggle { uri, .. } => Some(uri),
             _ => None,
         }
     }
@@ -207,6 +235,18 @@ impl Change {
                     path,
                     target.to_flake_follows_string()
                 )]
+            }
+            Change::Toggle { id, uri, previous } => {
+                vec![format!("Toggled {}: {} -> {}", id, previous, uri)]
+            }
+            Change::ToggleRemove { id, uri, activate } => {
+                let removed = format!("Removed {} alternate: {}", id, uri);
+                match activate {
+                    Some(activate) => {
+                        vec![format!("Toggled {}: {} -> {}", id, uri, activate), removed]
+                    }
+                    None => vec![removed],
+                }
             }
             Change::None => vec![],
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -151,6 +151,25 @@ pub enum Command {
         /// The id of an input attribute.
         id: Option<String>,
     },
+    /// Toggle an input between its active url and a stored alternate.
+    ///
+    /// Alternates live as commented copies of the url line next to the
+    /// active one. Flipping moves only the comment marker.
+    #[clap(alias = "t")]
+    Toggle {
+        /// An input id, or a flake reference to activate.
+        #[arg(value_name = "INPUT")]
+        input: Option<String>,
+        /// The variant to activate, stored as a new alternate when not
+        /// yet present.
+        #[arg(value_name = "REF")]
+        reference: Option<String>,
+        /// Remove a url instead of activating it. A bare input id removes the
+        /// active url and activates the stored alternate in its place. An
+        /// alternate's ref deletes that alternate and keeps the active url.
+        #[arg(short, long)]
+        remove: bool,
+    },
     /// Automatically add and remove follows declarations.
     ///
     /// Analyzes the flake.lock to find nested inputs that match top-level inputs,
@@ -221,6 +240,7 @@ pub enum CompletionMode {
     Add,
     Change,
     Follow,
+    Toggle,
 }
 
 /// Output format for the `list` subcommand.

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::change::Change;
 use crate::error::Error;
 use crate::input::{Follows, Input};
 use crate::validate;
-use crate::walk::Walker;
+use crate::walk::{Walker, toggle};
 
 pub struct FlakeEdit {
     walker: Walker,
@@ -33,6 +33,16 @@ pub enum OutputChange {
     None,
     Add(String),
     Remove(String),
+}
+
+/// Toggle surface of one input: its active url and the stored alternates
+/// adjacent to it, in file order.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ToggleState {
+    /// The currently active url.
+    pub active: String,
+    /// Urls of the commented alternates next to the active binding.
+    pub alternates: Vec<String>,
 }
 
 /// Result of applying a [`Change`].
@@ -106,6 +116,8 @@ impl FlakeEdit {
             Change::Remove { .. } => self.apply_remove(change),
             Change::Follows { .. } => self.apply_follows(change),
             Change::Change { .. } => self.apply_change_uri(change),
+            Change::Toggle { .. } => self.apply_toggle(change),
+            Change::ToggleRemove { .. } => self.apply_toggle_remove(change),
         }
     }
 
@@ -238,6 +250,108 @@ impl FlakeEdit {
         }
 
         Ok(self.walker.walk(&change)?.map(|n| n.to_string()))
+    }
+
+    /// A `Change::Toggle` edits through [`crate::walk::toggle`] directly
+    /// rather than the traversal in `walk`: the url binding is found via
+    /// the range recorded on the input, and the flip or new-alternate
+    /// write is a local green-tree rewrite around it.
+    fn apply_toggle(&mut self, change: Change) -> Result<Option<String>, Error> {
+        let Change::Toggle { id, uri, .. } = change else {
+            unreachable!("apply_toggle dispatched only for Change::Toggle");
+        };
+
+        self.ensure_inputs_populated()?;
+
+        let id_str = id.input().as_str().to_string();
+        let Some(input) = self.walker.inputs.get(&id_str) else {
+            return Err(Error::InputNotFound(id_str));
+        };
+        let Some(binding) = toggle::url_binding(&self.walker.root, input) else {
+            return Err(Error::NoUrlToToggle(id_str));
+        };
+        let parent = binding
+            .parent()
+            .expect("a url binding always sits inside an enclosing node");
+
+        let alternates = toggle::alternates(&binding);
+        if let Some(alternate) = alternates.iter().find(|a| a.url == uri) {
+            return Ok(Some(toggle::flip(&parent, &binding, alternate).to_string()));
+        }
+        if input.url() == uri {
+            // The url is already active and not stored as an alternate.
+            // Creating one would write a duplicate line below it, so this
+            // is a no-op.
+            return Ok(None);
+        }
+        Ok(Some(
+            toggle::synthesize(&parent, &binding, &uri).to_string(),
+        ))
+    }
+
+    /// A `Change::ToggleRemove` deletes the resolved variant's line through
+    /// [`crate::walk::toggle`]. Removing a stored alternate drops its
+    /// comment and leaves the active url untouched. Removing the active url
+    /// activates `activate` in its place and drops the previously active
+    /// line. A `uri` that is not stored on the input is a no-op.
+    fn apply_toggle_remove(&mut self, change: Change) -> Result<Option<String>, Error> {
+        let Change::ToggleRemove { id, uri, activate } = change else {
+            unreachable!("apply_toggle_remove dispatched only for Change::ToggleRemove");
+        };
+
+        self.ensure_inputs_populated()?;
+
+        let id_str = id.input().as_str().to_string();
+        let Some(input) = self.walker.inputs.get(&id_str) else {
+            return Err(Error::InputNotFound(id_str));
+        };
+        let Some(binding) = toggle::url_binding(&self.walker.root, input) else {
+            return Err(Error::NoUrlToToggle(id_str));
+        };
+        let parent = binding
+            .parent()
+            .expect("a url binding always sits inside an enclosing node");
+
+        let alternates = toggle::alternates(&binding);
+        if let Some(alternate) = alternates.iter().find(|a| a.url == uri) {
+            return Ok(Some(
+                toggle::remove_alternate(&parent, alternate).to_string(),
+            ));
+        }
+        if input.url() == uri {
+            let replacement = activate
+                .and_then(|activate| alternates.into_iter().find(|a| a.url == activate))
+                .ok_or(Error::RemoveActiveWithoutAlternate(id_str))?;
+            return Ok(Some(
+                toggle::flip_remove(&parent, &binding, &replacement).to_string(),
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Toggle states for every input with a url binding, keyed by input
+    /// id. Inputs without one (follows-only inputs) are absent. An input
+    /// is toggleable when its state lists at least one alternate.
+    pub fn toggle_states(&mut self) -> Result<BTreeMap<String, ToggleState>, Error> {
+        self.ensure_inputs_populated()?;
+        let mut states = BTreeMap::new();
+        for (id, input) in &self.walker.inputs {
+            let Some(binding) = toggle::url_binding(&self.walker.root, input) else {
+                continue;
+            };
+            let alternates = toggle::alternates(&binding)
+                .into_iter()
+                .map(|a| a.url)
+                .collect();
+            states.insert(
+                id.clone(),
+                ToggleState {
+                    active: input.url().to_string(),
+                    alternates,
+                },
+            );
+        }
+        Ok(states)
     }
 
     pub fn walker(&self) -> &Walker {

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
     /// Tried to operate on an input id that is not declared in the flake.
     #[error("input '{0}' not found in the flake")]
     InputNotFound(String),
+    /// Tried to toggle an input that has no url binding (e.g. a
+    /// follows-only input).
+    #[error("input '{0}' has no url to toggle (follows-only input)")]
+    NoUrlToToggle(String),
+    /// Tried to remove an input's active url without a stored alternate to
+    /// take its place. Honoring it would leave the input url-less.
+    #[error("cannot remove the active url of '{0}' without an alternate to activate")]
+    RemoveActiveWithoutAlternate(String),
     /// The `add-follow` subcommand received a path deeper than `parent.child`.
     /// `flake-edit follow` accepts deeper paths, bounded by
     /// [`crate::config::FollowConfig::max_depth`] when that is set; this

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -426,6 +426,7 @@ impl App {
             | Command::Completion { .. }
             | Command::Follow { .. }
             | Command::AddFollow { .. }
+            | Command::Toggle { .. }
             | Command::Config { .. } => None,
         }
     }

--- a/src/walk.rs
+++ b/src/walk.rs
@@ -5,6 +5,7 @@ mod error;
 mod inputs;
 mod node;
 mod outputs;
+pub(crate) mod toggle;
 
 use std::collections::HashMap;
 

--- a/src/walk/inputs.rs
+++ b/src/walk/inputs.rs
@@ -13,7 +13,7 @@ use super::node::{
     insertion_index_after, is_attrset_content_empty, last_line_with_newline, make_attrset_url_attr,
     make_attrset_url_flake_false_attr, make_flake_false_attr, make_quoted_string, make_url_attr,
     parse_node, remove_child_with_whitespace, should_remove_input, should_remove_nested_input,
-    substitute_child, trailing_inline_comment_indices, uses_attrset_style,
+    substitute_child, trailing_inline_comments, uses_attrset_style,
 };
 
 /// Insert or update `inputs[id]` from a parsed `Input`.
@@ -82,9 +82,14 @@ pub(crate) fn walk_inputs(
         // effect of populating the `inputs` map via the per-attr handlers, and
         // `Remove`/`Change` rewrite a single matched child in place. All three
         // only need to traverse children, never rebuilding the block.
-        Change::None | Change::Remove { .. } | Change::Change { .. } => {
-            walk_children(inputs, &node, ctx, change)
-        }
+        // The toggle changes never reach the walk because `FlakeEdit`
+        // edits through `walk::toggle` directly. Grouped here for
+        // exhaustiveness.
+        Change::None
+        | Change::Remove { .. }
+        | Change::Change { .. }
+        | Change::Toggle { .. }
+        | Change::ToggleRemove { .. } => walk_children(inputs, &node, ctx, change),
     }
 }
 
@@ -510,7 +515,10 @@ fn handle_child_attrpath_value(
             .replace_child(child.index(), replacement.green().into());
 
         if replacement.text().is_empty() {
-            let mut to_remove = trailing_inline_comment_indices(child);
+            let mut to_remove: Vec<usize> = trailing_inline_comments(child)
+                .iter()
+                .map(|t| t.index())
+                .collect();
             if let Some(ws_index) = adjacent_whitespace_index(child) {
                 to_remove.push(ws_index);
             }

--- a/src/walk/node.rs
+++ b/src/walk/node.rs
@@ -98,15 +98,15 @@ pub(crate) fn insertion_index_after(node: &SyntaxNode) -> usize {
     last_index
 }
 
-/// Indices of the trailing same-line tokens after `child` (the inline
-/// whitespace and a `# ...` comment that sit on the statement's own line).
+/// Trailing same-line tokens after `child` (the inline whitespace and a
+/// `# ...` comment that sit on the statement's own line).
 ///
 /// Returns an empty vec unless a `TOKEN_COMMENT` trails the statement before
 /// the next newline. A comment on its own line is preceded by a newline-bearing
 /// whitespace token, so the walk stops before reaching it and the comment is
-/// left untouched. The returned indices, together with the removed statement,
-/// keep a trailing comment from moving onto a neighbouring line.
-pub(crate) fn trailing_inline_comment_indices(child: &rnix::SyntaxElement) -> Vec<usize> {
+/// left untouched. The returned tokens, together with the removed or rewritten
+/// statement, keep a trailing comment from moving onto a neighbouring line.
+pub(crate) fn trailing_inline_comments(child: &rnix::SyntaxElement) -> Vec<rnix::SyntaxElement> {
     let mut pending = Vec::new();
     let mut cursor = child.next_sibling_or_token();
     while let Some(tok) = cursor {
@@ -115,10 +115,10 @@ pub(crate) fn trailing_inline_comment_indices(child: &rnix::SyntaxElement) -> Ve
                 if tok.to_string().contains('\n') {
                     break;
                 }
-                pending.push(tok.index());
+                pending.push(tok.clone());
             }
             SyntaxKind::TOKEN_COMMENT => {
-                pending.push(tok.index());
+                pending.push(tok.clone());
                 return pending;
             }
             _ => break,
@@ -137,7 +137,7 @@ pub(crate) fn remove_child_with_whitespace(
 ) -> SyntaxNode {
     let element: rnix::SyntaxElement = node.clone().into();
     let mut to_remove = vec![index];
-    to_remove.extend(trailing_inline_comment_indices(&element));
+    to_remove.extend(trailing_inline_comments(&element).iter().map(|t| t.index()));
     if let Some(ws_index) = adjacent_whitespace_index(&element) {
         to_remove.push(ws_index);
     }

--- a/src/walk/toggle.rs
+++ b/src/walk/toggle.rs
@@ -1,0 +1,307 @@
+//! Detection and flipping of commented url alternates.
+//!
+//! An input is *toggleable* when a commented copy of its url binding sits
+//! in the contiguous comment block directly above or below the active
+//! binding (no blank line in between). Detection is parsing, not prefix
+//! matching: stripped of its leading `#` (and at most one following
+//! space), the comment must parse as a single binding that binds the same
+//! url attribute at the position it occupies, with a string-literal
+//! value. Anything else is prose and is ignored.
+//!
+//! Flips never move lines, only the comment marker: deactivating prefixes
+//! the binding's source text with `# ` at its existing indentation, and
+//! activating strips `#` plus at most one space. A trailing same-line
+//! comment rides along verbatim in both directions, so toggling twice is
+//! byte-identical (the one permitted normalization is `#x` becoming
+//! `# x` after the first round trip).
+
+use rnix::{SyntaxKind, SyntaxNode, SyntaxToken, TextRange, TextSize};
+
+use crate::follows::strip_outer_quotes;
+use crate::input::Input;
+
+use super::node::{extract_indent, parse_node, trailing_inline_comments};
+
+/// A commented alternate adjacent to an input's url binding.
+#[derive(Debug, Clone)]
+pub(crate) struct Alternate {
+    /// Unquoted url string of the commented binding.
+    pub(crate) url: String,
+    /// The comment token holding the alternate.
+    token: SyntaxToken,
+}
+
+/// Locate the `NODE_ATTRPATH_VALUE` binding `input`'s url, anchored on the
+/// url value range the walker recorded. Returns `None` when the input has
+/// no url binding (e.g. a follows-only input, whose recorded range points
+/// at a `follows` binding instead).
+pub(crate) fn url_binding(root: &SyntaxNode, input: &Input) -> Option<SyntaxNode> {
+    if input.url().is_empty() || input.range.is_empty() {
+        return None;
+    }
+    let range = TextRange::new(
+        TextSize::from(input.range.start as u32),
+        TextSize::from(input.range.end as u32),
+    );
+    if !root.text_range().contains_range(range) {
+        return None;
+    }
+    let covering = root.covering_element(range);
+    let node = match covering {
+        rnix::NodeOrToken::Node(node) => node,
+        rnix::NodeOrToken::Token(token) => token.parent()?,
+    };
+    let binding = node
+        .ancestors()
+        .find(|a| a.kind() == SyntaxKind::NODE_ATTRPATH_VALUE)?;
+    let segments = attrpath_segments(&binding)?;
+    (segments.last().map(String::as_str) == Some("url")).then_some(binding)
+}
+
+/// Unquoted attrpath segments of a binding, e.g. `["rust-overlay", "url"]`.
+fn attrpath_segments(binding: &SyntaxNode) -> Option<Vec<String>> {
+    let attrpath = binding
+        .children()
+        .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)?;
+    Some(
+        attrpath
+            .children()
+            .map(|c| strip_outer_quotes(&c.to_string()).to_string())
+            .collect(),
+    )
+}
+
+/// Collect the alternates stored next to `binding`, in file order: the
+/// contiguous own-line comment block above, then the one below.
+pub(crate) fn alternates(binding: &SyntaxNode) -> Vec<Alternate> {
+    let Some(expected) = attrpath_segments(binding) else {
+        return Vec::new();
+    };
+
+    let mut above = Vec::new();
+    let mut cursor = binding.prev_sibling_or_token();
+    while let Some(el) = cursor.clone() {
+        match el.kind() {
+            SyntaxKind::TOKEN_WHITESPACE => {
+                if el.to_string().matches('\n').count() >= 2 {
+                    break;
+                }
+            }
+            SyntaxKind::TOKEN_COMMENT => {
+                // A comment with line content before it is a trailing
+                // comment of an earlier statement. The block ends there.
+                if !on_own_line(&el) {
+                    break;
+                }
+                if let Some(token) = el.as_token()
+                    && let Some(url) = parse_alternate(&token.to_string(), &expected)
+                {
+                    above.push(Alternate {
+                        url,
+                        token: token.clone(),
+                    });
+                }
+            }
+            _ => break,
+        }
+        cursor = el.prev_sibling_or_token();
+    }
+    above.reverse();
+
+    let mut found = above;
+    let mut cursor = binding.next_sibling_or_token();
+    while let Some(el) = cursor.clone() {
+        match el.kind() {
+            SyntaxKind::TOKEN_WHITESPACE => {
+                if el.to_string().matches('\n').count() >= 2 {
+                    break;
+                }
+            }
+            SyntaxKind::TOKEN_COMMENT => {
+                // Skip rather than break: a non-own-line comment here is
+                // the binding's own trailing comment, and the block may
+                // still start on the next line.
+                if on_own_line(&el)
+                    && let Some(token) = el.as_token()
+                    && let Some(url) = parse_alternate(&token.to_string(), &expected)
+                {
+                    found.push(Alternate {
+                        url,
+                        token: token.clone(),
+                    });
+                }
+            }
+            _ => break,
+        }
+        cursor = el.next_sibling_or_token();
+    }
+    found
+}
+
+/// Whether `el` starts its line: its previous sibling element is
+/// line-breaking whitespace (or it is the first child).
+fn on_own_line(el: &rnix::SyntaxElement) -> bool {
+    match el.prev_sibling_or_token() {
+        None => true,
+        Some(prev) => {
+            prev.kind() == SyntaxKind::TOKEN_WHITESPACE && prev.to_string().contains('\n')
+        }
+    }
+}
+
+/// Strip the comment marker: a leading `#` and at most one following space.
+fn uncomment(comment: &str) -> &str {
+    let body = comment.strip_prefix('#').unwrap_or(comment);
+    body.strip_prefix(' ').unwrap_or(body)
+}
+
+/// Parse `comment` as an alternate of the binding whose unquoted attrpath
+/// is `expected`. Returns the unquoted url on success.
+///
+/// The body is parsed inside a synthetic `{ ... }` because a bare binding
+/// is not a valid root expression. The wrapper makes "parses as a single
+/// binding" checkable with an error-free parse.
+fn parse_alternate(comment: &str, expected: &[String]) -> Option<String> {
+    if !comment.starts_with('#') {
+        return None;
+    }
+    let body = uncomment(comment);
+    let parse = rnix::Root::parse(&format!("{{\n{body}\n}}"));
+    if !parse.errors().is_empty() {
+        return None;
+    }
+    let attr_set = parse.syntax().first_child()?;
+    if attr_set.kind() != SyntaxKind::NODE_ATTR_SET {
+        return None;
+    }
+    let mut bindings = attr_set.children();
+    let binding = bindings.next()?;
+    if bindings.next().is_some() || binding.kind() != SyntaxKind::NODE_ATTRPATH_VALUE {
+        return None;
+    }
+    let segments = attrpath_segments(&binding)?;
+    if segments != expected {
+        return None;
+    }
+    let attrpath = binding
+        .children()
+        .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)?;
+    let value = attrpath.next_sibling()?;
+    if value.kind() != SyntaxKind::NODE_STRING {
+        return None;
+    }
+    Some(strip_outer_quotes(&value.to_string()).to_string())
+}
+
+/// The commented form of `binding`'s line: the `# `-prefixed source text
+/// (with any trailing same-line comment riding along verbatim) and the
+/// indices of the tail tokens that merge into it.
+fn deactivated_line(binding: &SyntaxNode) -> (String, Vec<usize>) {
+    let element: rnix::SyntaxElement = binding.clone().into();
+    let tail = trailing_inline_comments(&element);
+    let mut text = format!("# {binding}");
+    for token in &tail {
+        text.push_str(&token.to_string());
+    }
+    (text, tail.iter().map(|token| token.index()).collect())
+}
+
+/// Activate the stored `alternate` and deactivate the active `binding`.
+/// Both lines keep their position. Only the comment marker moves.
+pub(crate) fn flip(parent: &SyntaxNode, binding: &SyntaxNode, alternate: &Alternate) -> SyntaxNode {
+    let activated = parse_node(uncomment(&alternate.token.to_string()));
+    let (comment_text, tail) = deactivated_line(binding);
+    // Replacements are one-to-one and leave sibling indices valid. The
+    // tail removals shift only children after the binding, so they run
+    // last and in descending order.
+    let mut green = parent
+        .green()
+        .replace_child(alternate.token.index(), activated.green().into());
+    green = green.replace_child(binding.index(), parse_node(&comment_text).green().into());
+    for index in tail.iter().rev() {
+        green = green.remove_child(*index);
+    }
+    SyntaxNode::new_root(parent.replace_with(green))
+}
+
+/// Delete the stored `alternate`'s line: the comment token and the
+/// whitespace before it (the newline and indentation), so the
+/// surrounding lines keep their positions.
+pub(crate) fn remove_alternate(parent: &SyntaxNode, alternate: &Alternate) -> SyntaxNode {
+    let token = &alternate.token;
+    let mut green = parent.green().remove_child(token.index());
+    if let Some(prev) = token.prev_sibling_or_token()
+        && prev.kind() == SyntaxKind::TOKEN_WHITESPACE
+    {
+        green = green.remove_child(prev.index());
+    }
+    SyntaxNode::new_root(parent.replace_with(green))
+}
+
+/// Activate the stored `alternate` and delete the active `binding`'s line
+/// entirely: the binding, its trailing same-line comments, and the
+/// whitespace before it. The removing counterpart of [`flip`], dropping
+/// the deactivated variant instead of keeping it as a comment.
+pub(crate) fn flip_remove(
+    parent: &SyntaxNode,
+    binding: &SyntaxNode,
+    alternate: &Alternate,
+) -> SyntaxNode {
+    let activated = parse_node(uncomment(&alternate.token.to_string()));
+    let element: rnix::SyntaxElement = binding.clone().into();
+    let mut to_remove: Vec<usize> = trailing_inline_comments(&element)
+        .iter()
+        .map(|t| t.index())
+        .collect();
+    to_remove.push(binding.index());
+    if let Some(prev) = binding.prev_sibling_or_token()
+        && prev.kind() == SyntaxKind::TOKEN_WHITESPACE
+    {
+        to_remove.push(prev.index());
+    }
+    to_remove.sort_unstable();
+    // The replacement is one-to-one, so the collected indices stay valid.
+    // The removals then run highest-first to keep the lower ones valid.
+    let mut green = parent
+        .green()
+        .replace_child(alternate.token.index(), activated.green().into());
+    for index in to_remove.iter().rev() {
+        green = green.remove_child(*index);
+    }
+    SyntaxNode::new_root(parent.replace_with(green))
+}
+
+/// Store `uri` as the new active url: the active `binding` is commented in
+/// place and the new url binding is written directly below it, at the same
+/// indentation and with the same attrpath spelling.
+pub(crate) fn synthesize(parent: &SyntaxNode, binding: &SyntaxNode, uri: &str) -> SyntaxNode {
+    let attrpath_text = binding
+        .children()
+        .find(|c| c.kind() == SyntaxKind::NODE_ATTRPATH)
+        .map(|c| c.to_string())
+        .unwrap_or_default();
+    let indent = binding
+        .prev_sibling_or_token()
+        .filter(|t| t.kind() == SyntaxKind::TOKEN_WHITESPACE)
+        .map(|t| extract_indent(&t.to_string()).to_string())
+        .unwrap_or_default();
+
+    let (comment_text, tail) = deactivated_line(binding);
+    // Order matters: the replacement is one-to-one and the tail removals
+    // only touch children after the binding, so `binding.index()` stays
+    // valid throughout and the inserts below land directly after the
+    // commented line. Reordering these steps breaks the index arithmetic.
+    let mut green = parent
+        .green()
+        .replace_child(binding.index(), parse_node(&comment_text).green().into());
+    for index in tail.iter().rev() {
+        green = green.remove_child(*index);
+    }
+    let new_line = parse_node(&format!("{attrpath_text} = \"{uri}\";"));
+    green = green.insert_child(
+        binding.index() + 1,
+        parse_node(&format!("\n{indent}")).green().into(),
+    );
+    green = green.insert_child(binding.index() + 2, new_line.green().into());
+    SyntaxNode::new_root(parent.replace_with(green))
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1263,3 +1263,327 @@ fn test_pin_with_lock_file(#[case] fixture: &str) {
         );
     });
 }
+
+/// `toggle` previews with `--diff` like every other subcommand. Covers the
+/// zero-argument inference, the id form, ref forms naming the inactive and
+/// the active variant (flip-back), the `t` alias, and the two-arg form
+/// that stores a new alternate.
+#[rstest]
+#[case("toggle_flat", &["toggle"], "no_args")]
+#[case("toggle_flat_flipped", &["toggle"], "no_args")]
+#[case("toggle_flat", &["toggle", "rust-overlay"], "id")]
+#[case("toggle_flat", &["t", "rust-overlay"], "alias")]
+#[case("toggle_flat", &["toggle", "github:a-kenji/rust-overlay"], "ref_inactive")]
+#[case("toggle_flat", &["toggle", "github:oxalica/rust-overlay"], "ref_active_flips_back")]
+#[case("toggle_toplevel_flat", &["toggle", "crane"], "toplevel_trailing_comment")]
+#[case("toggle_block", &["toggle", "rust-overlay", "github:a-kenji/rust-overlay"], "synthesize_block")]
+#[case("toggle_flat", &["toggle", "rust-overlay", "git+https://example.org/forks/rust-overlay"], "synthesize_flat")]
+fn test_toggle_diff(#[case] fixture: &str, #[case] args: &[&str], #[case] suffix: &str) {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    settings.set_snapshot_suffix(format!("{fixture}_{suffix}"));
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path(fixture))
+                .arg("--diff")
+                .args(args)
+        );
+    });
+}
+
+/// The non-interactive error catalogue of `toggle`: every inference
+/// failure names the candidates and points at the explicit two-arg form.
+#[rstest]
+#[case("root", &["toggle"], "nothing_toggleable")]
+#[case("toggle_many_inputs", &["toggle"], "multiple_toggleable")]
+#[case("toggle_flat", &["toggle", "rust-overlai"], "unknown_input")]
+#[case("toggle_follows_only", &["toggle", "nixpkgs-lib"], "follows_only")]
+#[case("toggle_flat", &["toggle", "nixpkgs"], "no_alternate")]
+#[case("toggle_multi", &["toggle", "rust-overlay"], "ambiguous_variant")]
+#[case("toggle_flat", &["toggle", "github:nobody/nothing"], "ref_unmatched")]
+#[case("toggle_shared_repo", &["toggle", "github:nixos/nixpkgs"], "ref_ambiguous")]
+#[case("toggle_flat", &["toggle", "./does-not-exist-here"], "path_missing")]
+#[case("toggle_block", &["toggle", "github:oxalica/rust-overlay"], "already_active")]
+fn test_toggle_errors(#[case] fixture: &str, #[case] args: &[&str], #[case] suffix: &str) {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    error_filters(&mut settings);
+    settings.set_snapshot_suffix(format!("{fixture}_{suffix}"));
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path(fixture))
+                .arg("--diff")
+                .args(args)
+        );
+    });
+}
+
+/// `toggle --remove` deletes the resolved variant's line instead of
+/// activating it. Removing the active url flips to the stored alternate
+/// first, so the input always keeps exactly one active url.
+#[rstest]
+#[case("toggle_flat", &["toggle", "--remove"], "no_args")]
+#[case("toggle_flat", &["toggle", "--remove", "rust-overlay"], "id")]
+#[case("toggle_flat", &["toggle", "-r", "github:a-kenji/rust-overlay"], "ref_alternate")]
+#[case("toggle_flat", &["toggle", "--remove", "github:oxalica/rust-overlay"], "ref_active_flips_first")]
+#[case("toggle_toplevel_flat", &["toggle", "--remove", "github:ipetkov/crane"], "active_trailing_comment")]
+fn test_toggle_remove_diff(#[case] fixture: &str, #[case] args: &[&str], #[case] suffix: &str) {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    settings.set_snapshot_suffix(format!("{fixture}_{suffix}"));
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path(fixture))
+                .arg("--diff")
+                .args(args)
+        );
+    });
+}
+
+/// The non-interactive error catalogue of `toggle --remove`: an unstored
+/// ref has nothing to remove, the active url cannot be removed without a
+/// replacement, and ambiguity needs an explicit variant.
+#[rstest]
+#[case("toggle_flat", &["toggle", "--remove", "git+https://example.org/forks/rust-overlay"], "unstored")]
+#[case("toggle_block", &["toggle", "--remove", "github:oxalica/rust-overlay"], "active_no_alternate")]
+#[case("toggle_multi", &["toggle", "--remove", "rust-overlay"], "ambiguous_target")]
+#[case("toggle_multi", &["toggle", "--remove", "github:oxalica/rust-overlay"], "ambiguous_replacement")]
+fn test_toggle_remove_errors(#[case] fixture: &str, #[case] args: &[&str], #[case] suffix: &str) {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    error_filters(&mut settings);
+    settings.set_snapshot_suffix(format!("{fixture}_{suffix}"));
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path(fixture))
+                .arg("--diff")
+                .args(args)
+        );
+    });
+}
+
+/// `--remove` must accept a path-shaped ref whose directory no longer
+/// exists: cleaning up an alternate that points at a deleted checkout is
+/// precisely the removal use case, so the path-existence typo guard is
+/// relaxed here.
+#[test]
+fn toggle_remove_accepts_missing_path_ref() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    let content = r#"{
+  inputs = {
+    # rust-overlay.url = "path:../gone";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = _: { };
+}
+"#;
+    fs::write(&flake, content).expect("write flake.nix");
+
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("--no-lock")
+        .arg("toggle")
+        .arg("--remove")
+        .arg("../gone")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run toggle --remove");
+    assert!(
+        output.status.success(),
+        "toggle --remove must accept a dead path: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let result = fs::read_to_string(&flake).expect("read flake.nix");
+    assert!(
+        !result.contains("path:../gone"),
+        "the stale alternate must be gone, got:\n{result}",
+    );
+    assert!(
+        result.contains(r#"rust-overlay.url = "github:oxalica/rust-overlay";"#),
+        "the active url must be untouched, got:\n{result}",
+    );
+}
+
+/// A malformed ref-shaped argument reuses the invalid-URI error with the
+/// parse failure in the `caused by:` chain, as `add` and `change` do.
+#[test]
+fn test_toggle_invalid_ref() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    error_filters(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("toggle_flat"))
+                .arg("--diff")
+                .arg("toggle")
+                .arg("github:")
+        );
+    });
+}
+
+/// `completion toggle` lists only inputs that have a stored alternate.
+#[test]
+fn test_completion_toggle() {
+    let mut settings = insta::Settings::clone_current();
+    path_redactions(&mut settings);
+    settings.bind(|| {
+        assert_cmd_snapshot!(
+            cli()
+                .arg("--flake")
+                .arg(fixture_path("toggle_flat"))
+                .arg("completion")
+                .arg("toggle")
+        );
+    });
+}
+
+#[test]
+fn toggle_resolves_path_ref_via_git_remote() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git is not available in this environment");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+
+    // The basename deliberately matches no input id so only the remote
+    // identity can resolve it.
+    let checkout = tmp.path().join("my-fork");
+    fs::create_dir(&checkout).expect("create checkout");
+    for args in [
+        vec!["init", "--quiet"],
+        vec![
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/oxalica/rust-overlay.git",
+        ],
+    ] {
+        let status = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&checkout)
+            .args(&args)
+            .status()
+            .expect("run git");
+        assert!(status.success(), "git {args:?} must succeed");
+    }
+
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("--no-lock")
+        .arg("toggle")
+        .arg("./my-fork")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run toggle");
+    assert!(
+        output.status.success(),
+        "toggle must resolve the checkout via its git remote: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let result = fs::read_to_string(&flake).expect("read flake.nix");
+    assert!(
+        result.contains(r#"url = "path:./my-fork";"#),
+        "the typed path is stored with only a `path:` prefix added, got:\n{result}",
+    );
+    assert!(
+        result.contains(r#"# url = "github:oxalica/rust-overlay";"#),
+        "the previous url stays stored as an alternate, got:\n{result}",
+    );
+}
+
+#[test]
+fn toggle_resolves_path_ref_via_directory_basename() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+
+    let checkout = tmp.path().join("rust-overlay");
+    fs::create_dir(&checkout).expect("create checkout");
+
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("--no-lock")
+        .arg("toggle")
+        .arg("./rust-overlay")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run toggle");
+    assert!(
+        output.status.success(),
+        "toggle must resolve the directory via its basename: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let result = fs::read_to_string(&flake).expect("read flake.nix");
+    assert!(
+        result.contains(r#"url = "path:./rust-overlay";"#),
+        "expected the path variant to be active, got:\n{result}",
+    );
+}
+
+#[test]
+fn toggle_path_ref_equal_to_stored_variant_flips_it() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake_dir = tmp.path().join("project");
+    fs::create_dir(&flake_dir).expect("create project dir");
+    let flake = flake_dir.join("flake.nix");
+    let checkout = tmp.path().join("rust-overlay");
+    fs::create_dir(&checkout).expect("create checkout");
+
+    let content = r#"{
+  inputs = {
+    # rust-overlay.url = "path:../rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = _: { };
+}
+"#;
+    fs::write(&flake, content).expect("write flake.nix");
+
+    // Typed relative to the cwd (the tempdir root), stored relative to
+    // the flake's directory. Both canonicalize to the same checkout.
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("--no-lock")
+        .arg("toggle")
+        .arg("./rust-overlay")
+        .current_dir(tmp.path())
+        .output()
+        .expect("run toggle");
+    assert!(
+        output.status.success(),
+        "toggle must match the stored path variant: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let result = fs::read_to_string(&flake).expect("read flake.nix");
+    assert!(
+        result.contains(r#"rust-overlay.url = "path:../rust-overlay";"#),
+        "the stored alternate must be activated, not duplicated, got:\n{result}",
+    );
+    assert_eq!(
+        result.matches("path:").count(),
+        1,
+        "no duplicate alternate may be synthesized, got:\n{result}",
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -124,6 +124,26 @@ pub(crate) const FIXTURES: &[&str] = &[
     // comment on its original statement.
     "trailing_comment_on_removed_input",
     "trailing_comment_on_sibling_attr",
+    // flat input with one commented url alternate above the active line,
+    // plus a follows declaration on the same input
+    "toggle_flat",
+    // flat input with one commented url alternate below the active line,
+    // plus a follows declaration on the same input
+    "toggle_flat_flipped",
+    // attrset-form input with no stored alternate
+    "toggle_block",
+    // flat input with two commented url alternates above the active line
+    "toggle_multi",
+    // two inputs, each with one commented url alternate
+    "toggle_many_inputs",
+    // toplevel flat input with an `inputs.`-prefixed commented alternate
+    // and a trailing same-line comment on the active line
+    "toggle_toplevel_flat",
+    // two inputs whose urls point at different branches of the same repo,
+    // each with a commented alternate
+    "toggle_shared_repo",
+    // a follows-only input next to a url input with a commented alternate
+    "toggle_follows_only",
 ];
 
 /// Create a Walker from a fixture name.

--- a/tests/edit.rs
+++ b/tests/edit.rs
@@ -564,3 +564,454 @@ fn follows_merges_into_existing_inputs_block() {
         "stylix block should carry the merged `systems.follows` inside the existing inputs block, got:\n{text}"
     );
 }
+
+/// Apply a `Change::Toggle` to `content` and return the resulting text.
+fn apply_toggle(content: &str, id: &str, uri: &str, previous: &str) -> String {
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let change = Change::Toggle {
+        id: flake_edit::change::ChangeId::parse(id).unwrap(),
+        uri: uri.to_owned(),
+        previous: previous.to_owned(),
+    };
+    flake_edit
+        .apply_change(change)
+        .expect("apply Change::Toggle must succeed")
+        .text
+        .expect("toggle must produce changed text")
+}
+
+#[test]
+fn toggle_states_detects_alternate_above_flat_url() {
+    let content = load_flake("toggle_flat");
+    let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    let state = &states["rust-overlay"];
+    assert_eq!(state.active, "github:oxalica/rust-overlay");
+    assert_eq!(state.alternates, vec!["github:a-kenji/rust-overlay"]);
+    assert!(states["nixpkgs"].alternates.is_empty());
+}
+
+#[test]
+fn toggle_states_orders_alternates_above_then_below() {
+    let content = r#"{
+  inputs = {
+    # crane.url = "github:a-kenji/crane";
+    crane.url = "github:ipetkov/crane";
+    # crane.url = "path:../crane";
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+  outputs = _: { };
+}
+"#;
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    assert_eq!(
+        states["crane"].alternates,
+        vec!["github:a-kenji/crane", "path:../crane"],
+    );
+}
+
+#[test]
+fn toggle_states_ignores_prose_blank_line_and_wrong_attr_comments() {
+    let content = r#"{
+  # SPDX-License-Identifier: MIT
+
+  inputs = {
+    # this needs to be rolling so we're testing what most devs are using
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    # crane.url = "github:a-kenji/crane";
+
+    crane.url = "github:ipetkov/crane";
+    # nixpkgs.url = "github:someone/nixpkgs";
+    fenix.url = "github:nix-community/fenix";
+  };
+  outputs = _: { };
+}
+"#;
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    // The prose comment does not parse as a binding.
+    assert!(
+        states["nixpkgs"].alternates.is_empty(),
+        "prose comment must not count"
+    );
+    // The crane alternate is separated from the binding by a blank line.
+    assert!(
+        states["crane"].alternates.is_empty(),
+        "blank line breaks adjacency"
+    );
+    // The nixpkgs-flavoured comment above fenix binds a different attribute.
+    assert!(
+        states["fenix"].alternates.is_empty(),
+        "wrong attribute must not count"
+    );
+}
+
+#[test]
+fn toggle_states_requires_string_literal_value() {
+    let content = r#"{
+  inputs = {
+    # crane.url = true;
+    crane.url = "github:ipetkov/crane";
+  };
+  outputs = _: { };
+}
+"#;
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    assert!(states["crane"].alternates.is_empty());
+}
+
+#[test]
+fn toggle_states_detects_block_form_and_quoted_ids() {
+    let content = r#"{
+  inputs = {
+    rust-overlay = {
+      # url = "github:a-kenji/rust-overlay";
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    # "hls-1.10".url = "github:haskell/haskell-language-server/1.10.0.0";
+    "hls-1.10".url = "github:haskell/haskell-language-server";
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+  outputs = _: { };
+}
+"#;
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    assert_eq!(
+        states["rust-overlay"].alternates,
+        vec!["github:a-kenji/rust-overlay"],
+    );
+    assert_eq!(
+        states["hls-1.10"].alternates,
+        vec!["github:haskell/haskell-language-server/1.10.0.0"],
+    );
+}
+
+#[test]
+fn toggle_states_detects_toplevel_flat_alternate() {
+    let content = load_flake("toggle_toplevel_flat");
+    let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    assert_eq!(states["crane"].alternates, vec!["github:a-kenji/crane"]);
+    // A bare `# crane.url = ...` at top level would bind `crane.url`, not
+    // `inputs.crane.url`. Only the `inputs.`-prefixed spelling counts there.
+    assert!(states["nixpkgs"].alternates.is_empty());
+}
+
+#[test]
+fn toggle_flip_moves_only_the_comment_marker() {
+    let content = load_flake("toggle_flat");
+    let result = apply_toggle(
+        &content,
+        "rust-overlay",
+        "github:a-kenji/rust-overlay",
+        "github:oxalica/rust-overlay",
+    );
+    let expected = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:a-kenji/rust-overlay";
+    # rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_twice_is_byte_identical() {
+    let content = load_flake("toggle_flat");
+    let once = apply_toggle(
+        &content,
+        "rust-overlay",
+        "github:a-kenji/rust-overlay",
+        "github:oxalica/rust-overlay",
+    );
+    let twice = apply_toggle(
+        &once,
+        "rust-overlay",
+        "github:oxalica/rust-overlay",
+        "github:a-kenji/rust-overlay",
+    );
+    assert_eq!(
+        twice, content,
+        "double toggle must restore the file byte for byte"
+    );
+}
+
+#[test]
+fn toggle_synthesizes_new_alternate_below_active_in_block_form() {
+    let content = load_flake("toggle_block");
+    let result = apply_toggle(
+        &content,
+        "rust-overlay",
+        "path:../rust-overlay",
+        "github:oxalica/rust-overlay",
+    );
+    let expected = r#"{
+  description = "A tool built on rust-overlay";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      # url = "github:oxalica/rust-overlay";
+      url = "path:../rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, ... }: { };
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_no_space_comment_normalizes_once_then_stays_stable() {
+    let content = r#"{
+  inputs = {
+    #crane.url = "github:a-kenji/crane";
+    crane.url = "github:ipetkov/crane";
+  };
+  outputs = _: { };
+}
+"#;
+    let once = apply_toggle(
+        content,
+        "crane",
+        "github:a-kenji/crane",
+        "github:ipetkov/crane",
+    );
+    let twice = apply_toggle(
+        &once,
+        "crane",
+        "github:ipetkov/crane",
+        "github:a-kenji/crane",
+    );
+    let normalized = content.replace("#crane.url", "# crane.url");
+    assert_eq!(
+        twice, normalized,
+        "the only permitted change is `#x` -> `# x`"
+    );
+    let third = apply_toggle(
+        &twice,
+        "crane",
+        "github:a-kenji/crane",
+        "github:ipetkov/crane",
+    );
+    assert_eq!(third, once);
+    let fourth = apply_toggle(
+        &third,
+        "crane",
+        "github:ipetkov/crane",
+        "github:a-kenji/crane",
+    );
+    assert_eq!(
+        fourth, twice,
+        "round trips after normalization are byte-stable"
+    );
+}
+
+#[test]
+fn toggle_keeps_trailing_comment_on_its_line_in_both_directions() {
+    let content = load_flake("toggle_toplevel_flat");
+    let once = apply_toggle(
+        &content,
+        "crane",
+        "github:a-kenji/crane",
+        "github:ipetkov/crane",
+    );
+    let expected = r#"{
+  inputs.crane.url = "github:a-kenji/crane";
+  # inputs.crane.url = "github:ipetkov/crane"; # build tool
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs = { self, ... }: { };
+}
+"#;
+    assert_eq!(once, expected);
+    let twice = apply_toggle(
+        &once,
+        "crane",
+        "github:ipetkov/crane",
+        "github:a-kenji/crane",
+    );
+    assert_eq!(twice, content);
+}
+
+/// Apply a `Change::ToggleRemove` to `content` and return the outcome text.
+fn apply_toggle_remove(
+    content: &str,
+    id: &str,
+    uri: &str,
+    activate: Option<&str>,
+) -> Option<String> {
+    let mut flake_edit = FlakeEdit::from_text(content).unwrap();
+    let change = Change::ToggleRemove {
+        id: flake_edit::change::ChangeId::parse(id).unwrap(),
+        uri: uri.to_owned(),
+        activate: activate.map(str::to_owned),
+    };
+    flake_edit
+        .apply_change(change)
+        .expect("apply Change::ToggleRemove must succeed")
+        .text
+}
+
+#[test]
+fn toggle_remove_deletes_alternate_above_active() {
+    let content = load_flake("toggle_flat");
+    let result = apply_toggle_remove(
+        &content,
+        "rust-overlay",
+        "github:a-kenji/rust-overlay",
+        None,
+    )
+    .expect("removing a stored alternate must change the text");
+    let expected = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_remove_deletes_alternate_below_active() {
+    let content = load_flake("toggle_flat_flipped");
+    let result = apply_toggle_remove(
+        &content,
+        "rust-overlay",
+        "github:oxalica/rust-overlay",
+        None,
+    )
+    .expect("removing a stored alternate must change the text");
+    let expected = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:a-kenji/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_remove_active_activates_alternate_and_deletes_line() {
+    let content = load_flake("toggle_flat");
+    let result = apply_toggle_remove(
+        &content,
+        "rust-overlay",
+        "github:oxalica/rust-overlay",
+        Some("github:a-kenji/rust-overlay"),
+    )
+    .expect("removing the active url must change the text");
+    let expected = r#"{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:a-kenji/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_remove_active_takes_trailing_comment_along() {
+    let content = load_flake("toggle_toplevel_flat");
+    let result = apply_toggle_remove(
+        &content,
+        "crane",
+        "github:ipetkov/crane",
+        Some("github:a-kenji/crane"),
+    )
+    .expect("removing the active url must change the text");
+    let expected = r#"{
+  inputs.crane.url = "github:a-kenji/crane";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs = { self, ... }: { };
+}
+"#;
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn toggle_synthesize_then_remove_restores_original() {
+    let content = load_flake("toggle_block");
+    let synthesized = apply_toggle(
+        &content,
+        "rust-overlay",
+        "github:a-kenji/rust-overlay",
+        "github:oxalica/rust-overlay",
+    );
+    let restored = apply_toggle_remove(
+        &synthesized,
+        "rust-overlay",
+        "github:a-kenji/rust-overlay",
+        Some("github:oxalica/rust-overlay"),
+    )
+    .expect("removing the synthesized variant must change the text");
+    assert_eq!(
+        restored, content,
+        "removing through the active url must invert first-use synthesis byte for byte",
+    );
+}
+
+#[test]
+fn toggle_remove_unstored_uri_is_a_noop() {
+    let content = load_flake("toggle_flat");
+    let result = apply_toggle_remove(&content, "rust-overlay", "github:nobody/nothing", None);
+    assert_eq!(result, None, "an unstored uri must be a no-op");
+}
+
+#[test]
+fn toggle_remove_active_without_alternate_errors() {
+    let content = load_flake("toggle_block");
+    let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
+    let change = Change::ToggleRemove {
+        id: flake_edit::change::ChangeId::parse("rust-overlay").unwrap(),
+        uri: "github:oxalica/rust-overlay".to_owned(),
+        activate: None,
+    };
+    let err = flake_edit.apply_change(change).expect_err("must refuse");
+    assert!(
+        err.to_string().contains("without an alternate"),
+        "expected the remove-active error, got: {err}",
+    );
+}
+
+#[test]
+fn toggle_follows_only_input_has_no_url_to_toggle() {
+    let content = load_flake("toggle_follows_only");
+    let mut flake_edit = FlakeEdit::from_text(&content).unwrap();
+    let states = flake_edit.toggle_states().unwrap();
+    assert!(
+        !states.contains_key("nixpkgs-lib"),
+        "follows-only inputs have no toggle state",
+    );
+    let change = Change::Toggle {
+        id: flake_edit::change::ChangeId::parse("nixpkgs-lib").unwrap(),
+        uri: "github:nix-community/nixpkgs.lib".to_owned(),
+        previous: String::new(),
+    };
+    let err = flake_edit.apply_change(change).expect_err("must refuse");
+    assert!(
+        err.to_string().contains("no url to toggle"),
+        "expected the no-url error, got: {err}",
+    );
+}

--- a/tests/fixtures/toggle_block.flake.nix
+++ b/tests/fixtures/toggle_block.flake.nix
@@ -1,0 +1,13 @@
+{
+  description = "A tool built on rust-overlay";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, ... }: { };
+}

--- a/tests/fixtures/toggle_flat.flake.nix
+++ b/tests/fixtures/toggle_flat.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # rust-overlay.url = "github:a-kenji/rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}

--- a/tests/fixtures/toggle_flat_flipped.flake.nix
+++ b/tests/fixtures/toggle_flat_flipped.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:a-kenji/rust-overlay";
+    # rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+  outputs = args: import ./nix args;
+}

--- a/tests/fixtures/toggle_follows_only.flake.nix
+++ b/tests/fixtures/toggle_follows_only.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    # crane.url = "github:a-kenji/crane";
+    crane.url = "github:ipetkov/crane";
+    nixpkgs-lib.follows = "nixpkgs";
+  };
+  outputs = _: { };
+}

--- a/tests/fixtures/toggle_many_inputs.flake.nix
+++ b/tests/fixtures/toggle_many_inputs.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    # nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # rust-overlay.url = "path:../rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = _: { };
+}

--- a/tests/fixtures/toggle_multi.flake.nix
+++ b/tests/fixtures/toggle_multi.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # rust-overlay.url = "github:a-kenji/rust-overlay";
+    # rust-overlay.url = "path:../rust-overlay";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = _: { };
+}

--- a/tests/fixtures/toggle_shared_repo.flake.nix
+++ b/tests/fixtures/toggle_shared_repo.flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = {
+    # nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.05";
+  };
+  outputs = _: { };
+}

--- a/tests/fixtures/toggle_toplevel_flat.flake.nix
+++ b/tests/fixtures/toggle_toplevel_flat.flake.nix
@@ -1,0 +1,7 @@
+{
+  # inputs.crane.url = "github:a-kenji/crane";
+  inputs.crane.url = "github:ipetkov/crane"; # build tool
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs = { self, ... }: { };
+}

--- a/tests/snapshots/cli__completion_toggle.snap
+++ b/tests/snapshots/cli__completion_toggle.snap
@@ -1,0 +1,18 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - completion
+    - toggle
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+rust-overlay
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_block_synthesize_block.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_block_synthesize_block.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_block.flake.nix"
+    - "--diff"
+    - toggle
+    - rust-overlay
+    - "github:a-kenji/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -4,7 +4,8 @@
+   inputs = {
+     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+     rust-overlay = {
+-      url = "github:oxalica/rust-overlay";
++      # url = "github:oxalica/rust-overlay";
++      url = "github:a-kenji/rust-overlay";
+       inputs.nixpkgs.follows = "nixpkgs";
+     };
+   };
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_alias.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_alias.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - t
+    - rust-overlay
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_flipped_no_args.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_flipped_no_args.snap
@@ -1,0 +1,30 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat_flipped.flake.nix"
+    - "--diff"
+    - toggle
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    rust-overlay.url = "github:a-kenji/rust-overlay";
+-    # rust-overlay.url = "github:oxalica/rust-overlay";
++    # rust-overlay.url = "github:a-kenji/rust-overlay";
++    rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_id.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_id.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - rust-overlay
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_no_args.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_no_args.snap
@@ -1,0 +1,30 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_ref_active_flips_back.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_ref_active_flips_back.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:oxalica/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_ref_inactive.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_ref_inactive.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:a-kenji/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,8 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_flat_synthesize_flat.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_flat_synthesize_flat.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - rust-overlay
+    - "git+https://example.org/forks/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -2,7 +2,8 @@
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+     # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    # rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "git+https://example.org/forks/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_diff@toggle_toplevel_flat_toplevel_trailing_comment.snap
+++ b/tests/snapshots/cli__toggle_diff@toggle_toplevel_flat_toplevel_trailing_comment.snap
@@ -1,0 +1,29 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_toplevel_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - crane
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,6 +1,6 @@
+ {
+-  # inputs.crane.url = "github:a-kenji/crane";
+-  inputs.crane.url = "github:ipetkov/crane"; # build tool
++  inputs.crane.url = "github:a-kenji/crane";
++  # inputs.crane.url = "github:ipetkov/crane"; # build tool
+   inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+   outputs = { self, ... }: { };
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_errors@root_nothing_toggleable.snap
+++ b/tests/snapshots/cli__toggle_errors@root_nothing_toggleable.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/root.flake.nix"
+    - "--diff"
+    - toggle
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: no toggleable inputs in flake.nix
+
+hint: an input is toggleable when a commented alternate sits next to its url, e.g.
+        rust-overlay.url = "github:oxalica/rust-overlay";
+        # rust-overlay.url = "github:a-kenji/rust-overlay";
+      store one with `flake-edit toggle <id> <ref>`

--- a/tests/snapshots/cli__toggle_errors@toggle_block_already_active.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_block_already_active.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_block.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:oxalica/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: 'github:oxalica/rust-overlay' is already the active variant of 'rust-overlay'
+       and no alternate is stored
+
+hint: store one with `flake-edit toggle rust-overlay <other-ref>`

--- a/tests/snapshots/cli__toggle_errors@toggle_flat_no_alternate.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_flat_no_alternate.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - nixpkgs
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: input 'nixpkgs' has no stored alternate
+
+hint: store one and switch to it with `flake-edit toggle nixpkgs <ref>`

--- a/tests/snapshots/cli__toggle_errors@toggle_flat_path_missing.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_flat_path_missing.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "./does-not-exist-here"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: could not read path './does-not-exist-here'
+  caused by: No such file or directory (os error 2)
+
+hint: check the path, or pass a remote ref like `github:owner/repo`

--- a/tests/snapshots/cli__toggle_errors@toggle_flat_ref_unmatched.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_flat_ref_unmatched.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:nobody/nothing"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: could not match 'github:nobody/nothing' to any input
+
+hint: no variant, git remote, or directory name corresponds to an input; name it
+      explicitly: `flake-edit toggle <id> github:nobody/nothing`

--- a/tests/snapshots/cli__toggle_errors@toggle_flat_unknown_input.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_flat_unknown_input.snap
@@ -1,0 +1,21 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - rust-overlai
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: no input named 'rust-overlai' in flake.nix
+
+hint: run `flake-edit list` to see the current inputs

--- a/tests/snapshots/cli__toggle_errors@toggle_follows_only_follows_only.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_follows_only_follows_only.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_follows_only.flake.nix"
+    - "--diff"
+    - toggle
+    - nixpkgs-lib
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: input 'nixpkgs-lib' has no url to toggle (follows-only input)

--- a/tests/snapshots/cli__toggle_errors@toggle_many_inputs_multiple_toggleable.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_many_inputs_multiple_toggleable.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_many_inputs.flake.nix"
+    - "--diff"
+    - toggle
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: multiple toggleable inputs
+  - nixpkgs: github:nixos/nixpkgs/nixos-unstable <-> github:nixos/nixpkgs/nixos-25.05
+  - rust-overlay: github:oxalica/rust-overlay <-> path:../rust-overlay
+
+hint: pick one with `flake-edit toggle <id>`

--- a/tests/snapshots/cli__toggle_errors@toggle_multi_ambiguous_variant.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_multi_ambiguous_variant.snap
@@ -1,0 +1,24 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_multi.flake.nix"
+    - "--diff"
+    - toggle
+    - rust-overlay
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: input 'rust-overlay' has 3 variants, cannot infer which to activate
+  - github:oxalica/rust-overlay (active)
+  - github:a-kenji/rust-overlay
+  - path:../rust-overlay
+
+hint: name the variant: `flake-edit toggle rust-overlay <ref>`

--- a/tests/snapshots/cli__toggle_errors@toggle_shared_repo_ref_ambiguous.snap
+++ b/tests/snapshots/cli__toggle_errors@toggle_shared_repo_ref_ambiguous.snap
@@ -1,0 +1,23 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_shared_repo.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:nixos/nixpkgs"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: 'github:nixos/nixpkgs' matches multiple inputs
+  - nixpkgs (github:nixos/nixpkgs/nixos-unstable matches the repository)
+  - nixpkgs-stable (github:nixos/nixpkgs/nixos-25.05 matches the repository)
+
+hint: name the input explicitly: `flake-edit toggle <id> github:nixos/nixpkgs`

--- a/tests/snapshots/cli__toggle_invalid_ref.snap
+++ b/tests/snapshots/cli__toggle_invalid_ref.snap
@@ -1,0 +1,20 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "github:"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: invalid URI 'github:'
+  caused by: parse error at byte 7: expected label `TakeTill1`

--- a/tests/snapshots/cli__toggle_remove_diff@toggle_flat_id.snap
+++ b/tests/snapshots/cli__toggle_remove_diff@toggle_flat_id.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - rust-overlay
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,7 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_remove_diff@toggle_flat_no_args.snap
+++ b/tests/snapshots/cli__toggle_remove_diff@toggle_flat_no_args.snap
@@ -1,0 +1,30 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,7 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_remove_diff@toggle_flat_ref_active_flips_first.snap
+++ b/tests/snapshots/cli__toggle_remove_diff@toggle_flat_ref_active_flips_first.snap
@@ -1,0 +1,31 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - "github:oxalica/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,8 +1,7 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+-    rust-overlay.url = "github:oxalica/rust-overlay";
++    rust-overlay.url = "github:a-kenji/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+   outputs = args: import ./nix args;
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_remove_diff@toggle_flat_ref_alternate.snap
+++ b/tests/snapshots/cli__toggle_remove_diff@toggle_flat_ref_alternate.snap
@@ -1,0 +1,29 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "-r"
+    - "github:a-kenji/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,7 +1,6 @@
+ {
+   inputs = {
+     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+-    # rust-overlay.url = "github:a-kenji/rust-overlay";
+     rust-overlay.url = "github:oxalica/rust-overlay";
+     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+   };
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_remove_diff@toggle_toplevel_flat_active_trailing_comment.snap
+++ b/tests/snapshots/cli__toggle_remove_diff@toggle_toplevel_flat_active_trailing_comment.snap
@@ -1,0 +1,29 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_toplevel_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - "github:ipetkov/crane"
+  env:
+    NO_COLOR: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+--- original
++++ modified
+@@ -1,6 +1,5 @@
+ {
+-  # inputs.crane.url = "github:a-kenji/crane";
+-  inputs.crane.url = "github:ipetkov/crane"; # build tool
++  inputs.crane.url = "github:a-kenji/crane";
+   inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+   outputs = { self, ... }: { };
+
+----- stderr -----

--- a/tests/snapshots/cli__toggle_remove_errors@toggle_block_active_no_alternate.snap
+++ b/tests/snapshots/cli__toggle_remove_errors@toggle_block_active_no_alternate.snap
@@ -1,0 +1,22 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_block.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - "github:oxalica/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: 'github:oxalica/rust-overlay' is the active url of 'rust-overlay' and no alternate is stored to replace it
+
+hint: set a new url with `flake-edit change rust-overlay <uri>`, or drop the input with `flake-edit remove rust-overlay`

--- a/tests/snapshots/cli__toggle_remove_errors@toggle_flat_unstored.snap
+++ b/tests/snapshots/cli__toggle_remove_errors@toggle_flat_unstored.snap
@@ -1,0 +1,24 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_flat.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - "git+https://example.org/forks/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: 'git+https://example.org/forks/rust-overlay' is not a stored variant of 'rust-overlay'
+  - github:oxalica/rust-overlay (active)
+  - github:a-kenji/rust-overlay
+
+hint: name one of the stored variants: `flake-edit toggle --remove rust-overlay <ref>`

--- a/tests/snapshots/cli__toggle_remove_errors@toggle_multi_ambiguous_replacement.snap
+++ b/tests/snapshots/cli__toggle_remove_errors@toggle_multi_ambiguous_replacement.snap
@@ -1,0 +1,25 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_multi.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - "github:oxalica/rust-overlay"
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: input 'rust-overlay' has 3 variants, cannot infer which to activate
+  - github:oxalica/rust-overlay (active)
+  - github:a-kenji/rust-overlay
+  - path:../rust-overlay
+
+hint: name the variant: `flake-edit toggle rust-overlay <ref>`

--- a/tests/snapshots/cli__toggle_remove_errors@toggle_multi_ambiguous_target.snap
+++ b/tests/snapshots/cli__toggle_remove_errors@toggle_multi_ambiguous_target.snap
@@ -1,0 +1,25 @@
+---
+source: tests/cli.rs
+info:
+  program: flake-edit
+  args:
+    - "--flake"
+    - "[FIXTURES]/toggle_multi.flake.nix"
+    - "--diff"
+    - toggle
+    - "--remove"
+    - rust-overlay
+  env:
+    NO_COLOR: "1"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+error: input 'rust-overlay' has 3 variants, cannot infer which to activate
+  - github:oxalica/rust-overlay (active)
+  - github:a-kenji/rust-overlay
+  - path:../rust-overlay
+
+hint: name the variant: `flake-edit toggle rust-overlay <ref>`

--- a/tests/toggle_idempotence.rs
+++ b/tests/toggle_idempotence.rs
@@ -1,0 +1,342 @@
+//! `flake-edit toggle` must round-trip: toggling twice from any state
+//! that toggle produced restores the file byte for byte. The one
+//! permitted normalization is a hand-written `#x` comment becoming
+//! `# x` after its first round trip.
+
+#![cfg(feature = "application")]
+
+use insta_cmd::get_cargo_bin;
+use rstest::rstest;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn cli() -> Command {
+    let mut cmd = Command::new(get_cargo_bin("flake-edit"));
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+fn fixture_path(name: &str) -> String {
+    let dir = env!("CARGO_MANIFEST_DIR");
+    format!("{dir}/tests/fixtures/{name}.flake.nix")
+}
+
+fn run_toggle(flake: &Path, args: &[&str], label: &str) -> String {
+    let mut cmd = cli();
+    cmd.arg("--flake").arg(flake).arg("--no-lock").arg("toggle");
+    cmd.args(args);
+    let output = cmd.output().unwrap_or_else(|e| panic!("{label}: {e}"));
+    assert!(
+        output.status.success(),
+        "{label} failed (status {:?}): stdout={}\nstderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Toggle the fixture's single toggleable input twice and assert the file
+/// is restored byte for byte.
+#[rstest]
+#[case("toggle_flat")]
+#[case("toggle_toplevel_flat")]
+fn toggle_twice_restores_file(#[case] fixture: &str) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path(fixture), &flake).expect("copy flake.nix");
+    let original = fs::read_to_string(&flake).expect("read original");
+
+    run_toggle(&flake, &[], "first toggle");
+    let after_first = fs::read_to_string(&flake).expect("read after first");
+    assert_ne!(after_first, original, "first toggle must change the file");
+
+    run_toggle(&flake, &[], "second toggle");
+    let after_second = fs::read_to_string(&flake).expect("read after second");
+    assert_eq!(
+        after_second, original,
+        "fixture {fixture}: double toggle must restore the file byte for byte",
+    );
+}
+
+/// A hand-written `#crane.url = ...` (no space after the marker) is
+/// normalized to `# crane.url = ...` by its first round trip. Further
+/// round trips are byte-stable.
+#[test]
+fn no_space_marker_normalizes_once_then_round_trips() {
+    let content = r#"{
+  inputs = {
+    #crane.url = "github:a-kenji/crane";
+    crane.url = "github:ipetkov/crane";
+  };
+  outputs = _: { };
+}
+"#;
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::write(&flake, content).expect("write flake.nix");
+
+    run_toggle(&flake, &[], "first toggle");
+    run_toggle(&flake, &[], "second toggle");
+    let normalized = fs::read_to_string(&flake).expect("read normalized");
+    assert_eq!(
+        normalized,
+        content.replace("#crane.url", "# crane.url"),
+        "the only permitted normalization is `#x` -> `# x`",
+    );
+
+    run_toggle(&flake, &[], "third toggle");
+    run_toggle(&flake, &[], "fourth toggle");
+    let stable = fs::read_to_string(&flake).expect("read after fourth");
+    assert_eq!(stable, normalized, "later round trips must be byte-stable");
+}
+
+/// First use of a new ref stores it as an alternate. From then on the
+/// zero-argument flip oscillates between the two stored variants.
+#[test]
+fn synthesis_then_flips_reach_a_two_state_cycle() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+
+    run_toggle(
+        &flake,
+        &["rust-overlay", "github:a-kenji/rust-overlay"],
+        "synthesis",
+    );
+    let forked = fs::read_to_string(&flake).expect("read after synthesis");
+    assert!(forked.contains(r#"# url = "github:oxalica/rust-overlay";"#));
+    assert!(forked.contains(r#"url = "github:a-kenji/rust-overlay";"#));
+
+    run_toggle(&flake, &[], "flip back");
+    let upstream = fs::read_to_string(&flake).expect("read after flip back");
+    assert!(upstream.contains(r#"url = "github:oxalica/rust-overlay";"#));
+    assert!(
+        upstream.contains(r#"# url = "github:a-kenji/rust-overlay";"#),
+        "flipping back must keep the alternate stored in the file, got:\n{upstream}",
+    );
+
+    run_toggle(&flake, &[], "flip forward again");
+    let forked_again = fs::read_to_string(&flake).expect("read after third flip");
+    assert_eq!(
+        forked_again, forked,
+        "toggling twice from a toggle-produced state must be byte-identical",
+    );
+}
+
+/// `--remove` through the active url undoes a first use: storing a new
+/// ref and then removing it restores the file byte for byte.
+#[test]
+fn synthesize_then_remove_restores_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+    let original = fs::read_to_string(&flake).expect("read original");
+
+    run_toggle(
+        &flake,
+        &["rust-overlay", "github:a-kenji/rust-overlay"],
+        "synthesize",
+    );
+    let synthesized = fs::read_to_string(&flake).expect("read after synthesis");
+    assert_ne!(synthesized, original, "synthesis must change the file");
+
+    run_toggle(
+        &flake,
+        &["--remove", "github:a-kenji/rust-overlay"],
+        "remove",
+    );
+    let restored = fs::read_to_string(&flake).expect("read after remove");
+    assert_eq!(
+        restored, original,
+        "removing the synthesized variant must restore the file byte for byte",
+    );
+}
+
+/// A bare input id discards the active url and reverts to the stored
+/// alternate. It is the destructive sibling of the plain flip. Storing a
+/// new ref and then removing by id restores the file byte for byte.
+#[test]
+fn store_new_ref_then_remove_by_id_restores_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+    let original = fs::read_to_string(&flake).expect("read original");
+
+    run_toggle(
+        &flake,
+        &["rust-overlay", "github:a-kenji/rust-overlay"],
+        "store new ref",
+    );
+    let after_store = fs::read_to_string(&flake).expect("read after storing the ref");
+    assert_ne!(
+        after_store, original,
+        "storing a new ref must change the file"
+    );
+
+    run_toggle(&flake, &["--remove", "rust-overlay"], "remove by id");
+    let restored = fs::read_to_string(&flake).expect("read after remove");
+    assert_eq!(
+        restored, original,
+        "removing by bare id must discard the active url and revert to the alternate byte for byte",
+    );
+}
+
+/// The no-argument `--remove` resolves to the sole toggleable input and
+/// acts on its active url exactly like the bare-id form. It discards the
+/// active url and reverts to the stored alternate.
+#[test]
+fn store_new_ref_then_remove_no_args_restores_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_block"), &flake).expect("copy flake.nix");
+    let original = fs::read_to_string(&flake).expect("read original");
+
+    run_toggle(
+        &flake,
+        &["rust-overlay", "github:a-kenji/rust-overlay"],
+        "store new ref",
+    );
+    let after_store = fs::read_to_string(&flake).expect("read after storing the ref");
+    assert_ne!(
+        after_store, original,
+        "storing a new ref must change the file"
+    );
+
+    run_toggle(&flake, &["--remove"], "remove no args");
+    let restored = fs::read_to_string(&flake).expect("read after remove");
+    assert_eq!(
+        restored, original,
+        "the no-arg remove must discard the active url and revert byte for byte",
+    );
+}
+
+/// Removing a commented alternate cannot change the resolved source, so
+/// the lockfile refresh is skipped. Removing the active url flips first
+/// and refreshes the lock like any other toggle. A stub `nix` on PATH
+/// stands in for the real lock run.
+#[test]
+fn remove_refreshes_lock_only_when_the_source_changes() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bin = tmp.path().join("bin");
+    fs::create_dir(&bin).expect("create shim dir");
+    let shim = bin.join("nix");
+    fs::write(&shim, "#!/bin/sh\nexit 0\n").expect("write nix shim");
+    fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).expect("chmod shim");
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let run_remove = |flake: &Path, reference: &str, label: &str| -> String {
+        let output = cli()
+            .arg("--flake")
+            .arg(flake)
+            .arg("toggle")
+            .arg("--remove")
+            .arg(reference)
+            .env("PATH", &path)
+            .output()
+            .unwrap_or_else(|e| panic!("{label}: {e}"));
+        assert!(
+            output.status.success(),
+            "{label} failed: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_flat"), &flake).expect("copy flake.nix");
+    let stdout = run_remove(&flake, "github:a-kenji/rust-overlay", "remove alternate");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec!["Removed rust-overlay alternate: github:a-kenji/rust-overlay"],
+        "a comment-only removal must not refresh the lock",
+    );
+
+    fs::copy(fixture_path("toggle_flat"), &flake).expect("reset flake.nix");
+    let stdout = run_remove(&flake, "github:oxalica/rust-overlay", "remove active");
+    assert_eq!(
+        stdout.lines().collect::<Vec<_>>(),
+        vec![
+            "Updated flake.lock",
+            "Toggled rust-overlay: github:oxalica/rust-overlay -> github:a-kenji/rust-overlay",
+            "Removed rust-overlay alternate: github:oxalica/rust-overlay",
+        ],
+        "removing the active url flips first and refreshes the lock",
+    );
+}
+
+/// The lockfile refresh line prints before the success line, as in every
+/// other subcommand. A stub `nix` on PATH stands in for the real lock
+/// run.
+#[test]
+fn lock_line_prints_before_success_line() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_flat"), &flake).expect("copy flake.nix");
+
+    let bin = tmp.path().join("bin");
+    fs::create_dir(&bin).expect("create shim dir");
+    let shim = bin.join("nix");
+    fs::write(&shim, "#!/bin/sh\nexit 0\n").expect("write nix shim");
+    fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).expect("chmod shim");
+
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("toggle")
+        .env("PATH", path)
+        .output()
+        .expect("run toggle with stub nix");
+    assert!(output.status.success(), "toggle must succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "Updated flake.lock",
+            "Toggled rust-overlay: github:oxalica/rust-overlay -> github:a-kenji/rust-overlay",
+        ],
+        "the lock line prints first, then the success line",
+    );
+}
+
+/// `--diff` prints the patch and writes nothing.
+#[test]
+fn diff_mode_does_not_write() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let flake = tmp.path().join("flake.nix");
+    fs::copy(fixture_path("toggle_flat"), &flake).expect("copy flake.nix");
+    let original = fs::read_to_string(&flake).expect("read original");
+
+    let output = cli()
+        .arg("--flake")
+        .arg(&flake)
+        .arg("--diff")
+        .arg("toggle")
+        .output()
+        .expect("run toggle --diff");
+    assert!(output.status.success(), "toggle --diff must succeed");
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("+++ modified"),
+        "the diff must be printed",
+    );
+    assert_eq!(
+        fs::read_to_string(&flake).expect("read after diff"),
+        original,
+        "diff mode must not write",
+    );
+}


### PR DESCRIPTION
Flip an input between its active url and a commented alternative that
sits next to it:

```
rust-overlay.url = "github:oxalica/rust-overlay";
```

`flake-edit toggle rust-overlay`. Will leave us with the following
state:

```
rust-overlay.url = "github:a-kenji/rust-overlay";
```

Closes: #304
