### PR TITLE
ci: pin Mic92/hestia to @v1

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -30,6 +30,6 @@ jobs:
         name: kenji
         # If you chose API tokens for write access OR if you have a private cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - uses: Mic92/hestia@main
+    - uses: Mic92/hestia@v1
     - name: "actionlint"
       run: nix run -Lv --refresh --inputs-from .# nixpkgs#actionlint -- --ignore SC2002

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "build dependencies"
         run: nix build .#checks.x86_64-linux.cargoArtifacts -Lvv --no-update-lock-file
   formatting:
@@ -33,7 +33,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "check formatting"
         run: nix build .#checks.x86_64-linux.treefmt -Lvv --no-update-lock-file
   inputs:
@@ -46,7 +46,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "build flake inputs"
         run: nix build .#checks.x86_64-linux.inputs -Lvv --no-update-lock-file
   tests:
@@ -60,7 +60,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "run tests"
         run: nix build .#checks.x86_64-linux.cargoTest -Lvv --no-update-lock-file
   docs:
@@ -74,7 +74,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "build cargo documentation"
         run: nix build .#checks.x86_64-linux.cargoDoc -Lvv --no-update-lock-file
   clippy:
@@ -88,7 +88,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "run cargo clippy"
         run: nix build .#checks.x86_64-linux.cargoClippy -Lvv --no-update-lock-file
   flake-edit:
@@ -108,7 +108,7 @@ jobs:
           name: kenji
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
           skipPush: true
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "build flake-edit"
         run: nix build .#default -Lvv --no-update-lock-file
       - name: "push flake-edit to cachix"
@@ -124,7 +124,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "nixos-test"
         run: nix build .#checks.x86_64-linux.forge -Lvv --no-update-lock-file
   devshells:
@@ -138,7 +138,7 @@ jobs:
         with:
           extra-conf: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - uses: Mic92/hestia@main
+      - uses: Mic92/hestia@v1
       - name: "build devshells"
         run: nix develop .#full -Lvv --no-update-lock-file
   all:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       - name: "build flake-edit"
         run: nix build .#default -Lvv --no-update-lock-file
       - name: "push flake-edit to cachix"
+        if: github.event_name != 'pull_request'
         run: cachix push kenji ./result
   nixos-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         extra-conf: |
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    - uses: Mic92/hestia@main
+    - uses: Mic92/hestia@v1
     - name: "install editorconfig-checker"
       run: nix shell --refresh --inputs-from .# nixpkgs#editorconfig-checker
     - name: Checking EditorConfig

--- a/README.md
+++ b/README.md
@@ -463,9 +463,10 @@ Run `flake-edit config --print-default` to create a default configuration:
 
 # Alias mappings.
 # Key is the canonical name (must exist at top-level), values are alternatives.
-# Example: if nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
-# follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs
-# aliases = { nixpkgs = ["nixpkgs-lib"] }
+# If nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
+# follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs.
+# Set aliases = {} to disable built-in aliases.
+aliases = { nixpkgs = ["nixpkgs-lib"] }
 
 # Maximum depth of follows declarations to write.
 # Unset (the default) writes follows at every depth the lockfile graph

--- a/src/assets/config.toml
+++ b/src/assets/config.toml
@@ -14,9 +14,10 @@
 
 # Alias mappings.
 # Key is the canonical name (must exist at top-level), values are alternatives.
-# Example: if nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
-# follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs
-# aliases = { nixpkgs = ["nixpkgs-lib"] }
+# If nested input is "nixpkgs-lib" and top-level "nixpkgs" exists,
+# follow will suggest: poetry2nix.nixpkgs-lib -> nixpkgs.
+# Set aliases = {} to disable built-in aliases.
+aliases = { nixpkgs = ["nixpkgs-lib"] }
 
 # Maximum depth of follows declarations to write.
 # Unset (the default) writes follows at every depth the lockfile graph

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub struct FollowConfig {
 
     /// Alias mappings: canonical name to alternative names. For example,
     /// `nixpkgs = ["nixpkgs-lib"]` lets `nixpkgs-lib` follow `nixpkgs`.
-    #[serde(default)]
+    #[serde(default = "default_follow_aliases")]
     pub aliases: HashMap<String, Vec<String>>,
 
     /// Maximum depth of follows declarations to write.
@@ -72,7 +72,7 @@ impl Default for FollowConfig {
         Self {
             ignore: Vec::new(),
             transitive_min: default_transitive_min(),
-            aliases: HashMap::new(),
+            aliases: default_follow_aliases(),
             max_depth: None,
         }
     }
@@ -208,6 +208,10 @@ fn default_transitive_min() -> usize {
     0
 }
 
+fn default_follow_aliases() -> HashMap<String, Vec<String>> {
+    HashMap::from([("nixpkgs".to_string(), vec!["nixpkgs-lib".to_string()])])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,8 +222,41 @@ mod tests {
             toml::from_str(DEFAULT_CONFIG_TOML).expect("default config should parse");
         assert!(config.follow.ignore.is_empty());
         assert_eq!(config.follow.transitive_min, 0);
-        assert!(config.follow.aliases.is_empty());
+        assert_eq!(
+            config.follow.aliases,
+            HashMap::from([("nixpkgs".to_string(), vec!["nixpkgs-lib".to_string()])])
+        );
         assert_eq!(config.follow.max_depth, None);
+    }
+
+    #[test]
+    fn rust_defaults_match_embedded_default_config() {
+        let embedded: Config =
+            toml::from_str(DEFAULT_CONFIG_TOML).expect("default config should parse");
+        let rust_default = Config::default();
+
+        assert_eq!(embedded.follow.ignore, rust_default.follow.ignore);
+        assert_eq!(
+            embedded.follow.transitive_min,
+            rust_default.follow.transitive_min
+        );
+        assert_eq!(embedded.follow.aliases, rust_default.follow.aliases);
+        assert_eq!(embedded.follow.max_depth, rust_default.follow.max_depth);
+    }
+
+    #[test]
+    fn aliases_default_when_omitted() {
+        let cfg: Config = toml::from_str("[follow]\ntransitive_min = 0\n").unwrap();
+        assert_eq!(
+            cfg.follow.aliases,
+            HashMap::from([("nixpkgs".to_string(), vec!["nixpkgs-lib".to_string()])])
+        );
+    }
+
+    #[test]
+    fn aliases_can_be_cleared() {
+        let cfg: Config = toml::from_str("[follow]\naliases = {}\n").unwrap();
+        assert!(cfg.follow.aliases.is_empty());
     }
 
     #[test]

--- a/tests/snapshots/cli__follow@mixed_style.snap
+++ b/tests/snapshots/cli__follow@mixed_style.snap
@@ -17,9 +17,11 @@ exit_code: 0
 ----- stdout -----
 --- original
 +++ modified
-@@ -3,20 +3,35 @@
+@@ -2,21 +2,37 @@
+   inputs = {
      nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
      flake-parts.url = "github:hercules-ci/flake-parts";
++    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
      treefmt-nix.url = "github:numtide/treefmt-nix";
 +    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
      crane.url = "github:ipetkov/crane";

--- a/tests/snapshots/cli__multi_directory_other.snap
+++ b/tests/snapshots/cli__multi_directory_other.snap
@@ -6,6 +6,7 @@ expression: other_result
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";


### PR DESCRIPTION
Hestia [v1.0](https://github.com/Mic92/hestia/releases/tag/v1.0.2) is the first stable release line. Switch from `@main` to the floating `@v1` tag so CI tracks compatible 1.x updates automatically.