### PR TITLE
fix(ci): don't run cache push on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
       - name: "build flake-edit"
         run: nix build .#default -Lvv --no-update-lock-file
       - name: "push flake-edit to cachix"
+        if: github.event_name != 'pull_request'
         run: cachix push kenji ./result
   nixos-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fork pull requests get no secret access,
meaning a PR like #592 would always fail.

Let's use a simple fix here and only push what is in `main` to the cache.
