### PR TITLE
feat(follow): add `--stats` and `--dry-run` flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ name = "flake-edit"
 version = "0.3.6"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -712,6 +713,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "smallvec",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ application = [
   "clap",
   "write",
   "assets",
+  "sizes",
   "anyhow",
   "diffy",
   "tracing-subscriber",
@@ -37,6 +38,7 @@ application = [
   "nucleo-matcher",
 ]
 write = []
+sizes = ["dep:base64", "dep:sha2"]
 assets = [
   "clap_complete",
   "clap_complete_nushell",
@@ -47,6 +49,7 @@ assets = [
 
 [dependencies]
 anyhow = { version = "1.0.102", optional = true }
+base64 = { version = "0.22", optional = true }
 clap = { version = "4.6.1", optional = true, features = ["derive"] }
 color-eyre = { version = "0.6.5", default-features = false, features = [
   "track-caller",
@@ -63,6 +66,7 @@ serde = { version = "1.0.228", default-features = false, features = [
   "alloc",
 ] }
 serde_json = { version = "1.0.150" }
+sha2 = { version = "0.10", optional = true }
 smallvec = { version = "1.15", features = ["const_generics", "union"] }
 toml = "1.1"
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Arguments:
 
 Options:
   -r, --remove
-          Remove the resolved variant's line instead of activating it. Removing the active url flips to the stored alternate first
+          Remove a url instead of activating it. A bare input id removes the active url and activates the stored alternate in its place. An alternate's ref deletes that alternate and keeps the active url
 
       --config <CONFIG>
           Path to a custom configuration file
@@ -336,6 +336,12 @@ Options:
 
       --depth <DEPTH>
           Maximum depth of follows declarations to write. Omitting the flag writes follows at every depth the lockfile graph supports. `--depth N` caps emission: 1 writes only `parent.child.follows`, 2 also writes `parent.child.grandchild.follows`, and so on. Overrides the config file's `follow.max_depth`
+
+  -s, --stats
+          Show size gain estimates that follows deduplication brought
+
+      --dry-run
+          Preview what `--stats` would show without applying changes
 
       --config <CONFIG>
           Path to a custom configuration file

--- a/src/app/commands/follow.rs
+++ b/src/app/commands/follow.rs
@@ -13,7 +13,7 @@ use crate::change::{Change, ChangeId};
 use crate::edit::{FlakeEdit, InputMap};
 use crate::error::Error as FlakeError;
 use crate::follows::AttrPath;
-use crate::lock::NestedInput;
+use crate::lock::{FlakeLock, NestedInput};
 use crate::tui;
 
 use super::super::editor::Editor;
@@ -21,6 +21,7 @@ use super::super::state::AppState;
 use super::{Error, Result, apply_change, load_flake_lock};
 
 pub(super) struct FollowContext {
+    pub(super) lock: FlakeLock,
     pub(super) nested_inputs: Vec<NestedInput>,
     pub(super) top_level_inputs: HashSet<String>,
     /// Full input map. Cycle detection needs URLs.
@@ -34,8 +35,8 @@ pub(super) fn load_follow_context(
     flake_edit: &mut FlakeEdit,
     state: &AppState,
 ) -> Result<Option<FollowContext>> {
-    let nested_inputs: Vec<NestedInput> = match load_flake_lock(state) {
-        Ok(lock) => lock.nested_inputs(),
+    let lock = match load_flake_lock(state) {
+        Ok(lock) => lock,
         Err(e) => {
             let lock_path = state
                 .lock_file
@@ -48,6 +49,7 @@ pub(super) fn load_follow_context(
             });
         }
     };
+    let nested_inputs: Vec<NestedInput> = lock.nested_inputs();
 
     if nested_inputs.is_empty() {
         return Ok(None);
@@ -65,6 +67,7 @@ pub(super) fn load_follow_context(
     }
 
     Ok(Some(FollowContext {
+        lock,
         nested_inputs,
         top_level_inputs,
         inputs,

--- a/src/app/commands/follow/auto.rs
+++ b/src/app/commands/follow/auto.rs
@@ -15,6 +15,7 @@ use crate::follows::{
     AttrPath, Edge, EdgeOrigin, FollowsGraph, Segment, is_follows_reference_to_parent,
 };
 use crate::input::Range;
+use crate::lock::sizes::InputSizes;
 use crate::lock::{FlakeLock, NestedInput};
 use crate::validate;
 
@@ -23,11 +24,49 @@ use super::super::super::state::AppState;
 use super::super::{Error, Result};
 use super::load_follow_context;
 
+mod stats;
+
 const SENTINEL_ALREADY_DEDUPLICATED: &str = "All inputs are already deduplicated.";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportMode {
+    /// Summary of the applied changes.
+    Plain,
+    /// Add a stats section to the summary about newly deduplicated
+    /// as well as already deduplicated inputs.
+    Stats,
+    /// The same report as [`Self::Stats`], but without applying changes.
+    DryRun,
+}
+
+impl ReportMode {
+    pub fn from_flags(stats: bool, dry_run: bool) -> Self {
+        if dry_run {
+            Self::DryRun
+        } else if stats {
+            Self::Stats
+        } else {
+            Self::Plain
+        }
+    }
+
+    fn includes_stats(self) -> bool {
+        matches!(self, Self::Stats | Self::DryRun)
+    }
+
+    fn is_dry_run(self) -> bool {
+        matches!(self, Self::DryRun)
+    }
+}
+
 /// Entry point for `flake-edit follow` on a single in-memory flake.
-pub fn run(editor: &Editor, flake_edit: &mut FlakeEdit, state: &AppState) -> Result<()> {
-    run_impl(editor, flake_edit, state, false)
+pub fn run(
+    editor: &Editor,
+    flake_edit: &mut FlakeEdit,
+    state: &AppState,
+    report: ReportMode,
+) -> Result<()> {
+    run_impl(editor, flake_edit, state, false, report)
 }
 
 /// Run auto-follow against in-memory text.
@@ -81,6 +120,7 @@ pub fn run_batch(
     paths: &[std::path::PathBuf],
     transitive: Option<usize>,
     depth: Option<usize>,
+    report: ReportMode,
     args: &crate::cli::CliArgs,
 ) -> Result<()> {
     use std::path::PathBuf;
@@ -137,7 +177,11 @@ pub fn run_batch(
             state.config.follow.max_depth = Some(max);
         }
 
-        if let Err(e) = run_impl(&editor, &mut flake_edit, &state, true) {
+        let quiet = !report.includes_stats();
+        if !quiet && paths.len() > 1 {
+            println!("# {}", flake_path.display());
+        }
+        if let Err(e) = run_impl(&editor, &mut flake_edit, &state, quiet, report) {
             errors.push((flake_path.clone(), Box::new(e)));
         }
     }
@@ -233,12 +277,21 @@ fn run_impl(
     flake_edit: &mut FlakeEdit,
     state: &AppState,
     quiet: bool,
+    report: ReportMode,
 ) -> Result<()> {
     let Some(ctx) = load_follow_context(flake_edit, state)? else {
         if !quiet {
             println!("Nothing to deduplicate.");
         }
         return Ok(());
+    };
+
+    // Stats are opt-in because sizing spawns a `nix path-info` subprocess.
+    // This is potentially costly.
+    let sizes = if report.includes_stats() {
+        InputSizes::query(&ctx.lock, &ctx.nested_inputs)
+    } else {
+        InputSizes::default()
     };
 
     let lock_graph = FollowsGraph::from_nested_inputs(&ctx.nested_inputs);
@@ -257,6 +310,7 @@ fn run_impl(
     ) else {
         if !quiet {
             println!("{SENTINEL_ALREADY_DEDUPLICATED}");
+            render_existing_section(report, &ctx.nested_inputs, &sizes);
         }
         return Ok(());
     };
@@ -268,7 +322,30 @@ fn run_impl(
         &lock_graph,
         &plan,
     )?;
-    render_summary(editor, state, &applied, quiet)
+    render_summary(
+        editor,
+        state,
+        &applied,
+        quiet,
+        report,
+        &ctx.nested_inputs,
+        &sizes,
+    )?;
+    if !quiet {
+        render_existing_section(report, &ctx.nested_inputs, &sizes);
+    }
+    Ok(())
+}
+
+/// Render stats for the currently existing follow state.
+fn render_existing_section(report: ReportMode, nested_inputs: &[NestedInput], sizes: &InputSizes) {
+    if !report.includes_stats() {
+        return;
+    }
+    if let Some(section) = stats::existing_summary(nested_inputs, sizes) {
+        println!();
+        print!("{section}");
+    }
 }
 
 fn build_plan(
@@ -1149,6 +1226,9 @@ fn render_summary(
     state: &AppState,
     applied: &AppliedPlan,
     quiet: bool,
+    report: ReportMode,
+    nested_inputs: &[NestedInput],
+    sizes: &InputSizes,
 ) -> Result<()> {
     if !applied.warnings.is_empty() && !quiet {
         let mut seen: HashSet<String> = HashSet::new();
@@ -1167,48 +1247,26 @@ fn render_summary(
         return Ok(());
     }
 
-    if state.diff {
+    let stats_on = report.includes_stats();
+    let wrote = !state.diff && !report.is_dry_run();
+    if wrote {
+        editor.apply_or_diff(&applied.current_text, state)?;
+    } else {
         let original = editor.text();
-        let diff = crate::diff::Diff::new(&original, &applied.current_text);
-        diff.compare();
-        return Ok(());
+        crate::diff::Diff::new(&original, &applied.current_text).compare();
+        if !stats_on {
+            return Ok(());
+        }
     }
-
-    editor.apply_or_diff(&applied.current_text, state)?;
 
     if quiet {
         return Ok(());
     }
 
-    if !applied.applied_follows.is_empty() {
-        println!(
-            "Deduplicated {} {}.",
-            applied.applied_follows.len(),
-            if applied.applied_follows.len() == 1 {
-                "input"
-            } else {
-                "inputs"
-            }
-        );
-        for (input_path, target) in &applied.applied_follows {
-            println!("  {} -> {}", input_path, target);
-        }
-    }
-
-    if !applied.unfollowed.is_empty() {
-        println!(
-            "Removed {} stale follows {}.",
-            applied.unfollowed.len(),
-            if applied.unfollowed.len() == 1 {
-                "declaration"
-            } else {
-                "declarations"
-            }
-        );
-        for path in &applied.unfollowed {
-            println!("  {} (input no longer exists)", path);
-        }
-    }
+    print!(
+        "{}",
+        stats::applied_summary(applied, wrote, stats_on, nested_inputs, sizes)
+    );
 
     Ok(())
 }
@@ -1489,7 +1547,8 @@ mod tests {
         let paths = vec![missing_a.clone(), missing_b.clone()];
         let args = crate::cli::CliArgs::parse_from(["flake-edit", "follow"]);
 
-        let err = run_batch(&paths, None, None, &args).expect_err("expected batch failure");
+        let err = run_batch(&paths, None, None, ReportMode::Plain, &args)
+            .expect_err("expected batch failure");
         let Error::Batch { failures } = err else {
             panic!("expected Error::Batch, got: {err:?}");
         };

--- a/src/app/commands/follow/auto/stats.rs
+++ b/src/app/commands/follow/auto/stats.rs
@@ -1,0 +1,422 @@
+//! Rendering for `follow --stats` and `--dry-run` summaries.
+
+use std::collections::{BTreeMap, HashMap};
+
+use crate::follows::AttrPath;
+use crate::lock::NestedInput;
+use crate::lock::sizes::InputSizes;
+
+use super::AppliedPlan;
+
+/// The summary of what this run changed (or would change).
+pub(super) fn applied_summary(
+    applied: &AppliedPlan,
+    wrote: bool,
+    stats: bool,
+    nested_inputs: &[NestedInput],
+    sizes: &InputSizes,
+) -> String {
+    let mut out = String::new();
+
+    let lock_routes: HashMap<&AttrPath, &AttrPath> = if stats {
+        nested_inputs
+            .iter()
+            .filter_map(|nested| nested.follows.as_ref().map(|target| (&nested.path, target)))
+            .collect()
+    } else {
+        HashMap::new()
+    };
+    let realized: Vec<&(AttrPath, AttrPath)> = applied
+        .applied_follows
+        .iter()
+        .filter(|(path, target)| lock_routes.get(path) != Some(&target))
+        .collect();
+
+    if !realized.is_empty() {
+        let verb = if wrote {
+            "Deduplicated"
+        } else {
+            "Would deduplicate"
+        };
+        let noun = if realized.len() == 1 {
+            "input"
+        } else {
+            "inputs"
+        };
+        let entry_sizes: Vec<Option<u64>> = realized
+            .iter()
+            .map(|(path, _)| if stats { sizes.size_for(path) } else { None })
+            .collect();
+        let suffix = if stats {
+            sum_suffix(&entry_sizes, false)
+        } else {
+            String::new()
+        };
+        out.push_str(&format!("{verb} {} {noun}{suffix}.\n", realized.len()));
+        for ((path, target), size) in realized.iter().zip(&entry_sizes) {
+            out.push_str(&format!(
+                "  {path} -> {target}{}\n",
+                entry_suffix(*size, stats)
+            ));
+        }
+    }
+
+    if !applied.unfollowed.is_empty() {
+        let verb = if wrote { "Removed" } else { "Would remove" };
+        let noun = if applied.unfollowed.len() == 1 {
+            "declaration"
+        } else {
+            "declarations"
+        };
+        out.push_str(&format!(
+            "{verb} {} stale follows {noun}.\n",
+            applied.unfollowed.len()
+        ));
+        for path in &applied.unfollowed {
+            out.push_str(&format!("  {path} (input no longer exists)\n"));
+        }
+    }
+
+    out
+}
+
+/// The summary of follows already existing in `flake.lock`.
+/// Grouped by the store path they resolve to.
+pub(super) fn existing_summary(
+    nested_inputs: &[NestedInput],
+    sizes: &InputSizes,
+) -> Option<String> {
+    let entries: Vec<(&AttrPath, &AttrPath)> = nested_inputs
+        .iter()
+        .filter_map(|nested| nested.follows.as_ref().map(|target| (&nested.path, target)))
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+
+    let mut groups: BTreeMap<String, Group> = BTreeMap::new();
+    for (path, target) in &entries {
+        let store_path = sizes.store_path_for(path);
+        let key = store_path.map_or_else(|| format!("target:{target}"), str::to_string);
+        let label = store_path
+            .and_then(|sp| sizes.label_for_store_path(sp))
+            .map_or_else(|| target.to_string(), str::to_string);
+        let group = groups.entry(key).or_insert_with(|| Group {
+            label,
+            count: 0,
+            unit_size: sizes.size_for(path),
+        });
+        group.count += 1;
+    }
+
+    let group_totals: Vec<Option<u64>> = groups.values().map(Group::total).collect();
+    let count = entries.len();
+    let input_noun = if count == 1 { "input" } else { "inputs" };
+    let target_noun = if groups.len() == 1 {
+        "target"
+    } else {
+        "targets"
+    };
+
+    let mut out = format!(
+        "Already deduplicated by existing follows: {count} {input_noun} across {} {target_noun}{}.\n",
+        groups.len(),
+        sum_suffix(&group_totals, true),
+    );
+
+    // Biggest savings first, then by label.
+    let mut rows: Vec<&Group> = groups.values().collect();
+    rows.sort_by(|a, b| {
+        b.total()
+            .cmp(&a.total())
+            .then_with(|| a.label.cmp(&b.label))
+    });
+    for group in rows {
+        let unit = match group.unit_size {
+            Some(bytes) => format!("~{}", format_size(bytes)),
+            None => "size unknown".to_string(),
+        };
+        if group.count == 1 {
+            out.push_str(&format!("  {} ({unit})\n", group.label));
+        } else {
+            let total = group
+                .total()
+                .map(|bytes| format!(" (~{})", format_size(bytes)))
+                .unwrap_or_default();
+            out.push_str(&format!(
+                "  {} ({unit}) x {}{total}\n",
+                group.label, group.count
+            ));
+        }
+    }
+
+    Some(out)
+}
+
+/// One row of [`existing_summary`].
+struct Group {
+    label: String,
+    count: u64,
+    unit_size: Option<u64>,
+}
+
+impl Group {
+    fn total(&self) -> Option<u64> {
+        self.unit_size.map(|size| size.saturating_mul(self.count))
+    }
+}
+
+fn sum_suffix(entry_sizes: &[Option<u64>], hypothetical: bool) -> String {
+    let known: Vec<u64> = entry_sizes.iter().flatten().copied().collect();
+    if known.is_empty() {
+        return " (size unknown)".to_string();
+    }
+    let total = known
+        .iter()
+        .fold(0u64, |acc, size| acc.saturating_add(*size));
+    let qualifier = if known.len() == entry_sizes.len() {
+        ""
+    } else {
+        "at least "
+    };
+    let size = format_size(total);
+    if hypothetical {
+        format!(" ({qualifier}~{size})")
+    } else {
+        format!(" ({qualifier}{size} saved)")
+    }
+}
+
+fn entry_suffix(size: Option<u64>, stats: bool) -> String {
+    if !stats {
+        return String::new();
+    }
+    match size {
+        Some(bytes) => format!(" ({})", format_size(bytes)),
+        None => " (size unknown)".to_string(),
+    }
+}
+
+/// Human-readable sizes.
+fn format_size(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{} MiB", bytes / MIB)
+    } else if bytes >= KIB {
+        format!("{} KiB", bytes / KIB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ap(s: &str) -> AttrPath {
+        s.parse().unwrap()
+    }
+
+    fn nested(path: &str, follows: Option<&str>) -> NestedInput {
+        NestedInput {
+            path: ap(path),
+            follows: follows.map(ap),
+            url: None,
+        }
+    }
+
+    fn applied(follows: &[(&str, &str)], unfollowed: &[&str]) -> AppliedPlan {
+        AppliedPlan {
+            applied_follows: follows.iter().map(|(s, t)| (ap(s), ap(t))).collect(),
+            unfollowed: unfollowed.iter().map(|s| ap(s)).collect(),
+            ..AppliedPlan::default()
+        }
+    }
+
+    #[test]
+    fn format_size_picks_unit_by_scale() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(2048), "2 KiB");
+        assert_eq!(format_size(150 * 1024 * 1024), "150 MiB");
+        assert_eq!(
+            format_size(1024 * 1024 * 1024 + 512 * 1024 * 1024),
+            "1.5 GiB"
+        );
+    }
+
+    #[test]
+    fn sum_suffix_reports_partial_and_unknown_sums() {
+        assert_eq!(sum_suffix(&[None, None], false), " (size unknown)");
+        assert_eq!(sum_suffix(&[None, None], true), " (size unknown)");
+        assert_eq!(
+            sum_suffix(&[Some(100 * 1024 * 1024), Some(50 * 1024 * 1024)], false),
+            " (150 MiB saved)",
+        );
+        assert_eq!(
+            sum_suffix(&[Some(100 * 1024 * 1024), Some(50 * 1024 * 1024)], true),
+            " (~150 MiB)",
+        );
+        assert_eq!(
+            sum_suffix(&[Some(100 * 1024 * 1024), None], false),
+            " (at least 100 MiB saved)",
+        );
+        assert_eq!(
+            sum_suffix(&[Some(100 * 1024 * 1024), None], true),
+            " (at least ~100 MiB)",
+        );
+    }
+
+    #[test]
+    fn applied_summary_without_stats_renders_plain_summary() {
+        let plan = applied(
+            &[("home-manager.nixpkgs", "nixpkgs")],
+            &["crane.flake-compat"],
+        );
+        let out = applied_summary(&plan, true, false, &[], &InputSizes::default());
+        assert_eq!(
+            out,
+            "Deduplicated 1 input.\n\
+             \x20 home-manager.nixpkgs -> nixpkgs\n\
+             Removed 1 stale follows declaration.\n\
+             \x20 crane.flake-compat (input no longer exists)\n",
+        );
+    }
+
+    #[test]
+    fn applied_summary_uses_preview_framing_when_not_written() {
+        let plan = applied(&[("home-manager.nixpkgs", "nixpkgs")], &["crane.old"]);
+        let out = applied_summary(&plan, false, true, &[], &InputSizes::default());
+        assert_eq!(
+            out,
+            "Would deduplicate 1 input (size unknown).\n\
+             \x20 home-manager.nixpkgs -> nixpkgs (size unknown)\n\
+             Would remove 1 stale follows declaration.\n\
+             \x20 crane.old (input no longer exists)\n",
+        );
+    }
+
+    #[test]
+    fn applied_summary_excludes_lock_routed_entries_from_realized() {
+        // `crane.nixpkgs` is already deduplicated,
+        // application must not count toward realized savings.
+        let plan = applied(
+            &[
+                ("home-manager.nixpkgs", "nixpkgs"),
+                ("crane.nixpkgs", "nixpkgs"),
+            ],
+            &[],
+        );
+        let nested_inputs = [nested("crane.nixpkgs", Some("nixpkgs"))];
+        let sizes = InputSizes::from_attr_entries([
+            (
+                "home-manager.nixpkgs".to_string(),
+                "/store/a".to_string(),
+                Some(100 * 1024 * 1024),
+            ),
+            (
+                "crane.nixpkgs".to_string(),
+                "/store/a".to_string(),
+                Some(100 * 1024 * 1024),
+            ),
+        ]);
+        let out = applied_summary(&plan, true, true, &nested_inputs, &sizes);
+        assert_eq!(
+            out,
+            "Deduplicated 1 input (100 MiB saved).\n\
+             \x20 home-manager.nixpkgs -> nixpkgs (100 MiB)\n",
+        );
+    }
+
+    #[test]
+    fn applied_summary_keeps_retargeted_entries_in_realized() {
+        let plan = applied(&[("crane.nixpkgs", "nixpkgs")], &[]);
+        let nested_inputs = [nested("crane.nixpkgs", Some("flake-utils.nixpkgs"))];
+        let out = applied_summary(&plan, true, true, &nested_inputs, &InputSizes::default());
+        assert_eq!(
+            out,
+            "Deduplicated 1 input (size unknown).\n\
+             \x20 crane.nixpkgs -> nixpkgs (size unknown)\n",
+        );
+    }
+
+    #[test]
+    fn existing_summary_saturates_absurd_sizes() {
+        let nested_inputs = [
+            nested("a.nixpkgs", Some("nixpkgs")),
+            nested("b.nixpkgs", Some("nixpkgs")),
+        ];
+        let sizes = InputSizes::from_attr_entries([
+            (
+                "a.nixpkgs".to_string(),
+                "/store/a".to_string(),
+                Some(u64::MAX),
+            ),
+            ("b.nixpkgs".to_string(), "/store/a".to_string(), None),
+        ]);
+        let out = existing_summary(&nested_inputs, &sizes).expect("has follows");
+        assert_eq!(
+            out,
+            "Already deduplicated by existing follows: 2 inputs across 1 target \
+             (~17179869184.0 GiB).\n\
+             \x20 a.nixpkgs (~17179869184.0 GiB) x 2 (~17179869184.0 GiB)\n",
+        );
+    }
+
+    #[test]
+    fn existing_summary_groups_followers_by_store_path() {
+        let nested_inputs = [
+            nested("a.nixpkgs", Some("nixpkgs")),
+            nested("b.nixpkgs", Some("nixpkgs")),
+            nested("a.flake-utils", Some("flake-utils")),
+        ];
+        let mib = 1024 * 1024;
+        let sizes = InputSizes::from_attr_entries([
+            (
+                "nixpkgs".to_string(),
+                "/store/a".to_string(),
+                Some(200 * mib),
+            ),
+            ("a.nixpkgs".to_string(), "/store/a".to_string(), None),
+            ("b.nixpkgs".to_string(), "/store/a".to_string(), None),
+            (
+                "a.flake-utils".to_string(),
+                "/store/b".to_string(),
+                Some(10 * mib),
+            ),
+        ]);
+        let out = existing_summary(&nested_inputs, &sizes).expect("has follows");
+        assert_eq!(
+            out,
+            "Already deduplicated by existing follows: 3 inputs across 2 targets (~410 MiB).\n\
+             \x20 nixpkgs (~200 MiB) x 2 (~400 MiB)\n\
+             \x20 a.flake-utils (~10 MiB)\n",
+        );
+    }
+
+    #[test]
+    fn existing_summary_keeps_unknown_targets_apart() {
+        // Two unresolved followers of different targets must not merge into one row.
+        let nested_inputs = [
+            nested("a.nixpkgs", Some("nixpkgs")),
+            nested("a.flake-utils", Some("flake-utils")),
+        ];
+        let out = existing_summary(&nested_inputs, &InputSizes::default()).expect("has follows");
+        assert_eq!(
+            out,
+            "Already deduplicated by existing follows: 2 inputs across 2 targets \
+             (size unknown).\n\
+             \x20 flake-utils (size unknown)\n\
+             \x20 nixpkgs (size unknown)\n",
+        );
+    }
+
+    #[test]
+    fn existing_summary_is_none_without_follows() {
+        let nested_inputs = [nested("a.nixpkgs", None)];
+        assert!(existing_summary(&nested_inputs, &InputSizes::default()).is_none());
+    }
+}

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -20,13 +20,16 @@ pub fn run(args: CliArgs) -> Result<()> {
         paths,
         transitive,
         depth,
+        stats,
+        dry_run,
     } = args.subcommand()
         && !paths.is_empty()
     {
         if args.flake().is_some() || args.lock_file().is_some() {
             return Err(Error::IncompatibleFollowOptions);
         }
-        return follow::auto::run_batch(paths, *transitive, *depth, &args);
+        let report = follow::auto::ReportMode::from_flags(*stats, *dry_run);
+        return follow::auto::run_batch(paths, *transitive, *depth, report, &args);
     }
 
     let (editor, mut flake_edit, mut state) = setup(&args)?;
@@ -242,6 +245,8 @@ fn dispatch_follow(
         paths: _,
         transitive,
         depth,
+        stats,
+        dry_run,
     } = args.subcommand()
     else {
         unreachable!("wrong Command variant");
@@ -253,7 +258,12 @@ fn dispatch_follow(
         state.config.follow.max_depth = Some(*max);
     }
     state.lock_offline = true;
-    follow::auto::run(editor, flake_edit, state)
+    follow::auto::run(
+        editor,
+        flake_edit,
+        state,
+        follow::auto::ReportMode::from_flags(*stats, *dry_run),
+    )
 }
 
 fn dispatch_add_follow(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -194,6 +194,12 @@ pub enum Command {
         /// config file's `follow.max_depth`.
         #[arg(long)]
         depth: Option<usize>,
+        /// Show size gain estimates that follows deduplication brought.
+        #[arg(long, short = 's')]
+        stats: bool,
+        /// Preview what `--stats` would show without applying changes.
+        #[arg(long)]
+        dry_run: bool,
         /// Flake.nix paths to process. If empty, runs on current directory.
         #[arg(trailing_var_arg = true, num_args = 0..)]
         paths: Vec<std::path::PathBuf>,

--- a/src/follows.rs
+++ b/src/follows.rs
@@ -11,4 +11,5 @@ pub use graph::{
     Cycle, DEFAULT_MAX_DEPTH, Edge, EdgeOrigin, FollowsGraph, StaleLockDeclaration,
     is_follows_reference_to_parent,
 };
+pub(crate) use path::join_raw;
 pub use path::{AttrPath, AttrPathParseError, Segment, SegmentError, strip_outer_quotes};

--- a/src/follows/path.rs
+++ b/src/follows/path.rs
@@ -308,6 +308,15 @@ impl AttrPath {
     }
 }
 
+/// Raw dot-joined rendering of `segments` (`hls-1.10.nixpkgs`).
+pub(crate) fn join_raw(segments: &[Segment]) -> String {
+    segments
+        .iter()
+        .map(|s| s.as_str())
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 /// Idents for the `inputs.<S0>.inputs.<S1>...inputs.<SN>.follows` attrpath shape.
 pub(crate) fn follows_idents_prefixed(segments: &[Segment]) -> Vec<&str> {
     let mut out: Vec<&str> = Vec::with_capacity(segments.len() * 2 + 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! ([`app`], [`cli`], [`diff`], [`tui`]) and pulls in `clap`, `ratatui`,
 //! `crossterm`, `diffy`, etc. Library-only consumers can disable it with
 //! `--no-default-features` to compile the pure edit / walk / forge surface.
+//! `sizes` (implied by `application`) adds [`lock::sizes`] store-size estimation.
 
 #[cfg(feature = "application")]
 pub mod app;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,10 +1,13 @@
 use crate::error::Error;
-use crate::follows::{AttrPath, Segment};
+use crate::follows::{AttrPath, Segment, join_raw};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+
+#[cfg(feature = "sizes")]
+pub mod sizes;
 
 /// Errors that arise from parsing or walking `flake.lock`.
 ///
@@ -169,12 +172,16 @@ impl<'de> Deserialize<'de> for Input {
     }
 }
 
-/// Locked metadata for a node. Only [`Self::rev`] is consumed by the
-/// crate; the other JSON coordinates (`owner`, `repo`, `type`, `narHash`,
-/// ...) are ignored on parse.
+/// Locked metadata for a node. Only [`Self::rev`] and, under the
+/// `sizes` feature, the NAR hash (store-size estimation) are kept.
+/// The other JSON coordinates (`owner`, `repo`, `type`, ...) are
+/// ignored on parse.
 #[derive(Debug, Deserialize, Clone)]
 pub(crate) struct Locked {
     rev: Option<String>,
+    #[cfg(feature = "sizes")]
+    #[serde(rename = "narHash")]
+    nar_hash: Option<String>,
 }
 
 impl Locked {
@@ -505,19 +512,18 @@ impl FlakeLock {
                 if i == 0 {
                     LockError::RootHasNoInputs
                 } else {
-                    let prefix: Vec<_> = segments[..i].iter().map(|s| s.as_str()).collect();
                     LockError::InputHasNoSubInputs {
-                        path: prefix.join("."),
+                        path: join_raw(&segments[..i]),
                     }
                 }
             })?;
 
-            let resolved = inputs.get(segment.as_str()).ok_or_else(|| {
-                let prefix: Vec<_> = segments[..=i].iter().map(|s| s.as_str()).collect();
-                LockError::InputNotFound {
-                    path: prefix.join("."),
-                }
-            })?;
+            let resolved =
+                inputs
+                    .get(segment.as_str())
+                    .ok_or_else(|| LockError::InputNotFound {
+                        path: join_raw(&segments[..=i]),
+                    })?;
 
             match resolved {
                 Input::Direct(node_key) => {
@@ -529,21 +535,20 @@ impl FlakeLock {
                     return self.resolve_input_path_inner(&new_path, budget - 1);
                 }
                 Input::Indirect(None) => {
-                    let prefix: Vec<_> = segments[..=i].iter().map(|s| s.as_str()).collect();
                     return Err(LockError::FollowsTargetMissing {
-                        path: prefix.join("."),
+                        path: join_raw(&segments[..=i]),
                     });
                 }
             }
 
             if i + 1 < segments.len() {
-                current_node = self.nodes.get(&current_key).ok_or_else(|| {
-                    let prefix: Vec<_> = segments[..=i].iter().map(|s| s.as_str()).collect();
-                    LockError::NodeMissingForPath {
-                        node: current_key.clone(),
-                        path: prefix.join("."),
-                    }
-                })?;
+                current_node =
+                    self.nodes
+                        .get(&current_key)
+                        .ok_or_else(|| LockError::NodeMissingForPath {
+                            node: current_key.clone(),
+                            path: join_raw(&segments[..=i]),
+                        })?;
             }
         }
 

--- a/src/lock/sizes.rs
+++ b/src/lock/sizes.rs
@@ -1,0 +1,402 @@
+//! Store-size estimation for flake inputs.
+//!
+//! `flake-edit follow --stats` reports how much disk follows deduplication saves.
+use std::collections::{BTreeSet, HashMap};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+
+use crate::follows::{AttrPath, Segment, join_raw};
+use crate::lock::{FlakeLock, NestedInput};
+
+/// Wall-clock cap a single `nix path-info` invocation.
+const PATH_INFO_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Sizes and store paths for the attribute paths of a lockfile.
+#[derive(Debug, Default)]
+pub struct InputSizes {
+    /// Dotted attribute path to the store path its lock node unpacks to.
+    store_paths: HashMap<String, String>,
+    /// Store path to NAR size in bytes, where known.
+    sizes: HashMap<String, u64>,
+}
+
+impl InputSizes {
+    pub fn query(lock: &FlakeLock, nested_inputs: &[NestedInput]) -> Self {
+        Self::query_with(lock, nested_inputs, query_path_sizes)
+    }
+
+    fn query_with(
+        lock: &FlakeLock,
+        nested_inputs: &[NestedInput],
+        size_lookup: impl FnOnce(&[&str]) -> HashMap<String, u64>,
+    ) -> Self {
+        let store_dir = store_dir();
+        let mut store_paths: HashMap<String, String> = HashMap::new();
+        for (attr, node_key) in attr_to_node_map(lock, nested_inputs) {
+            let nar_hash = lock
+                .nodes
+                .get(&node_key)
+                .and_then(|node| node.locked.as_ref())
+                .and_then(|locked| locked.nar_hash.as_deref());
+            let Some(store_path) =
+                nar_hash.and_then(|hash| store_path_from_nar_hash(&store_dir, hash))
+            else {
+                continue;
+            };
+            store_paths.insert(attr, store_path);
+        }
+        let unique: BTreeSet<&str> = store_paths.values().map(String::as_str).collect();
+        let sizes = if unique.is_empty() {
+            HashMap::new()
+        } else {
+            let paths: Vec<&str> = unique.into_iter().collect();
+            size_lookup(&paths)
+        };
+        Self { store_paths, sizes }
+    }
+
+    pub fn from_attr_entries(
+        entries: impl IntoIterator<Item = (String, String, Option<u64>)>,
+    ) -> Self {
+        let mut store_paths = HashMap::new();
+        let mut sizes = HashMap::new();
+        for (attr, store_path, size) in entries {
+            if let Some(size) = size {
+                sizes.insert(store_path.clone(), size);
+            }
+            store_paths.insert(attr, store_path);
+        }
+        Self { store_paths, sizes }
+    }
+
+    /// NAR size in bytes of the store path `path` resolves to.
+    pub fn size_for(&self, path: &AttrPath) -> Option<u64> {
+        self.sizes.get(self.store_path_for(path)?).copied()
+    }
+
+    /// Store path `path` resolves to.
+    pub fn store_path_for(&self, path: &AttrPath) -> Option<&str> {
+        self.store_paths.get(&dotted(path)).map(String::as_str)
+    }
+
+    /// Shortest attribute path resolving to `store_path`.
+    pub fn label_for_store_path(&self, store_path: &str) -> Option<&str> {
+        self.store_paths
+            .iter()
+            .filter(|(_, sp)| sp.as_str() == store_path)
+            .map(|(attr, _)| attr.as_str())
+            .min_by_key(|attr| (attr.matches('.').count(), attr.len(), *attr))
+    }
+}
+
+/// Dotted raw form of an attribute path (`hls-1.10.nixpkgs`).
+fn dotted(path: &AttrPath) -> String {
+    join_raw(path.segments())
+}
+
+fn store_dir() -> String {
+    std::env::var("NIX_STORE_DIR").unwrap_or_else(|_| "/nix/store".to_string())
+}
+
+fn attr_to_node_map(lock: &FlakeLock, nested_inputs: &[NestedInput]) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    if let Some(root_inputs) = lock
+        .nodes
+        .get(&lock.root)
+        .and_then(|node| node.inputs.as_ref())
+    {
+        for name in root_inputs.keys() {
+            let Ok(seg) = Segment::from_unquoted(name.clone()) else {
+                continue;
+            };
+            if let Ok(key) = lock.resolve_input_path(&AttrPath::new(seg)) {
+                out.insert(name.clone(), key);
+            }
+        }
+    }
+    for nested in nested_inputs {
+        if let Ok(key) = lock.resolve_input_path(&nested.path) {
+            out.insert(dotted(&nested.path), key);
+        }
+    }
+    out
+}
+
+/// Compute the store path a fixed-output source tree with `nar_hash`
+/// unpacks to.
+///
+/// Returns `None` for hashes that are not SRI sha256.
+fn store_path_from_nar_hash(store_dir: &str, nar_hash: &str) -> Option<String> {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let encoded = nar_hash.strip_prefix("sha256-")?;
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    if raw.len() != 32 {
+        return None;
+    }
+    let mut hex = String::with_capacity(64);
+    for byte in &raw {
+        hex.push(HEX[(byte >> 4) as usize] as char);
+        hex.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    let fingerprint = format!("source:sha256:{hex}:{store_dir}:source");
+    let digest = Sha256::digest(fingerprint.as_bytes());
+    let mut folded = [0u8; 20];
+    for (i, byte) in digest.iter().enumerate() {
+        folded[i % 20] ^= byte;
+    }
+    Some(format!("{store_dir}/{}-source", nix_base32(&folded)))
+}
+
+fn nix_base32(bytes: &[u8; 20]) -> String {
+    const ALPHABET: &[u8; 32] = b"0123456789abcdfghijklmnpqrsvwxyz";
+    let mut out = String::with_capacity(32);
+    for n in (0..32).rev() {
+        let bit = n * 5;
+        let byte = bit / 8;
+        let shift = bit % 8;
+        let mut value = bytes[byte] >> shift;
+        if shift > 0 && byte + 1 < bytes.len() {
+            value |= bytes[byte + 1] << (8 - shift);
+        }
+        out.push(ALPHABET[(value & 0x1f) as usize] as char);
+    }
+    out
+}
+
+fn query_path_sizes(paths: &[&str]) -> HashMap<String, u64> {
+    let mut args: Vec<&str> = vec![
+        "path-info",
+        "--json",
+        "--extra-experimental-features",
+        "nix-command",
+    ];
+    args.extend(paths);
+    let Some(raw) = run_nix(&args, PATH_INFO_TIMEOUT) else {
+        return HashMap::new();
+    };
+    serde_json::from_slice::<serde_json::Value>(&raw)
+        .map(|json| parse_path_info(&json))
+        .unwrap_or_default()
+}
+
+/// Parse `nix path-info --json` output into a `store path -> narSize` map.
+/// Supports both of these versions:
+/// - object keyed by store path: (`{"/nix/store/a": {...}}`).
+/// - array of objects: (`[{"path": "/nix/store/a", "narSize": 1}, ...]`).
+fn parse_path_info(json: &serde_json::Value) -> HashMap<String, u64> {
+    let mut out = HashMap::new();
+    if let Some(entries) = json.as_array() {
+        for entry in entries {
+            if let (Some(path), Some(size)) = (
+                entry.get("path").and_then(|v| v.as_str()),
+                entry.get("narSize").and_then(|v| v.as_u64()),
+            ) {
+                out.insert(path.to_string(), size);
+            }
+        }
+    } else if let Some(entries) = json.as_object() {
+        for (path, entry) in entries {
+            if let Some(size) = entry.get("narSize").and_then(|v| v.as_u64()) {
+                out.insert(path.clone(), size);
+            }
+        }
+    }
+    out
+}
+
+fn run_nix(args: &[&str], timeout: Duration) -> Option<Vec<u8>> {
+    use std::io::Read;
+
+    let mut child = Command::new("nix")
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let mut stdout_pipe = child.stdout.take()?;
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stdout_pipe.read_to_end(&mut buf);
+        buf
+    });
+    let mut stderr_pipe = child.stderr.take()?;
+    let stderr_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf);
+        buf
+    });
+
+    let start = std::time::Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    tracing::debug!("nix {} timed out after {:?}", args.join(" "), timeout);
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    if status.success() {
+        Some(stdout)
+    } else {
+        let stderr = stderr_reader.join().unwrap_or_default();
+        tracing::debug!(
+            "nix {} failed ({status}): {}",
+            args.join(" "),
+            String::from_utf8_lossy(&stderr).trim(),
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn store_path_from_nar_hash_matches_nix() {
+        assert_eq!(
+            store_path_from_nar_hash(
+                "/nix/store",
+                "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+            )
+            .as_deref(),
+            Some("/nix/store/3a2vdn5i7vd2wl654xs8nb52jf1v6cbh-source"),
+        );
+    }
+
+    #[test]
+    fn store_path_from_nar_hash_rejects_non_sri_sha256() {
+        for hash in [
+            "",
+            "not-a-hash",
+            "sha512-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+            "sha256-@@@invalid@@@",
+            // Valid base64 but not 32 bytes of digest.
+            "sha256-YWJj",
+        ] {
+            assert_eq!(
+                store_path_from_nar_hash("/nix/store", hash),
+                None,
+                "hash {hash:?} must not produce a store path",
+            );
+        }
+    }
+
+    #[test]
+    fn parse_path_info_handles_array_shape() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"[
+                {"path": "/nix/store/a", "narSize": 100},
+                {"path": "/nix/store/b", "narSize": 200}
+            ]"#,
+        )
+        .unwrap();
+        let map = parse_path_info(&json);
+        assert_eq!(map.get("/nix/store/a"), Some(&100));
+        assert_eq!(map.get("/nix/store/b"), Some(&200));
+    }
+
+    #[test]
+    fn parse_path_info_handles_object_shape() {
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{
+                "/nix/store/a": {"narSize": 100},
+                "/nix/store/b": {"narSize": 200}
+            }"#,
+        )
+        .unwrap();
+        let map = parse_path_info(&json);
+        assert_eq!(map.get("/nix/store/a"), Some(&100));
+        assert_eq!(map.get("/nix/store/b"), Some(&200));
+    }
+
+    #[test]
+    fn query_maps_follows_chain_to_shared_store_path() {
+        let lock = FlakeLock::read_from_str(
+            r#"{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "nixos", "repo": "nixpkgs", "rev": "aaa", "type": "github"
+      },
+      "original": { "owner": "nixos", "repo": "nixpkgs", "type": "github" }
+    },
+    "home-manager": {
+      "inputs": { "nixpkgs": ["nixpkgs"] },
+      "locked": {
+        "narHash": "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "owner": "o", "repo": "r", "rev": "bbb", "type": "github"
+      },
+      "original": { "owner": "o", "repo": "r", "type": "github" }
+    },
+    "root": {
+      "inputs": { "nixpkgs": "nixpkgs", "home-manager": "home-manager" }
+    }
+  },
+  "root": "root",
+  "version": 7
+}"#,
+        )
+        .expect("lock parses");
+        let nested = lock.nested_inputs();
+
+        let nixpkgs_path = "/nix/store/3a2vdn5i7vd2wl654xs8nb52jf1v6cbh-source";
+        let sizes = InputSizes::query_with(&lock, &nested, |paths| {
+            assert!(
+                paths.contains(&nixpkgs_path),
+                "computed store path must reach the size lookup, got {paths:?}",
+            );
+            paths.iter().map(|p| ((*p).to_string(), 42)).collect()
+        });
+
+        let top: AttrPath = "nixpkgs".parse().unwrap();
+        let follower: AttrPath = "home-manager.nixpkgs".parse().unwrap();
+        assert_eq!(sizes.store_path_for(&top), Some(nixpkgs_path));
+        assert_eq!(
+            sizes.store_path_for(&follower),
+            sizes.store_path_for(&top),
+            "follows chain must land on the target's store path",
+        );
+        assert_eq!(sizes.size_for(&follower), Some(42));
+        assert_eq!(
+            sizes.label_for_store_path(nixpkgs_path),
+            Some("nixpkgs"),
+            "shortest attribute path must label the shared store path",
+        );
+    }
+
+    #[test]
+    fn from_attr_entries_shares_sizes_via_store_path() {
+        let sizes = InputSizes::from_attr_entries([
+            ("nixpkgs".to_string(), "/store/a".to_string(), Some(7)),
+            ("crane.nixpkgs".to_string(), "/store/a".to_string(), None),
+            ("crane".to_string(), "/store/b".to_string(), None),
+        ]);
+        let follower: AttrPath = "crane.nixpkgs".parse().unwrap();
+        let unknown: AttrPath = "crane".parse().unwrap();
+        assert_eq!(sizes.size_for(&follower), Some(7));
+        assert_eq!(sizes.size_for(&unknown), None);
+        assert_eq!(sizes.label_for_store_path("/store/a"), Some("nixpkgs"));
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1216,6 +1216,150 @@ fn test_follow_paths_batch_with_inputless() {
     );
 }
 
+/// Point `NIX_STORE_DIR` at an empty directory, so we test the unknown path.
+fn unknown_sizes_env(cmd: &mut Command, dir: &std::path::Path) -> std::path::PathBuf {
+    let store = dir.join("store");
+    fs::create_dir_all(&store).expect("create empty store dir");
+    cmd.env("NIX_STORE_DIR", &store);
+    store
+}
+
+#[test]
+fn test_follow_dry_run_leaves_flake_nix_unchanged() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    copy_fixture_to_dir("centerpiece", tmp.path());
+    let original = fs::read_to_string(tmp.path().join("flake.nix")).expect("read flake.nix");
+
+    let mut cmd = cli();
+    unknown_sizes_env(&mut cmd, tmp.path());
+    let output = cmd
+        .arg("--flake")
+        .arg(tmp.path().join("flake.nix"))
+        .arg("--lock-file")
+        .arg(tmp.path().join("flake.lock"))
+        .arg("follow")
+        .arg("--dry-run")
+        .output()
+        .expect("run flake-edit");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let after = fs::read_to_string(tmp.path().join("flake.nix")).expect("read flake.nix");
+    assert_eq!(after, original, "--dry-run must not modify flake.nix");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Would deduplicate 2 inputs"),
+        "dry-run summary must use 'Would deduplicate' framing: {stdout}"
+    );
+    assert!(
+        stdout.contains("+++ modified"),
+        "dry-run must render the would-be diff: {stdout}"
+    );
+}
+
+#[test]
+fn test_follow_dry_run_size_unknown() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let mut cmd = cli();
+    unknown_sizes_env(&mut cmd, tmp.path());
+    let output = cmd
+        .arg("--flake")
+        .arg(fixture_path("centerpiece"))
+        .arg("--lock-file")
+        .arg(fixture_lock_path("centerpiece"))
+        .arg("follow")
+        .arg("--dry-run")
+        .output()
+        .expect("run flake-edit");
+
+    assert!(
+        output.status.success(),
+        "stats with no sizes must still succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(
+        stdout.contains("Would deduplicate 2 inputs (size unknown)."),
+        "expected explicit 'size unknown' marker: {stdout}"
+    );
+    insta::assert_snapshot!("follow_dry_run_size_unknown", stdout);
+}
+
+#[test]
+fn test_follow_dry_run_implies_stats() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let run = |global: &[&str], sub: &[&str]| {
+        let mut cmd = cli();
+        unknown_sizes_env(&mut cmd, tmp.path());
+        cmd.arg("--flake")
+            .arg(fixture_path("centerpiece"))
+            .arg("--lock-file")
+            .arg(fixture_lock_path("centerpiece"));
+        for arg in global {
+            cmd.arg(arg);
+        }
+        cmd.arg("follow");
+        for arg in sub {
+            cmd.arg(arg);
+        }
+        let output = cmd.output().expect("run flake-edit");
+        assert!(
+            output.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    };
+
+    let dry = run(&[], &["--dry-run"]);
+    let dry_stats = run(&[], &["--dry-run", "-s"]);
+    let diff_stats = run(&["--diff"], &["--stats"]);
+
+    assert_eq!(dry, dry_stats, "--dry-run alone must equal --dry-run -s");
+    assert_eq!(
+        dry, diff_stats,
+        "--dry-run must equal --diff follow --stats"
+    );
+}
+
+/// Batch mode normally runs quiet. With `--dry-run` the preview is
+/// the point of the invocation, so it must print the summary and
+/// leave the files alone.
+#[test]
+fn test_follow_dry_run_batch_prints_summary() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    copy_fixture_to_dir("centerpiece", tmp.path());
+    let original = fs::read_to_string(tmp.path().join("flake.nix")).expect("read flake.nix");
+
+    let mut cmd = cli();
+    unknown_sizes_env(&mut cmd, tmp.path());
+    let output = cmd
+        .arg("follow")
+        .arg("--dry-run")
+        .arg(tmp.path().join("flake.nix"))
+        .output()
+        .expect("run flake-edit");
+
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let after = fs::read_to_string(tmp.path().join("flake.nix")).expect("read flake.nix");
+    assert_eq!(after, original, "batch --dry-run must not modify flake.nix");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Would deduplicate"),
+        "batch --dry-run must print the summary: {stdout}"
+    );
+}
+
 /// Test follow without arguments (runs on current directory).
 ///
 /// Creates a tmpdir with flake.nix + flake.lock, changes to that directory,

--- a/tests/snapshots/cli__follow_dry_run_size_unknown.snap
+++ b/tests/snapshots/cli__follow_dry_run_size_unknown.snap
@@ -1,0 +1,19 @@
+---
+source: tests/cli.rs
+expression: stdout
+---
+--- original
++++ modified
+@@ -4,7 +4,9 @@
+   inputs = {
+     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+     home-manager.url = "github:nix-community/home-manager";
++    home-manager.inputs.nixpkgs.follows = "nixpkgs";
+     treefmt-nix.url = "github:numtide/treefmt-nix";
++    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+     crane.url = "github:ipetkov/crane";
+   };
+
+Would deduplicate 2 inputs (size unknown).
+  home-manager.nixpkgs -> nixpkgs (size unknown)
+  treefmt-nix.nixpkgs -> nixpkgs (size unknown)


### PR DESCRIPTION
Add the `--stats` as well as `--dry-run` flags, that print a summary of
the sizes potentially, or already saved through deduplication:

```
All inputs are already deduplicated.

Already deduplicated by existing follows: 5 inputs across 2 targets (~1002 MiB).
  nixpkgs (~201 MiB) x 4 (~805 MiB)
  nixos-stable (~196 MiB)
```

The `--stats` flag will do the normal follows command, whereas the `--dry-run` flag
will not write any changes back.
